### PR TITLE
Support time zones in CronExpression

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/CronSchedule.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/CronSchedule.java
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -37,16 +38,29 @@ public class CronSchedule implements Schedule {
 
     private static final Logger LOG = LoggerFactory.getLogger(CronSchedule.class);
     private final ExecutionTime cronExecutionTime;
+    private final ZoneId zoneId;
 
-    public CronSchedule(String pattern) {
+    public CronSchedule(String pattern, ZoneId zoneId) {
         CronParser parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.SPRING));
         Cron cron = parser.parse(pattern);
         this.cronExecutionTime = ExecutionTime.forCron(cron);
+
+        if (zoneId == null) {
+            throw new IllegalArgumentException("zoneId may not be null");
+        }
+        this.zoneId = zoneId;
+    }
+
+    public CronSchedule(String pattern) {
+        this(pattern, ZoneId.systemDefault());
     }
 
     @Override
     public Instant getNextExecutionTime(ExecutionComplete executionComplete) {
-        Optional<ZonedDateTime> nextTime = cronExecutionTime.nextExecution(ZonedDateTime.ofInstant(executionComplete.getTimeDone(), ZoneId.systemDefault()));
+        ZonedDateTime lastDone = ZonedDateTime.ofInstant(executionComplete.getTimeDone(), zoneId);  //frame the 'last done' time in the context of the time zone for this schedule
+        //so that expressions like "0 05 13,20 * * ?" (New York) can operate in the
+        // context of the desired time zone
+        Optional<ZonedDateTime> nextTime = cronExecutionTime.nextExecution(lastDone);
         if (!nextTime.isPresent()) {
             LOG.error("Cron-pattern did not return any further execution-times. This behavior is currently not supported by the scheduler. Setting next execution-time to far-future.");
             return Instant.now().plus(1000, ChronoUnit.YEARS);

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/CronSchedule.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/CronSchedule.java
@@ -28,7 +28,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Objects;
 import java.util.Optional;
 
 /**

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/Schedules.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/Schedules.java
@@ -17,6 +17,7 @@ package com.github.kagkarlsson.scheduler.task.schedule;
 
 import java.time.Duration;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -37,6 +38,8 @@ public class Schedules {
 	}
 
 	public static Schedule cron(String cronPattern) { return new CronSchedule(cronPattern); }
+
+	public static Schedule cron(String cronPattern, ZoneId zoneId) { return new CronSchedule(cronPattern, zoneId); }
 
 	/**
 	 * Currently supports Daily- and FixedDelay-schedule on the formats:

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/CronTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/CronTest.java
@@ -1,6 +1,8 @@
 package com.github.kagkarlsson.scheduler.task;
 
 import com.github.kagkarlsson.scheduler.task.schedule.CronSchedule;
+import com.github.kagkarlsson.scheduler.task.schedule.Schedule;
+import com.github.kagkarlsson.scheduler.task.schedule.Schedules;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -17,7 +19,6 @@ public class CronTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-    ZoneId defaultZone = ZoneId.systemDefault();
     ZoneId london = ZoneId.of("Europe/London");
     ZoneId utc = ZoneId.of("UTC");
     ZoneId newYork = ZoneId.of("America/New_York");
@@ -75,10 +76,10 @@ public class CronTest {
     }
 
     private void assertNextExecutionTime(ZonedDateTime timeDone, String cronPattern, ZoneId zoneId, ZonedDateTime expectedTime) {
-        assertNextExecutionTime(timeDone, expectedTime, new CronSchedule(cronPattern, zoneId));
+        assertNextExecutionTime(timeDone, expectedTime, Schedules.cron(cronPattern, zoneId));
     }
 
-    private void assertNextExecutionTime(ZonedDateTime timeDone, ZonedDateTime expectedTime, CronSchedule schedule) {
+    private void assertNextExecutionTime(ZonedDateTime timeDone, ZonedDateTime expectedTime, Schedule schedule) {
         Instant nextExecutionTime = schedule.getNextExecutionTime(complete(timeDone.toInstant()));
 
         assertThat(nextExecutionTime, is(expectedTime.toInstant()));

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/CronTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/CronTest.java
@@ -17,10 +17,22 @@ public class CronTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
+    ZoneId defaultZone = ZoneId.systemDefault();
+    ZoneId london = ZoneId.of("Europe/London");
+    ZoneId utc = ZoneId.of("UTC");
+    ZoneId newYork = ZoneId.of("America/New_York");
+
+
     @Test
     public void should_validate_pattern() {
         expectedException.expect(IllegalArgumentException.class);
         new CronSchedule("asdf asdf asdf");
+    }
+
+    @Test
+    public void should_validate_zone() {
+        expectedException.expect(IllegalArgumentException.class);
+        new CronSchedule("0 * * * * ?", null);
     }
 
     @Test
@@ -34,8 +46,39 @@ public class CronTest {
         assertNextExecutionTime(timeDone, "0 0 12 1 1 ?", timeDone.plusYears(1));
     }
 
+    @Test
+    public void should_take_time_zone_into_account() {
+        ZoneId london = ZoneId.of("Europe/London");
+
+        ZonedDateTime timeDone = ZonedDateTime.of(2019, 10, 26, 12, 0, 0, 0, london);  //British Summer time 2019 ends at 2am on Sunday 27th October
+
+        // "0 0 12 * * ?" means: At 12:00:00pm every day
+        assertNextExecutionTime(timeDone, "0 0 12 * * ?", london, timeDone.plusHours(25));  //12 midday on the 27th is 25 hours after 12 midday on the 26th
+    }
+
+    @Test
+    public void should_always_use_time_zone() {
+
+        //11am UTC = 12pm BST
+        ZonedDateTime timeDone = ZonedDateTime.of(2019, 10, 26, 11, 0, 0, 0, utc);  //British Summer time 2019 ends at 2am on Sunday 27th October
+
+        // "0 0 12 * * ?" means: At 12:00:00pm every day
+        assertNextExecutionTime(timeDone, "0 0 12 * * ?", london, timeDone.plusHours(25));  //12 midday on the 27th is 25 hours after 12 midday on the 26th
+
+        //Every day: 13:05 and 20:05 New York time
+        ZonedDateTime firstJanuaryMiddayUTC = ZonedDateTime.of(2000, 1, 1, 12, 0, 0, 0, utc);   //midday UTC = 07:00 New York time
+        assertNextExecutionTime(firstJanuaryMiddayUTC, "0 05 13,20 * * ?", newYork, ZonedDateTime.of(2000, 1, 1, 13, 5, 0, 0, newYork));  //next fire time should be 13:05 New York time
+    }
+
     private void assertNextExecutionTime(ZonedDateTime timeDone, String cronPattern, ZonedDateTime expectedTime) {
-        CronSchedule schedule = new CronSchedule(cronPattern);
+        assertNextExecutionTime(timeDone, expectedTime, new CronSchedule(cronPattern));
+    }
+
+    private void assertNextExecutionTime(ZonedDateTime timeDone, String cronPattern, ZoneId zoneId, ZonedDateTime expectedTime) {
+        assertNextExecutionTime(timeDone, expectedTime, new CronSchedule(cronPattern, zoneId));
+    }
+
+    private void assertNextExecutionTime(ZonedDateTime timeDone, ZonedDateTime expectedTime, CronSchedule schedule) {
         Instant nextExecutionTime = schedule.getNextExecutionTime(complete(timeDone.toInstant()));
 
         assertThat(nextExecutionTime, is(expectedTime.toInstant()));


### PR DESCRIPTION
Support time zones in CronExpression so that schedules can fire at a time of day that moves specific to the explicit zone not the zone of the JVM.

For example the expression "0 05 13,20 * * ?" (New York) should fire at 13:05/20:05 NY time every day, regardless of where the JVM sits.