### PR TITLE
Configurable scheduler start

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -82,7 +82,9 @@ This software includes third party software subject to the following licenses:
   Spring Boot Actuator AutoConfigure under Apache License, Version 2.0
   Spring Boot Actuator Starter under Apache License, Version 2.0
   Spring Boot AOP Starter under Apache License, Version 2.0
+  Spring Boot Auto-Configure Annotation Processor under Apache License, Version 2.0
   Spring Boot AutoConfigure under Apache License, Version 2.0
+  Spring Boot Configuration Processor under Apache License, Version 2.0
   Spring Boot Data JPA Starter under Apache License, Version 2.0
   Spring Boot JDBC Starter under Apache License, Version 2.0
   Spring Boot Json Starter under Apache License, Version 2.0

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ For Spring Boot applications, there is a starter `db-scheduler-spring-boot-start
     <dependency>
         <groupId>com.github.kagkarlsson</groupId>
         <artifactId>db-scheduler-spring-boot-starter</artifactId>
-        <version>6.0</version>
+        <version>6.1</version>
     </dependency>
     ```
    **NOTE**: This includes the db-scheduler dependency itself.
@@ -202,6 +202,7 @@ db-scheduler.table-name=scheduled_tasks
 db-scheduler.immediate-execution-enabled=false
 db-scheduler.scheduler-name=
 db-scheduler.threads=10
+db-scheduler.start-scheduler-immediately=true
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ db-scheduler.table-name=scheduled_tasks
 db-scheduler.immediate-execution-enabled=false
 db-scheduler.scheduler-name=
 db-scheduler.threads=10
-db-scheduler.start-scheduler-immediately=true
+db-scheduler.delay-startup-until-context-ready=false
 ```
 
 

--- a/db-scheduler-boot-starter/pom.xml
+++ b/db-scheduler-boot-starter/pom.xml
@@ -53,6 +53,16 @@
             <artifactId>spring-boot-actuator-autoconfigure</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Validation -->
         <dependency>

--- a/db-scheduler-boot-starter/pom.xml
+++ b/db-scheduler-boot-starter/pom.xml
@@ -66,6 +66,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Annotations -->
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>junit</groupId>

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
@@ -118,11 +118,11 @@ public class DbSchedulerAutoConfiguration {
     @ConditionalOnBean(Scheduler.class)
     @Bean
     public DbSchedulerStarter dbSchedulerStarter(Scheduler scheduler) {
-        if (config.isStartSchedulerImmediately()) {
-            return new ImmediateStart(scheduler);
+        if (config.isDelayStartupUntilContextReady()) {
+            return new ContextReadyStart(scheduler);
         }
 
-        return new ContextReadyStart(scheduler);
+        return new ImmediateStart(scheduler);
     }
 
     private static DataSource configureDataSource(DataSource existingDataSource) {

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
@@ -69,10 +69,10 @@ public class DbSchedulerProperties {
     private Optional<Integer> pollingLimit = Optional.empty();
 
     /**
-     * <p>Whether to start the scheduler as soon as possible or to wait until the application
-     * context has been loaded.
+     * <p>Whether to start the scheduler when the application context has been loaded or as soon as
+     * possible.
      */
-    private boolean startSchedulerImmediately = true;
+    private boolean delayStartupUntilContextReady = false;
 
     public boolean isEnabled() {
         return enabled;
@@ -138,11 +138,11 @@ public class DbSchedulerProperties {
         this.pollingLimit = pollingLimit;
     }
 
-    public boolean isStartSchedulerImmediately() {
-        return startSchedulerImmediately;
+    public boolean isDelayStartupUntilContextReady() {
+        return delayStartupUntilContextReady;
     }
 
-    public void setStartSchedulerImmediately(final boolean startSchedulerImmediately) {
-        this.startSchedulerImmediately = startSchedulerImmediately;
+    public void setDelayStartupUntilContextReady(final boolean delayStartupUntilContextReady) {
+        this.delayStartupUntilContextReady = delayStartupUntilContextReady;
     }
 }

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
@@ -68,6 +68,12 @@ public class DbSchedulerProperties {
      */
     private Optional<Integer> pollingLimit = Optional.empty();
 
+    /**
+     * <p>Whether to start the scheduler as soon as possible or to wait until the application
+     * context has been loaded.
+     */
+    private boolean startSchedulerImmediately = true;
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -130,5 +136,13 @@ public class DbSchedulerProperties {
 
     public void setPollingLimit(final Optional<Integer> pollingLimit) {
         this.pollingLimit = pollingLimit;
+    }
+
+    public boolean isStartSchedulerImmediately() {
+        return startSchedulerImmediately;
+    }
+
+    public void setStartSchedulerImmediately(final boolean startSchedulerImmediately) {
+        this.startSchedulerImmediately = startSchedulerImmediately;
     }
 }

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerStarter.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerStarter.java
@@ -1,0 +1,5 @@
+package com.github.kagkarlsson.scheduler.boot.config;
+
+public interface DbSchedulerStarter {
+  void doStart();
+}

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/startup/AbstractSchedulerStarter.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/startup/AbstractSchedulerStarter.java
@@ -1,0 +1,35 @@
+package com.github.kagkarlsson.scheduler.boot.config.startup;
+
+import com.github.kagkarlsson.scheduler.Scheduler;
+import com.github.kagkarlsson.scheduler.SchedulerState;
+import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerStarter;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractSchedulerStarter implements DbSchedulerStarter {
+  private final Logger log = LoggerFactory.getLogger(this.getClass());
+  private final Scheduler scheduler;
+
+  protected AbstractSchedulerStarter(Scheduler scheduler) {
+    this.scheduler = Objects.requireNonNull(scheduler, "A scheduler must be provided");
+  }
+
+  @Override
+  public void doStart() {
+    SchedulerState state = scheduler.getSchedulerState();
+
+    if (state.isShuttingDown()) {
+      log.warn("Scheduler is shutting down - will not attempting to start");
+      return;
+    }
+
+    if (state.isStarted()) {
+      log.info("Scheduler already started - will not attempt to start again");
+      return;
+    }
+
+    log.info("Triggering scheduler start");
+    scheduler.start();
+  }
+}

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/startup/ContextReadyStart.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/startup/ContextReadyStart.java
@@ -1,0 +1,16 @@
+package com.github.kagkarlsson.scheduler.boot.config.startup;
+
+import com.github.kagkarlsson.scheduler.Scheduler;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+
+public class ContextReadyStart extends AbstractSchedulerStarter {
+  public ContextReadyStart(Scheduler scheduler) {
+    super(scheduler);
+  }
+
+  @EventListener(ContextRefreshedEvent.class)
+  public void whenContextIsReady() {
+    doStart();
+  }
+}

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/startup/ImmediateStart.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/startup/ImmediateStart.java
@@ -1,0 +1,15 @@
+package com.github.kagkarlsson.scheduler.boot.config.startup;
+
+import com.github.kagkarlsson.scheduler.Scheduler;
+import javax.annotation.PostConstruct;
+
+public class ImmediateStart extends AbstractSchedulerStarter {
+  public ImmediateStart(final Scheduler scheduler) {
+    super(scheduler);
+  }
+
+  @PostConstruct
+  void startImmediately() {
+    doStart();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -377,6 +377,10 @@
 						<configuration>
 							<failOnWarning>true</failOnWarning>
 							<ignoreNonCompile>true</ignoreNonCompile>
+							<ignoredDependencies>
+								<ignoredDependency>org.springframework.boot:spring-boot-autoconfigure-processor</ignoredDependency>
+								<ignoredDependency>org.springframework.boot:spring-boot-configuration-processor</ignoredDependency>
+							</ignoredDependencies>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
This PR resolves #70 by introducing a new configuration property: `db-scheduler.start-scheduler-immediately`.

Existing behaviour is enabled by default (`true`). However, if it is set to `false` the scheduler will start after the Spring context is ready/refreshed ([`ContextRefreshedEvent`](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/event/ContextRefreshedEvent.html)).