### PR TITLE
Spring Boot: Fix health check in 2.2.x

### DIFF
--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
@@ -20,10 +20,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.autoconfigure.health.HealthIndicatorAutoConfiguration;
 import org.springframework.boot.actuate.health.HealthIndicator;
-import org.springframework.boot.actuate.health.HealthIndicatorRegistry;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
@@ -109,7 +109,8 @@ public class DbSchedulerAutoConfiguration {
         return builder.build();
     }
 
-    @ConditionalOnBean({Scheduler.class, HealthIndicatorRegistry.class})
+    @ConditionalOnClass(HealthIndicator.class)
+    @ConditionalOnBean(Scheduler.class)
     @Bean
     public HealthIndicator dbScheduler(Scheduler scheduler) {
         return new DbSchedulerHealthIndicator(scheduler);


### PR DESCRIPTION
This patch now only depends on the HealthIndicator class being present
on the classpath and delegates the responsibility of using the indicator
and registering it with a registry to Spring Boot itself.

Depending on a HealthIndicatorRegistry bean was a naive approach. In
Spring Boot 2.2.0, HealthIndicatorRegistry is deprecated in favor of
HealthContributorRegistry.

This approach has been tested with Spring Boot 2.1.10 and 2.2.1.