### PR TITLE
Log task name on failure

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -323,12 +323,12 @@ public class Scheduler implements SchedulerClient {
 				statsRegistry.register(StatsRegistry.ExecutionStatsEvent.COMPLETED);
 
 			} catch (RuntimeException unhandledException) {
-				LOG.error("Unhandled exception during execution. Treating as failure.", unhandledException);
+				LOG.error("Unhandled exception during execution of task with name '{}'. Treating as failure.", task.get().getName(), unhandledException);
 				failure(task.get().getFailureHandler(), execution, unhandledException, executionStarted);
 				statsRegistry.register(StatsRegistry.ExecutionStatsEvent.FAILED);
 
 			} catch (Throwable unhandledError) {
-				LOG.error("Error during execution. Treating as failure.", unhandledError);
+				LOG.error("Error during execution of task with name '{}'. Treating as failure.", task.get().getName(), unhandledError);
 				failure(task.get().getFailureHandler(), execution, unhandledError, executionStarted);
 				statsRegistry.register(StatsRegistry.ExecutionStatsEvent.FAILED);
 			}


### PR DESCRIPTION
When multiple tasks are scheduled and something goes wrong with them, it could be useful to know which ones failed.