### PR TITLE
Allow for configurable timeout of the Scheduler.

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -73,7 +73,6 @@ This software includes third party software subject to the following licenses:
   PostgreSQL JDBC Driver - JDBC 4.2 under The PostgreSQL License
   project ':json-path' under The Apache Software License, Version 2.0
   SLF4J API Module under MIT License
-  SLF4J Simple Binding under MIT License
   SnakeYAML under Apache License, Version 2.0
   Spring AOP under Apache License, Version 2.0
   Spring Aspects under Apache License, Version 2.0

--- a/db-scheduler-boot-starter/pom.xml
+++ b/db-scheduler-boot-starter/pom.xml
@@ -85,6 +85,12 @@
 
         <!-- Test -->
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/db-scheduler-boot-starter/src/test/resources/logback-test.xml
+++ b/db-scheduler-boot-starter/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) %cyan(%logger{50}) - %msg%n%rootException</pattern>
+    </encoder>
+  </appender>
+
+  <logger level="INFO" name="com.github.kagkarlsson"/>
+
+  <root level="WARN">
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+</configuration>

--- a/db-scheduler/pom.xml
+++ b/db-scheduler/pom.xml
@@ -45,9 +45,9 @@
 
         <!-- Test -->
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${slf4j.version}</version>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ExecutorUtils.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ExecutorUtils.java
@@ -48,23 +48,34 @@ public class ExecutorUtils {
 	}
 
 	public static ThreadFactory defaultThreadFactoryWithPrefix(String prefix) {
-		return new PrefixingDefaultThreadFactory(prefix);
+		return new PrefixingDefaultThreadFactory(prefix, false);
+	}
+
+	public static ThreadFactory defaultThreadFactoryWithPrefix(String prefix, boolean useDaemonThreads) {
+		return new PrefixingDefaultThreadFactory(prefix, useDaemonThreads);
 	}
 
 	private static class PrefixingDefaultThreadFactory implements ThreadFactory {
 
 		private final String prefix;
+		private final boolean useDaemonThreads;
 		private final ThreadFactory defaultThreadFactory;
 
 		public PrefixingDefaultThreadFactory(String prefix) {
+			this(prefix, false);
+		}
+
+		public PrefixingDefaultThreadFactory(String prefix, boolean useDaemonThreads) {
 			this.defaultThreadFactory = Executors.defaultThreadFactory();
 			this.prefix = prefix;
+			this.useDaemonThreads = useDaemonThreads;
 		}
 
 		@Override
 		public Thread newThread(Runnable r) {
 			final Thread thread = defaultThreadFactory.newThread(r);
 			thread.setName(prefix + thread.getName());
+			thread.setDaemon(useDaemonThreads);
 			return thread;
 		}
 	}

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -26,8 +26,7 @@ import javax.sql.DataSource;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -35,339 +34,392 @@ import static com.github.kagkarlsson.scheduler.ExecutorUtils.defaultThreadFactor
 
 public class Scheduler implements SchedulerClient {
 
-	public static final double TRIGGER_NEXT_BATCH_WHEN_AVAILABLE_THREADS_RATIO = 0.5;
-	public static final String THREAD_PREFIX = "db-scheduler";
-	public static final Duration SHUTDOWN_WAIT = Duration.ofMinutes(30);
-	private static final Logger LOG = LoggerFactory.getLogger(Scheduler.class);
-	private final SchedulerClient delegate;
-	private final Clock clock;
-	private final TaskRepository taskRepository;
-	private final TaskResolver taskResolver;
-    private int threadpoolSize;
-    private final ExecutorService executorService;
-	private final Waiter executeDueWaiter;
-    private final Duration deleteUnresolvedAfter;
-    protected final List<OnStartup> onStartup;
-	private final Waiter detectDeadWaiter;
-	private final Duration heartbeatInterval;
-	private final StatsRegistry statsRegistry;
-	private final int pollingLimit;
-	private final ExecutorService dueExecutor;
-	private final ExecutorService detectDeadExecutor;
-	private final ExecutorService updateHeartbeatExecutor;
-	private final Map<Execution, CurrentlyExecuting> currentlyProcessing = Collections.synchronizedMap(new HashMap<>());
-	private final Waiter heartbeatWaiter;
-	private final SettableSchedulerState schedulerState = new SettableSchedulerState();
-	private int currentGenerationNumber = 1;
+  private static final Duration DEFAULT_SHUTDOWN_TIMEOUT = Duration.ofMinutes(30);
+  private static final Duration THREAD_POOL_TIMEOUT = Duration.ofMinutes(5);
 
-	protected Scheduler(Clock clock, TaskRepository taskRepository, TaskResolver taskResolver, int threadpoolSize, ExecutorService executorService, SchedulerName schedulerName,
-			  Waiter executeDueWaiter, Duration heartbeatInterval, boolean enableImmediateExecution, StatsRegistry statsRegistry, int pollingLimit, Duration deleteUnresolvedAfter, List<OnStartup> onStartup) {
-		this.clock = clock;
-		this.taskRepository = taskRepository;
-		this.taskResolver = taskResolver;
-        this.threadpoolSize = threadpoolSize;
-        this.executorService = executorService;
-		this.executeDueWaiter = executeDueWaiter;
-        this.deleteUnresolvedAfter = deleteUnresolvedAfter;
-        this.onStartup = onStartup;
-		this.detectDeadWaiter = new Waiter(heartbeatInterval.multipliedBy(2), clock);
-		this.heartbeatInterval = heartbeatInterval;
-		this.heartbeatWaiter = new Waiter(heartbeatInterval, clock);
-		this.statsRegistry = statsRegistry;
-		this.pollingLimit = pollingLimit;
-		this.dueExecutor = Executors.newSingleThreadExecutor(defaultThreadFactoryWithPrefix(THREAD_PREFIX + "-execute-due-"));
-		this.detectDeadExecutor = Executors.newSingleThreadExecutor(defaultThreadFactoryWithPrefix(THREAD_PREFIX + "-detect-dead-"));
-		this.updateHeartbeatExecutor = Executors.newSingleThreadExecutor(defaultThreadFactoryWithPrefix(THREAD_PREFIX + "-update-heartbeat-"));
-		SchedulerClientEventListener earlyExecutionListener = (enableImmediateExecution ? new TriggerCheckForDueExecutions(schedulerState, clock, executeDueWaiter) : SchedulerClientEventListener.NOOP);
-		delegate = new StandardSchedulerClient(taskRepository, earlyExecutionListener);
-	}
+  public static final double TRIGGER_NEXT_BATCH_WHEN_AVAILABLE_THREADS_RATIO = 0.5;
+  public static final String THREAD_PREFIX = "db-scheduler";
+  private static final Logger LOG = LoggerFactory.getLogger(Scheduler.class);
+  private final SchedulerClient delegate;
+  private final Clock clock;
+  private final TaskRepository taskRepository;
+  private final TaskResolver taskResolver;
+  private final int parallelism;
+  private final Waiter executeDueWaiter;
+  private final Duration deleteUnresolvedAfter;
+  protected final List<OnStartup> onStartup;
+  private final Waiter detectDeadWaiter;
+  private final Duration heartbeatInterval;
+  private final StatsRegistry statsRegistry;
+  private final int pollingLimit;
 
-	public void start() {
-		LOG.info("Starting scheduler.");
+  private final ExecutorService dueExecutor;
+  private final ExecutorService detectDeadExecutor;
+  private final ExecutorService updateHeartbeatExecutor;
 
-		executeOnStartup();
+  private final ExecutorService executorService;
+	private final boolean managedExecutorService; //if true, the executorService is managed by this instance
+  public final Duration executorShutdownWait;
 
-		dueExecutor.submit(new RunUntilShutdown(this::executeDue, executeDueWaiter, schedulerState, statsRegistry));
-		detectDeadExecutor.submit(new RunUntilShutdown(this::detectDeadExecutions, detectDeadWaiter, schedulerState, statsRegistry));
-		updateHeartbeatExecutor.submit(new RunUntilShutdown(this::updateHeartbeats, heartbeatWaiter, schedulerState, statsRegistry));
+  private final Map<Execution, CurrentlyExecuting> currentlyProcessing = Collections.synchronizedMap(new HashMap<>());
+  private final Waiter heartbeatWaiter;
+  private final SettableSchedulerState schedulerState = new SettableSchedulerState();
+  private int currentGenerationNumber = 1;
 
-		schedulerState.setStarted();
-	}
+  protected Scheduler(Clock clock, TaskRepository taskRepository, TaskResolver taskResolver, int parallelism, ExecutorService executorService, Duration executorShutdownWait, SchedulerName schedulerName,
+                      Waiter executeDueWaiter, Duration heartbeatInterval, boolean enableImmediateExecution, StatsRegistry statsRegistry, int pollingLimit, Duration deleteUnresolvedAfter, List<OnStartup> onStartup) {
+    this.clock = clock;
+    this.taskRepository = taskRepository;
+    this.taskResolver = taskResolver;
+    this.parallelism = parallelism;
+    this.executeDueWaiter = executeDueWaiter;
+    this.deleteUnresolvedAfter = deleteUnresolvedAfter;
+    this.onStartup = onStartup;
+    this.detectDeadWaiter = new Waiter(heartbeatInterval.multipliedBy(2), clock);
+    this.heartbeatInterval = heartbeatInterval;
+    this.heartbeatWaiter = new Waiter(heartbeatInterval, clock);
+    this.statsRegistry = statsRegistry;
+    this.pollingLimit = pollingLimit;
 
-	protected void executeOnStartup() {
-		onStartup.forEach(os -> {
-			try {
-				os.onStartup(this, this.clock);
-			} catch (Exception e) {
-				LOG.error("Unexpected error while executing OnStartup tasks. Continuing.", e);
-				statsRegistry.register(SchedulerStatsEvent.UNEXPECTED_ERROR);
-			}
-		});
-	}
+    ThreadPoolExecutor housekeepingExecutor = newThreadPool(THREAD_PREFIX + "-housekeeper-", 3, THREAD_POOL_TIMEOUT);
+    this.dueExecutor = housekeepingExecutor;
+    this.detectDeadExecutor = housekeepingExecutor;
+    this.updateHeartbeatExecutor = housekeepingExecutor;
 
-	public void stop() {
-		if (schedulerState.isShuttingDown()) {
-			LOG.warn("Multiple calls to 'stop()'. Scheduler is already stopping.");
-			return;
+//    this.dueExecutor = Executors.newSingleThreadExecutor(defaultThreadFactoryWithPrefix(THREAD_PREFIX + "-execute-due-"));
+//    this.detectDeadExecutor = Executors.newSingleThreadExecutor(defaultThreadFactoryWithPrefix(THREAD_PREFIX + "-detect-dead-"));
+//    this.updateHeartbeatExecutor = Executors.newSingleThreadExecutor(defaultThreadFactoryWithPrefix(THREAD_PREFIX + "-update-heartbeat-"));
+
+    ExecutorService candidateExecutorService = executorService;
+    if (candidateExecutorService == null) {
+      candidateExecutorService = newThreadPool(THREAD_PREFIX + "-", parallelism, THREAD_POOL_TIMEOUT);
+      managedExecutorService = true;
+    } else {
+    	managedExecutorService = false;
 		}
+		this.executorService = candidateExecutorService;
 
-		schedulerState.setIsShuttingDown();
-
-		LOG.info("Shutting down Scheduler.");
-		if (!ExecutorUtils.shutdownNowAndAwaitTermination(dueExecutor, Duration.ofSeconds(5))) {
-			LOG.warn("Failed to shutdown due-executor properly.");
-		}
-		if (!ExecutorUtils.shutdownNowAndAwaitTermination(detectDeadExecutor, Duration.ofSeconds(5))) {
-			LOG.warn("Failed to shutdown detect-dead-executor properly.");
-		}
-		if (!ExecutorUtils.shutdownNowAndAwaitTermination(updateHeartbeatExecutor, Duration.ofSeconds(5))) {
-			LOG.warn("Failed to shutdown update-heartbeat-executor properly.");
-		}
-
-		LOG.info("Letting running executions finish. Will wait up to {}.", SHUTDOWN_WAIT);
-		if (ExecutorUtils.shutdownAndAwaitTermination(executorService, SHUTDOWN_WAIT)) {
-			LOG.info("Scheduler stopped.");
-		} else {
-			LOG.warn("Scheduler stopped, but some tasks did not complete. Was currently running the following executions:\n{}",
-					new ArrayList<>(currentlyProcessing.keySet()).stream().map(Execution::toString).collect(Collectors.joining("\n")));
-		}
-	}
-
-	public SchedulerState getSchedulerState() {
-	    return schedulerState;
+    if(executorShutdownWait == null) {
+      this.executorShutdownWait = DEFAULT_SHUTDOWN_TIMEOUT;
+    } else {
+      this.executorShutdownWait = executorShutdownWait;
     }
 
-	@Override
-	public <T> void schedule(TaskInstance<T> taskInstance, Instant executionTime) {
-		this.delegate.schedule(taskInstance, executionTime);
-	}
+    SchedulerClientEventListener earlyExecutionListener = (enableImmediateExecution ? new TriggerCheckForDueExecutions(schedulerState, clock, executeDueWaiter) : SchedulerClientEventListener.NOOP);
+    delegate = new StandardSchedulerClient(taskRepository, earlyExecutionListener);
+  }
 
-	@Override
-	public void reschedule(TaskInstanceId taskInstanceId, Instant newExecutionTime) {
-		this.delegate.reschedule(taskInstanceId, newExecutionTime);
-	}
+  public void start() {
+    LOG.info("Starting scheduler.");
 
-	@Override
-	public void cancel(TaskInstanceId taskInstanceId) {
-		this.delegate.cancel(taskInstanceId);
-	}
+    executeOnStartup();
 
-	@Override
-	public void getScheduledExecutions(Consumer<ScheduledExecution<Object>> consumer) {
-		this.delegate.getScheduledExecutions(consumer);
-	}
+    dueExecutor.submit(new RunUntilShutdown(this::executeDue, executeDueWaiter, schedulerState, statsRegistry));
+    detectDeadExecutor.submit(new RunUntilShutdown(this::detectDeadExecutions, detectDeadWaiter, schedulerState, statsRegistry));
+    updateHeartbeatExecutor.submit(new RunUntilShutdown(this::updateHeartbeats, heartbeatWaiter, schedulerState, statsRegistry));
 
-	@Override
-	public <T> void getScheduledExecutionsForTask(String taskName, Class<T> dataClass, Consumer<ScheduledExecution<T>> consumer) {
-		this.delegate.getScheduledExecutionsForTask(taskName, dataClass, consumer);
-	}
+    schedulerState.setStarted();
+  }
 
-	@Override
-	public Optional<ScheduledExecution<Object>> getScheduledExecution(TaskInstanceId taskInstanceId) {
-		return this.delegate.getScheduledExecution(taskInstanceId);
-	}
+  protected void executeOnStartup() {
+    onStartup.forEach(os -> {
+      try {
+        os.onStartup(this, this.clock);
+      } catch (Exception e) {
+        LOG.error("Unexpected error while executing OnStartup tasks. Continuing.", e);
+        statsRegistry.register(SchedulerStatsEvent.UNEXPECTED_ERROR);
+      }
+    });
+  }
 
-	public List<Execution> getFailingExecutions(Duration failingAtLeastFor) {
-		return taskRepository.getExecutionsFailingLongerThan(failingAtLeastFor);
-	}
+  public void stop() {
+    if (schedulerState.isShuttingDown()) {
+      LOG.warn("Multiple calls to 'stop()'. Scheduler is already stopping.");
+      return;
+    }
 
-	public boolean triggerCheckForDueExecutions() {
-		return executeDueWaiter.wake();
-	}
+    schedulerState.setIsShuttingDown();
 
-	public List<CurrentlyExecuting> getCurrentlyExecuting() {
-		return new ArrayList<>(currentlyProcessing.values());
-	}
+    LOG.info("Shutting down Scheduler.");
+    if (!ExecutorUtils.shutdownNowAndAwaitTermination(dueExecutor, Duration.ofSeconds(5))) {
+      LOG.warn("Failed to shutdown due-executor properly.");
+    }
+    if (!ExecutorUtils.shutdownNowAndAwaitTermination(detectDeadExecutor, Duration.ofSeconds(5))) {
+      LOG.warn("Failed to shutdown detect-dead-executor properly.");
+    }
+    if (!ExecutorUtils.shutdownNowAndAwaitTermination(updateHeartbeatExecutor, Duration.ofSeconds(5))) {
+      LOG.warn("Failed to shutdown update-heartbeat-executor properly.");
+    }
 
-	protected void executeDue() {
-		Instant now = clock.now();
-		List<Execution> dueExecutions = taskRepository.getDue(now, pollingLimit);
-		LOG.trace("Found {} taskinstances due for execution", dueExecutions.size());
-
-		int thisGenerationNumber = this.currentGenerationNumber + 1;
-		DueExecutionsBatch newDueBatch = new DueExecutionsBatch(Scheduler.this.threadpoolSize, thisGenerationNumber, dueExecutions.size(), pollingLimit == dueExecutions.size());
-
-		for (Execution e : dueExecutions) {
-			executorService.execute(new PickAndExecute(e, newDueBatch));
-		}
-		this.currentGenerationNumber = thisGenerationNumber;
-		statsRegistry.register(SchedulerStatsEvent.RAN_EXECUTE_DUE);
-	}
-
-	@SuppressWarnings({"rawtypes","unchecked"})
-	protected void detectDeadExecutions() {
-        LOG.debug("Deleting executions with unresolved tasks.");
-        taskResolver.getUnresolvedTaskNames(deleteUnresolvedAfter)
-            .forEach(taskName -> {
-                LOG.warn("Deleting all executions for task with name '{}'. They have been unresolved for more than {}", taskName, deleteUnresolvedAfter);
-                int removed = taskRepository.removeExecutions(taskName);
-                LOG.info("Removed {} executions", removed);
-                taskResolver.clearUnresolved(taskName);
-            });
-
-		LOG.debug("Checking for dead executions.");
-		Instant now = clock.now();
-		final Instant oldAgeLimit = now.minus(getMaxAgeBeforeConsideredDead());
-		List<Execution> oldExecutions = taskRepository.getDeadExecutions(oldAgeLimit);
-
-		if (!oldExecutions.isEmpty()) {
-			oldExecutions.forEach(execution -> {
-
-				LOG.info("Found dead execution. Delegating handling to task. Execution: " + execution);
-				try {
-
-					Optional<Task> task = taskResolver.resolve(execution.taskInstance.getTaskName());
-					if (task.isPresent()) {
-						statsRegistry.register(SchedulerStatsEvent.DEAD_EXECUTION);
-						task.get().getDeadExecutionHandler().deadExecution(execution, new ExecutionOperations(taskRepository, execution));
-					} else {
-						LOG.error("Failed to find implementation for task with name '{}' for detected dead execution. Either delete the execution from the databaser, or add an implementation for it.", execution.taskInstance.getTaskName());
-					}
-
-				} catch (Throwable e) {
-					LOG.error("Failed while handling dead execution {}. Will be tried again later.", execution, e);
-					statsRegistry.register(SchedulerStatsEvent.UNEXPECTED_ERROR);
-				}
-			});
+    if(managedExecutorService) {
+			LOG.info("Letting running executions finish. Will wait up to {}.", executorShutdownWait);
+			if (ExecutorUtils.shutdownAndAwaitTermination(executorService, executorShutdownWait)) {
+				LOG.info("Scheduler stopped.");
+			} else {
+        if(!currentlyProcessing.isEmpty()) {
+          String runningJobs = currentlyProcessing.keySet().stream().map(Execution::toString).collect(Collectors.joining("\n"));
+          LOG.warn("Scheduler did not shut down within the timeout. Interrupting the following jobs:\n{}", runningJobs);
+        } else {
+          LOG.warn("Scheduler did not shut down cleanly within the timeout. Terminating the executor.");
+        }
+			  if(!ExecutorUtils.shutdownNowAndAwaitTermination(executorService, Duration.ofSeconds(5))) {
+			    LOG.warn("Scheduler did not terminate within the timeout. The Scheduler pool may be orphaned and have live threads.");
+        }
+        if(!currentlyProcessing.isEmpty()) {
+          String staleJobs = currentlyProcessing.keySet().stream().map(Execution::toString).collect(Collectors.joining("\n"));
+          LOG.warn("Scheduler stopped, but the following jobs were orphaned:\n{}", staleJobs);
+        }
+			}
 		} else {
-			LOG.trace("No dead executions found.");
+    	LOG.info("Not shutting down externally managed job executor.");
 		}
-		statsRegistry.register(SchedulerStatsEvent.RAN_DETECT_DEAD);
-	}
+  }
 
-	void updateHeartbeats() {
-		if (currentlyProcessing.isEmpty()) {
-			LOG.trace("No executions to update heartbeats for. Skipping.");
-			return;
-		}
+  public SchedulerState getSchedulerState() {
+    return schedulerState;
+  }
 
-		LOG.debug("Updating heartbeats for {} executions being processed.", currentlyProcessing.size());
-		Instant now = clock.now();
-		new ArrayList<>(currentlyProcessing.keySet()).forEach(execution -> {
-			LOG.trace("Updating heartbeat for execution: " + execution);
-			try {
-				taskRepository.updateHeartbeat(execution, now);
-			} catch (Throwable e) {
-				LOG.error("Failed while updating heartbeat for execution {}. Will try again later.", execution, e);
-				statsRegistry.register(SchedulerStatsEvent.UNEXPECTED_ERROR);
-			}
-		});
-		statsRegistry.register(SchedulerStatsEvent.RAN_UPDATE_HEARTBEATS);
-	}
+  @Override
+  public <T> void schedule(TaskInstance<T> taskInstance, Instant executionTime) {
+    this.delegate.schedule(taskInstance, executionTime);
+  }
 
-	private Duration getMaxAgeBeforeConsideredDead() {
-		return heartbeatInterval.multipliedBy(4);
-	}
+  @Override
+  public void reschedule(TaskInstanceId taskInstanceId, Instant newExecutionTime) {
+    this.delegate.reschedule(taskInstanceId, newExecutionTime);
+  }
 
-	private class PickAndExecute implements Runnable {
-		private Execution candidate;
-		private DueExecutionsBatch addedDueExecutionsBatch;
+  @Override
+  public void cancel(TaskInstanceId taskInstanceId) {
+    this.delegate.cancel(taskInstanceId);
+  }
 
-		public PickAndExecute(Execution candidate, DueExecutionsBatch dueExecutionsBatch) {
-			this.candidate = candidate;
-			this.addedDueExecutionsBatch = dueExecutionsBatch;
-		}
+  @Override
+  public void getScheduledExecutions(Consumer<ScheduledExecution<Object>> consumer) {
+    this.delegate.getScheduledExecutions(consumer);
+  }
 
-		@Override
-		public void run() {
-			if (schedulerState.isShuttingDown()) {
-				LOG.info("Scheduler has been shutdown. Skipping fetched due execution: " + candidate.taskInstance.getTaskAndInstance());
-				return;
-			}
+  @Override
+  public <T> void getScheduledExecutionsForTask(String taskName, Class<T> dataClass, Consumer<ScheduledExecution<T>> consumer) {
+    this.delegate.getScheduledExecutionsForTask(taskName, dataClass, consumer);
+  }
 
-			if (addedDueExecutionsBatch.isOlderGenerationThan(currentGenerationNumber)) {
-				// skipping execution due to it being stale
-				addedDueExecutionsBatch.markBatchAsStale();
-				statsRegistry.register(StatsRegistry.CandidateStatsEvent.STALE);
-				LOG.trace("Skipping queued execution (current generationNumber: {}, execution generationNumber: {})", currentGenerationNumber, addedDueExecutionsBatch.getGenerationNumber());
-				return;
-			}
+  @Override
+  public Optional<ScheduledExecution<Object>> getScheduledExecution(TaskInstanceId taskInstanceId) {
+    return this.delegate.getScheduledExecution(taskInstanceId);
+  }
 
-			final Optional<Execution> pickedExecution = taskRepository.pick(candidate, clock.now());
+  public List<Execution> getFailingExecutions(Duration failingAtLeastFor) {
+    return taskRepository.getExecutionsFailingLongerThan(failingAtLeastFor);
+  }
 
-			if (!pickedExecution.isPresent()) {
-				// someone else picked id
-				LOG.debug("Execution picked by another scheduler. Continuing to next due execution.");
-				statsRegistry.register(StatsRegistry.CandidateStatsEvent.ALREADY_PICKED);
-				return;
-			}
+  public boolean triggerCheckForDueExecutions() {
+    return executeDueWaiter.wake();
+  }
 
-			currentlyProcessing.put(pickedExecution.get(), new CurrentlyExecuting(pickedExecution.get(), clock));
-			try {
-				statsRegistry.register(StatsRegistry.CandidateStatsEvent.EXECUTED);
-				executePickedExecution(pickedExecution.get());
-			} finally {
-				if (currentlyProcessing.remove(pickedExecution.get()) == null) {
-					// May happen in rare circumstances (typically concurrency tests)
-					LOG.warn("Released execution was not found in collection of executions currently being processed. Should never happen.");
-				}
-				addedDueExecutionsBatch.oneExecutionDone(() -> triggerCheckForDueExecutions());
-			}
-		}
+  public List<CurrentlyExecuting> getCurrentlyExecuting() {
+    return new ArrayList<>(currentlyProcessing.values());
+  }
 
-		private void executePickedExecution(Execution execution) {
-			final Optional<Task> task = taskResolver.resolve(execution.taskInstance.getTaskName());
-			if (!task.isPresent()) {
-				LOG.error("Failed to find implementation for task with name '{}'. Should have been excluded in JdbcRepository.", execution.taskInstance.getTaskName());
-				statsRegistry.register(SchedulerStatsEvent.UNEXPECTED_ERROR);
-				return;
-			}
+  protected void executeDue() {
+    Instant now = clock.now();
+    List<Execution> dueExecutions = taskRepository.getDue(now, pollingLimit);
+    LOG.trace("Found {} taskinstances due for execution", dueExecutions.size());
 
-			Instant executionStarted = clock.now();
-			try {
-				LOG.debug("Executing " + execution);
-				CompletionHandler completion = task.get().execute(execution.taskInstance, new ExecutionContext(schedulerState, execution, Scheduler.this));
-				LOG.debug("Execution done");
+    int thisGenerationNumber = this.currentGenerationNumber + 1;
+    DueExecutionsBatch newDueBatch = new DueExecutionsBatch(Scheduler.this.parallelism, thisGenerationNumber, dueExecutions.size(), pollingLimit == dueExecutions.size());
 
-				complete(completion, execution, executionStarted);
-				statsRegistry.register(StatsRegistry.ExecutionStatsEvent.COMPLETED);
+    for (Execution e : dueExecutions) {
+      executorService.execute(new PickAndExecute(e, newDueBatch));
+    }
+    this.currentGenerationNumber = thisGenerationNumber;
+    statsRegistry.register(SchedulerStatsEvent.RAN_EXECUTE_DUE);
+  }
 
-			} catch (RuntimeException unhandledException) {
-				LOG.error("Unhandled exception during execution of task with name '{}'. Treating as failure.", task.get().getName(), unhandledException);
-				failure(task.get().getFailureHandler(), execution, unhandledException, executionStarted);
-				statsRegistry.register(StatsRegistry.ExecutionStatsEvent.FAILED);
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  protected void detectDeadExecutions() {
+    LOG.debug("Deleting executions with unresolved tasks.");
+    taskResolver.getUnresolvedTaskNames(deleteUnresolvedAfter)
+        .forEach(taskName -> {
+          LOG.warn("Deleting all executions for task with name '{}'. They have been unresolved for more than {}", taskName, deleteUnresolvedAfter);
+          int removed = taskRepository.removeExecutions(taskName);
+          LOG.info("Removed {} executions", removed);
+          taskResolver.clearUnresolved(taskName);
+        });
 
-			} catch (Throwable unhandledError) {
-				LOG.error("Error during execution of task with name '{}'. Treating as failure.", task.get().getName(), unhandledError);
-				failure(task.get().getFailureHandler(), execution, unhandledError, executionStarted);
-				statsRegistry.register(StatsRegistry.ExecutionStatsEvent.FAILED);
-			}
-		}
+    LOG.debug("Checking for dead executions.");
+    Instant now = clock.now();
+    final Instant oldAgeLimit = now.minus(getMaxAgeBeforeConsideredDead());
+    List<Execution> oldExecutions = taskRepository.getDeadExecutions(oldAgeLimit);
 
-		private void complete(CompletionHandler completion, Execution execution, Instant executionStarted) {
-			ExecutionComplete completeEvent = ExecutionComplete.success(execution, executionStarted, clock.now());
-			try {
-				completion.complete(completeEvent, new ExecutionOperations(taskRepository, execution));
-				statsRegistry.registerSingleCompletedExecution(completeEvent);
-			} catch (Throwable e) {
-				statsRegistry.register(SchedulerStatsEvent.COMPLETIONHANDLER_ERROR);
-				statsRegistry.register(SchedulerStatsEvent.UNEXPECTED_ERROR);
-				LOG.error("Failed while completing execution {}. Execution will likely remain scheduled and locked/picked. " +
-						"The execution should be detected as dead in {}, and handled according to the tasks DeadExecutionHandler.", execution, getMaxAgeBeforeConsideredDead(), e);
-			}
-		}
+    if (!oldExecutions.isEmpty()) {
+      oldExecutions.forEach(execution -> {
 
-		private void failure(FailureHandler failureHandler, Execution execution, Throwable cause, Instant executionStarted) {
-			ExecutionComplete completeEvent = ExecutionComplete.failure(execution, executionStarted, clock.now(), cause);
-			try {
-				failureHandler.onFailure(completeEvent, new ExecutionOperations(taskRepository, execution));
-				statsRegistry.registerSingleCompletedExecution(completeEvent);
-			} catch (Throwable e) {
-				statsRegistry.register(SchedulerStatsEvent.FAILUREHANDLER_ERROR);
-				statsRegistry.register(SchedulerStatsEvent.UNEXPECTED_ERROR);
-				LOG.error("Failed while completing execution {}. Execution will likely remain scheduled and locked/picked. " +
-						"The execution should be detected as dead in {}, and handled according to the tasks DeadExecutionHandler.", execution, getMaxAgeBeforeConsideredDead(), e);
-			}
-		}
+        LOG.info("Found dead execution. Delegating handling to task. Execution: " + execution);
+        try {
 
-	}
+          Optional<Task> task = taskResolver.resolve(execution.taskInstance.getTaskName());
+          if (task.isPresent()) {
+            statsRegistry.register(SchedulerStatsEvent.DEAD_EXECUTION);
+            task.get().getDeadExecutionHandler().deadExecution(execution, new ExecutionOperations(taskRepository, execution));
+          } else {
+            LOG.error("Failed to find implementation for task with name '{}' for detected dead execution. Either delete the execution from the databaser, or add an implementation for it.", execution.taskInstance.getTaskName());
+          }
 
-	public static SchedulerBuilder create(DataSource dataSource, Task<?> ... knownTasks) {
-		return create(dataSource, Arrays.asList(knownTasks));
-	}
+        } catch (Throwable e) {
+          LOG.error("Failed while handling dead execution {}. Will be tried again later.", execution, e);
+          statsRegistry.register(SchedulerStatsEvent.UNEXPECTED_ERROR);
+        }
+      });
+    } else {
+      LOG.trace("No dead executions found.");
+    }
+    statsRegistry.register(SchedulerStatsEvent.RAN_DETECT_DEAD);
+  }
 
-	public static SchedulerBuilder create(DataSource dataSource, List<Task<?>> knownTasks) {
-		return new SchedulerBuilder(dataSource, knownTasks);
-	}
+  void updateHeartbeats() {
+    if (currentlyProcessing.isEmpty()) {
+      LOG.trace("No executions to update heartbeats for. Skipping.");
+      return;
+    }
+
+    LOG.debug("Updating heartbeats for {} executions being processed.", currentlyProcessing.size());
+    Instant now = clock.now();
+    new ArrayList<>(currentlyProcessing.keySet()).forEach(execution -> {
+      LOG.trace("Updating heartbeat for execution: " + execution);
+      try {
+        taskRepository.updateHeartbeat(execution, now);
+      } catch (Throwable e) {
+        LOG.error("Failed while updating heartbeat for execution {}. Will try again later.", execution, e);
+        statsRegistry.register(SchedulerStatsEvent.UNEXPECTED_ERROR);
+      }
+    });
+    statsRegistry.register(SchedulerStatsEvent.RAN_UPDATE_HEARTBEATS);
+  }
+
+  private Duration getMaxAgeBeforeConsideredDead() {
+    return heartbeatInterval.multipliedBy(4);
+  }
+
+  private class PickAndExecute implements Runnable {
+    private final Execution candidate;
+    private final DueExecutionsBatch addedDueExecutionsBatch;
+
+    public PickAndExecute(Execution candidate, DueExecutionsBatch dueExecutionsBatch) {
+      this.candidate = candidate;
+      this.addedDueExecutionsBatch = dueExecutionsBatch;
+    }
+
+    @Override
+    public void run() {
+      if (schedulerState.isShuttingDown()) {
+        LOG.info("Scheduler has been shutdown. Skipping fetched due execution: " + candidate.taskInstance.getTaskAndInstance());
+        return;
+      }
+
+      if (addedDueExecutionsBatch.isOlderGenerationThan(currentGenerationNumber)) {
+        // skipping execution due to it being stale
+        addedDueExecutionsBatch.markBatchAsStale();
+        statsRegistry.register(StatsRegistry.CandidateStatsEvent.STALE);
+        LOG.trace("Skipping queued execution (current generationNumber: {}, execution generationNumber: {})", currentGenerationNumber, addedDueExecutionsBatch.getGenerationNumber());
+        return;
+      }
+
+      final Optional<Execution> pickedExecution = taskRepository.pick(candidate, clock.now());
+
+      if (!pickedExecution.isPresent()) {
+        // someone else picked id
+        LOG.debug("Execution picked by another scheduler. Continuing to next due execution.");
+        statsRegistry.register(StatsRegistry.CandidateStatsEvent.ALREADY_PICKED);
+        return;
+      }
+
+      currentlyProcessing.put(pickedExecution.get(), new CurrentlyExecuting(pickedExecution.get(), clock));
+      try {
+        statsRegistry.register(StatsRegistry.CandidateStatsEvent.EXECUTED);
+        executePickedExecution(pickedExecution.get());
+      } finally {
+        if (currentlyProcessing.remove(pickedExecution.get()) == null) {
+          // May happen in rare circumstances (typically concurrency tests)
+          LOG.warn("Released execution was not found in collection of executions currently being processed. Should never happen.");
+        }
+        addedDueExecutionsBatch.oneExecutionDone(Scheduler.this::triggerCheckForDueExecutions);
+      }
+    }
+
+    private void executePickedExecution(Execution execution) {
+      final Optional<Task> task = taskResolver.resolve(execution.taskInstance.getTaskName());
+      if (!task.isPresent()) {
+        LOG.error("Failed to find implementation for task with name '{}'. Should have been excluded in JdbcRepository.", execution.taskInstance.getTaskName());
+        statsRegistry.register(SchedulerStatsEvent.UNEXPECTED_ERROR);
+        return;
+      }
+
+      Instant executionStarted = clock.now();
+      try {
+        LOG.debug("Executing " + execution);
+        CompletionHandler<?> completion = task.get().execute(execution.taskInstance, new ExecutionContext(schedulerState, execution, Scheduler.this));
+        LOG.debug("Execution done");
+
+        complete(completion, execution, executionStarted);
+        statsRegistry.register(StatsRegistry.ExecutionStatsEvent.COMPLETED);
+
+      } catch (RuntimeException unhandledException) {
+        LOG.error("Unhandled exception during execution of task with name '{}'. Treating as failure.", task.get().getName(), unhandledException);
+        failure(task.get().getFailureHandler(), execution, unhandledException, executionStarted);
+        statsRegistry.register(StatsRegistry.ExecutionStatsEvent.FAILED);
+
+      } catch (Throwable unhandledError) {
+        LOG.error("Error during execution of task with name '{}'. Treating as failure.", task.get().getName(), unhandledError);
+        failure(task.get().getFailureHandler(), execution, unhandledError, executionStarted);
+        statsRegistry.register(StatsRegistry.ExecutionStatsEvent.FAILED);
+      }
+    }
+
+    private void complete(CompletionHandler completion, Execution execution, Instant executionStarted) {
+      ExecutionComplete completeEvent = ExecutionComplete.success(execution, executionStarted, clock.now());
+      try {
+        completion.complete(completeEvent, new ExecutionOperations(taskRepository, execution));
+        statsRegistry.registerSingleCompletedExecution(completeEvent);
+      } catch (Throwable e) {
+        statsRegistry.register(SchedulerStatsEvent.COMPLETIONHANDLER_ERROR);
+        statsRegistry.register(SchedulerStatsEvent.UNEXPECTED_ERROR);
+        LOG.error("Failed while completing execution {}. Execution will likely remain scheduled and locked/picked. " +
+            "The execution should be detected as dead in {}, and handled according to the tasks DeadExecutionHandler.", execution, getMaxAgeBeforeConsideredDead(), e);
+      }
+    }
+
+    private void failure(FailureHandler failureHandler, Execution execution, Throwable cause, Instant executionStarted) {
+      ExecutionComplete completeEvent = ExecutionComplete.failure(execution, executionStarted, clock.now(), cause);
+      try {
+        failureHandler.onFailure(completeEvent, new ExecutionOperations(taskRepository, execution));
+        statsRegistry.registerSingleCompletedExecution(completeEvent);
+      } catch (Throwable e) {
+        statsRegistry.register(SchedulerStatsEvent.FAILUREHANDLER_ERROR);
+        statsRegistry.register(SchedulerStatsEvent.UNEXPECTED_ERROR);
+        LOG.error("Failed while completing execution {}. Execution will likely remain scheduled and locked/picked. " +
+            "The execution should be detected as dead in {}, and handled according to the tasks DeadExecutionHandler.", execution, getMaxAgeBeforeConsideredDead(), e);
+      }
+    }
+
+  }
+
+  public static SchedulerBuilder create(DataSource dataSource, Task<?>... knownTasks) {
+    return create(dataSource, Arrays.asList(knownTasks));
+  }
+
+  public static SchedulerBuilder create(DataSource dataSource, List<Task<?>> knownTasks) {
+    return new SchedulerBuilder(dataSource, knownTasks);
+  }
+
+  private static ThreadPoolExecutor newThreadPool(String prefix, int maxThreads, Duration threadTimeout) {
+    ThreadPoolExecutor executor = new ThreadPoolExecutor(maxThreads, maxThreads,
+        threadTimeout.toMillis(), TimeUnit.MILLISECONDS,
+        new LinkedBlockingQueue<>(),
+        defaultThreadFactoryWithPrefix(prefix)
+    );
+    executor.allowCoreThreadTimeOut(true);
+    return executor;
+  }
 
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskResolver.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskResolver.java
@@ -24,11 +24,9 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/Execution.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/Execution.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 
 @SuppressWarnings("rawtypes")
 public final class Execution {
-	public final TaskInstance taskInstance;
+	public final TaskInstance<?> taskInstance;
 	public final Instant executionTime;
 	public final boolean picked;
 	public final String pickedBy;

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/ManualScheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/ManualScheduler.java
@@ -32,7 +32,7 @@ public class ManualScheduler extends Scheduler {
     private final SettableClock clock;
 
     ManualScheduler(SettableClock clock, TaskRepository taskRepository, TaskResolver taskResolver, int maxThreads, ExecutorService executorService, SchedulerName schedulerName, Waiter waiter, Duration heartbeatInterval, boolean executeImmediately, StatsRegistry statsRegistry, int pollingLimit, Duration deleteUnresolvedAfter, List<OnStartup> onStartup) {
-        super(clock, taskRepository, taskResolver, maxThreads, executorService, schedulerName, waiter, heartbeatInterval, executeImmediately, statsRegistry, pollingLimit, deleteUnresolvedAfter, onStartup);
+        super(clock, taskRepository, taskResolver, maxThreads, executorService, null, schedulerName, waiter, heartbeatInterval, executeImmediately, statsRegistry, pollingLimit, deleteUnresolvedAfter, onStartup);
         this.clock = clock;
     }
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
@@ -61,6 +61,7 @@ public class DeadExecutionsTest {
 				taskResolver,
 				1,
 				MoreExecutors.newDirectExecutorService(),
+				null,
 				new SchedulerName.Fixed("test-scheduler"),
 				new Waiter(Duration.ZERO),
 				Duration.ofMinutes(1),

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
@@ -48,7 +48,7 @@ public class SchedulerTest {
         final StatsRegistry statsRegistry = StatsRegistry.NOOP;
         TaskResolver taskResolver = new TaskResolver(statsRegistry, clock, Arrays.asList(tasks));
 		JdbcTaskRepository taskRepository = new JdbcTaskRepository(postgres.getDataSource(), DEFAULT_TABLE_NAME, taskResolver, new SchedulerName.Fixed("scheduler1"));
-		return new Scheduler(clock, taskRepository, taskResolver, 1, executor, new SchedulerName.Fixed("name"), new Waiter(Duration.ZERO), Duration.ofSeconds(1), false, statsRegistry, 10_000, Duration.ofDays(14), new ArrayList<>());
+		return new Scheduler(clock, taskRepository, taskResolver, 1, executor, null, new SchedulerName.Fixed("name"), new Waiter(Duration.ZERO), Duration.ofSeconds(1), false, statsRegistry, 10_000, Duration.ofDays(14), new ArrayList<>());
 	}
 
 	@Test

--- a/db-scheduler/src/test/resources/logback-test.xml
+++ b/db-scheduler/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) %cyan(%logger{50}) - %msg%n%rootException</pattern>
+    </encoder>
+  </appender>
+
+  <logger level="INFO" name="com.github.kagkarlsson"/>
+
+  <root level="WARN">
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+</configuration>

--- a/examples/spring-boot-example/pom.xml
+++ b/examples/spring-boot-example/pom.xml
@@ -50,6 +50,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/examples/spring-boot-example/src/test/resources/logback-test.xml
+++ b/examples/spring-boot-example/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) %cyan(%logger{50}) - %msg%n%rootException</pattern>
+    </encoder>
+  </appender>
+
+  <logger level="INFO" name="com.github.kagkarlsson"/>
+
+  <root level="WARN">
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 				<plugin>
 					<groupId>org.jasig.maven</groupId>
 					<artifactId>maven-notice-plugin</artifactId>
-					<version>1.0.6.1</version>
+					<version>1.1.0</version>
 					<configuration>
 						<noticeTemplate>${license.dir}/NOTICE.template</noticeTemplate>
 						<licenseMapping>
@@ -99,6 +99,19 @@
 							<inherited>false</inherited>
 						</execution>
 					</executions>
+					<!-- missing dependencies that allow this plugin to run on JDK 9+ -->
+					<dependencies>
+						<dependency>
+							<groupId>jakarta.xml.bind</groupId>
+							<artifactId>jakarta.xml.bind-api</artifactId>
+							<version>2.3.2</version>
+						</dependency>
+						<dependency>
+							<groupId>org.glassfish.jaxb</groupId>
+							<artifactId>jaxb-runtime</artifactId>
+							<version>2.3.2</version>
+						</dependency>
+					</dependencies>
 
 				</plugin>
 				<plugin>


### PR DESCRIPTION
- Modify Scheduler to take responsibility for the lifecycle of
  the job ExecutorService only if it's not externally supplied.
- Make the shutdown timeout be externally configurable by the user.
- Additional logging for when the Scheduler does not shut down cleanly.
- Add bits to the POM that allow for building under Java 9+
- Have the tests use logback instead of slf4-simple for log output

This addresses #88 