### PR TITLE
allow rescheduling task with new data

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -148,6 +148,11 @@ public class Scheduler implements SchedulerClient {
     }
 
     @Override
+    public <T> void reschedule(TaskInstanceId taskInstanceId, Instant newExecutionTime, T newData) {
+        this.delegate.reschedule(taskInstanceId, newExecutionTime, newData);
+    }
+
+    @Override
     public void cancel(TaskInstanceId taskInstanceId) {
         this.delegate.cancel(taskInstanceId);
     }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/TestTasks.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/TestTasks.java
@@ -172,6 +172,15 @@ public class TestTasks {
         }
     }
 
+    public static class SavingHandler<T> implements VoidExecutionHandler<T> {
+        public T savedData;
+
+        @Override
+        public void execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+            savedData = taskInstance.getData();
+        }
+    }
+
     public static class SimpleStatsRegistry extends StatsRegistry.DefaultStatsRegistry {
         public final AtomicInteger unexpectedErrors = new AtomicInteger(0);
 


### PR DESCRIPTION
I have a use case where I need to reschedule a task, but with different data. `TaskRepository` already has this capability, so this PR just introduces a new method on the `Scheduler` and `SchedulerClient`.

Please let me know if this makes sense, or if you want me to change anything. Thanks!