### PR TITLE
Disable schedule startup tasks configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ db-scheduler.scheduler-name=
 db-scheduler.threads=10
 # Ignored if a custom DbSchedulerStarter bean is defined
 db-scheduler.delay-startup-until-context-ready=false
+# Whether to schedule default recurring and startup tasks when application starts.
+db-scheduler.schedule-startup-tasks-enabled=true
 ```
 
 

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
@@ -171,6 +171,6 @@ public class DbSchedulerAutoConfiguration {
     }
 
     private Predicate<Task<?>> shouldBeStarted() {
-        return task -> task instanceof OnStartup && config.isStartupTasksEnabled();
+        return task -> task instanceof OnStartup && config.isScheduleStartupTasksEnabled();
     }
 }

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
@@ -96,9 +96,9 @@ public class DbSchedulerProperties {
     private Duration deleteUnresolvedAfter = Duration.ofDays(14);
 
     /**
-     * <p>Whether to schedule recurring tasks on startup.</p>
+     * <p>Whether to schedule default recurring and startup tasks when application starts.</p>
      */
-    private boolean startupTasksEnabled = true;
+    private boolean scheduleStartupTasksEnabled = true;
 
     public boolean isEnabled() {
         return enabled;
@@ -180,11 +180,11 @@ public class DbSchedulerProperties {
         this.deleteUnresolvedAfter = deleteUnresolvedAfter;
     }
 
-    public boolean isStartupTasksEnabled() {
-        return startupTasksEnabled;
+    public boolean isScheduleStartupTasksEnabled() {
+        return scheduleStartupTasksEnabled;
     }
 
-    public void setStartupTasksEnabled(boolean startupTasksEnabled) {
-        this.startupTasksEnabled = startupTasksEnabled;
+    public void setScheduleStartupTasksEnabled(boolean scheduleStartupTasksEnabled) {
+        this.scheduleStartupTasksEnabled = scheduleStartupTasksEnabled;
     }
 }

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
@@ -95,6 +95,11 @@ public class DbSchedulerProperties {
     @NotNull
     private Duration deleteUnresolvedAfter = Duration.ofDays(14);
 
+    /**
+     * <p>Whether to schedule recurring tasks on startup.</p>
+     */
+    private boolean startupTasksEnabled = true;
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -173,5 +178,13 @@ public class DbSchedulerProperties {
 
     public void setDeleteUnresolvedAfter(Duration deleteUnresolvedAfter) {
         this.deleteUnresolvedAfter = deleteUnresolvedAfter;
+    }
+
+    public boolean isStartupTasksEnabled() {
+        return startupTasksEnabled;
+    }
+
+    public void setStartupTasksEnabled(boolean startupTasksEnabled) {
+        this.startupTasksEnabled = startupTasksEnabled;
     }
 }


### PR DESCRIPTION
In my use case, I'm creating recurring task dynamically from my application. I don't know which tasks should be running and what task data they should have during the startup.

With current behavior, all recurring tasks are started automatically with default task data, which is not desirable for me.

This option will disable recurring tasks to start on startup.