### PR TITLE
Commit explicitly if auto-commit=false. Add compatibility test for such data-source.

### DIFF
--- a/db-scheduler/pom.xml
+++ b/db-scheduler/pom.xml
@@ -19,7 +19,7 @@
         <hsqldb.version>2.3.3</hsqldb.version>
         <java8-matchers.version>1.6</java8-matchers.version>
         <equals-verifier.version>3.1.12</equals-verifier.version>
-        <micro-jdbc.version>0.1</micro-jdbc.version>
+        <micro-jdbc.version>0.2</micro-jdbc.version>
         <otj-pg-embedded.version>0.11.4</otj-pg-embedded.version>
         <postgresql.version>9.4.1207</postgresql.version>
         <slf4j.version>1.7.7</slf4j.version>
@@ -110,6 +110,11 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mysql</artifactId>

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
@@ -41,7 +41,7 @@ public class SchedulerBuilder {
     protected Clock clock = new SystemClock(); // if this is set, waiter-clocks must be updated
 
     protected final DataSource dataSource;
-    protected SchedulerName schedulerName = new SchedulerName.Hostname();
+    protected SchedulerName schedulerName;
     protected int executorThreads = 10;
     protected final List<Task<?>> knownTasks = new ArrayList<>();
     protected final List<OnStartup> startTasks = new ArrayList<>();
@@ -150,6 +150,11 @@ public class SchedulerBuilder {
         if (pollingLimit < executorThreads) {
             LOG.warn("Polling-limit is less than number of threads. Should be equal or higher.");
         }
+
+        if (schedulerName == null) {
+             schedulerName = new SchedulerName.Hostname();
+        }
+
         final TaskResolver taskResolver = new TaskResolver(statsRegistry, clock, knownTasks);
         final JdbcCustomization jdbcCustomization = ofNullable(this.jdbcCustomization).orElse(new AutodetectJdbcCustomization(dataSource));
         final JdbcTaskRepository taskRepository = new JdbcTaskRepository(dataSource, jdbcCustomization, tableName, taskResolver, schedulerName, serializer);

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerName.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerName.java
@@ -46,7 +46,14 @@ public interface SchedulerName {
 
         public Hostname() {
             try {
+                long start = System.currentTimeMillis();
+                LOG.debug("Resolving hostname..");
                 cachedHostname = InetAddress.getLocalHost().getHostName();
+                LOG.debug("Resolved hostname..");
+                long duration = System.currentTimeMillis() - start;
+                if (duration > 1000) {
+                    LOG.warn("Hostname-lookup took {}ms", duration);
+                }
             } catch (UnknownHostException e) {
                 LOG.warn("Failed to resolve hostname. Using dummy-name for scheduler.");
                 cachedHostname = "failed.hostname.lookup";

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
@@ -34,6 +34,7 @@ public class AutodetectJdbcCustomization implements JdbcCustomization {
     public AutodetectJdbcCustomization(DataSource dataSource) {
         JdbcCustomization detectedCustomization = new DefaultJdbcCustomization();
 
+        LOG.debug("Detecting database...");
         try (Connection c = dataSource.getConnection()) {
             String databaseProductName = c.getMetaData().getDatabaseProductName();
             LOG.info("Detected database {}.", databaseProductName);

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
@@ -15,6 +15,7 @@
  */
 package com.github.kagkarlsson.scheduler.testhelper;
 
+import com.github.kagkarlsson.scheduler.SchedulerName;
 import com.github.kagkarlsson.scheduler.jdbc.DefaultJdbcCustomization;
 import com.github.kagkarlsson.scheduler.SchedulerBuilder;
 import com.github.kagkarlsson.scheduler.JdbcTaskRepository;
@@ -65,7 +66,7 @@ public class TestHelper {
 
         public ManualScheduler build() {
             final TaskResolver taskResolver = new TaskResolver(statsRegistry, clock, knownTasks);
-            final JdbcTaskRepository taskRepository = new JdbcTaskRepository(dataSource, new DefaultJdbcCustomization(), tableName, taskResolver, schedulerName, serializer);
+            final JdbcTaskRepository taskRepository = new JdbcTaskRepository(dataSource, new DefaultJdbcCustomization(), tableName, taskResolver, new SchedulerName.Fixed("manual"), serializer);
 
             return new ManualScheduler(clock, taskRepository, taskResolver, executorThreads, new DirectExecutorService(), schedulerName, waiter, heartbeatInterval, enableImmediateExecution, statsRegistry, pollingLimit, deleteUnresolvedAfter, startTasks);
         }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/ClusterTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/ClusterTest.java
@@ -38,7 +38,7 @@ public class ClusterTest {
 
     @Test
     public void test_concurrency() throws InterruptedException {
-        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(20), () -> {
 
             final List<String> ids = IntStream.range(1, 1001).mapToObj(String::valueOf).collect(toList());
 
@@ -75,7 +75,7 @@ public class ClusterTest {
 
     @Test
     public void test_concurrency_recurring() throws InterruptedException {
-        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(20), () -> {
 
             final RecurringTask<Void> task1 = Tasks.recurring("task1", Schedules.fixedDelay(Duration.ofMillis(0)))
                 .execute((taskInstance, executionContext) -> {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/ClusterTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/ClusterTest.java
@@ -38,7 +38,7 @@ public class ClusterTest {
 
     @Test
     public void test_concurrency() throws InterruptedException {
-        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(20), () -> {
+        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
 
             final List<String> ids = IntStream.range(1, 1001).mapToObj(String::valueOf).collect(toList());
 
@@ -75,7 +75,7 @@ public class ClusterTest {
 
     @Test
     public void test_concurrency_recurring() throws InterruptedException {
-        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(20), () -> {
+        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
 
             final RecurringTask<Void> task1 = Tasks.recurring("task1", Schedules.fixedDelay(Duration.ofMillis(0)))
                 .execute((taskInstance, executionContext) -> {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/EmbeddedPostgresqlExtension.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/EmbeddedPostgresqlExtension.java
@@ -29,15 +29,18 @@ public class EmbeddedPostgresqlExtension implements AfterEachCallback {
         this.initializeSchema = initializeSchema;
         this.cleanupAfter = cleanupAfter;
         try {
-            if (embeddedPostgresql == null) {
-                embeddedPostgresql = initPostgres();
+            synchronized (this) {
 
-                HikariConfig config = new HikariConfig();
-                config.setDataSource(embeddedPostgresql.getDatabase("test", "test"));
+                if (embeddedPostgresql == null) {
+                    embeddedPostgresql = initPostgres();
 
-                dataSource = new HikariDataSource(config);
+                    HikariConfig config = new HikariConfig();
+                    config.setDataSource(embeddedPostgresql.getDatabase("test", "test"));
 
-                initializeSchema.accept(dataSource);
+                    dataSource = new HikariDataSource(config);
+
+                    initializeSchema.accept(dataSource);
+                }
             }
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/CompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/CompatibilityTest.java
@@ -71,6 +71,7 @@ public abstract class CompatibilityTest {
         scheduler = Scheduler.create(getDataSource(), Lists.newArrayList(oneTime, recurring))
                 .pollingInterval(Duration.ofMillis(10))
                 .heartbeatInterval(Duration.ofMillis(100))
+                .schedulerName(new SchedulerName.Fixed("test"))
                 .statsRegistry(statsRegistry)
                 .build();
         stopScheduler.register(scheduler);

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/NoAutoCommitPostgresqlCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/NoAutoCommitPostgresqlCompatibilityTest.java
@@ -1,13 +1,15 @@
 package com.github.kagkarlsson.scheduler.compatibility;
 
 import com.github.kagkarlsson.scheduler.DbUtils;
+import com.github.kagkarlsson.scheduler.EmbeddedPostgresqlExtension;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.util.DriverDataSource;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
-import org.testcontainers.containers.MySQLContainer;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.MSSQLServerContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -16,26 +18,31 @@ import java.util.Properties;
 
 @Tag("compatibility")
 @Testcontainers
-public class MysqlCompatibilityTest extends CompatibilityTest {
+public class NoAutoCommitPostgresqlCompatibilityTest extends CompatibilityTest {
 
     @Container
-    private static final MySQLContainer MY_SQL = new MySQLContainer();
+    private static final PostgreSQLContainer POSTGRES = new PostgreSQLContainer();
     private static HikariDataSource pooledDatasource;
 
     @BeforeAll
     private static void initSchema() {
-        final DriverDataSource datasource = new DriverDataSource(MY_SQL.getJdbcUrl(), "com.mysql.cj.jdbc.Driver", new Properties(), MY_SQL.getUsername(), MY_SQL.getPassword());
-
-        final HikariConfig hikariConfig = new HikariConfig();
-        hikariConfig.setDataSource(datasource);
-        pooledDatasource = new HikariDataSource(hikariConfig);
+        final DriverDataSource datasource = new DriverDataSource(POSTGRES.getJdbcUrl(), "org.postgresql.Driver",
+            new Properties(), POSTGRES.getUsername(), POSTGRES.getPassword());
 
         // init schema
-        DbUtils.runSqlResource("/mysql_tables.sql").accept(pooledDatasource);
-    }
+        DbUtils.runSqlResource("/postgresql_tables.sql").accept(datasource);
 
+
+        // Setup non auto-committing datasource
+        final HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setDataSource(datasource);
+        hikariConfig.setAutoCommit(false);
+        pooledDatasource = new HikariDataSource(hikariConfig);
+
+    }
     @Override
     public DataSource getDataSource() {
         return pooledDatasource;
     }
+
 }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/DeadExecutionTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/DeadExecutionTest.java
@@ -30,7 +30,7 @@ public class DeadExecutionTest {
 
     @Test
     public void test_dead_execution() {
-        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(20), () -> {
+        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
             CustomTask<Void> customTask = Tasks.custom("custom-a", Void.class)
                 .execute((taskInstance, executionContext) -> new CompletionHandler<Void>() {
                     @Override

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/DeadExecutionTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/DeadExecutionTest.java
@@ -3,6 +3,7 @@ package com.github.kagkarlsson.scheduler.functional;
 import com.github.kagkarlsson.scheduler.DbUtils;
 import com.github.kagkarlsson.scheduler.EmbeddedPostgresqlExtension;
 import com.github.kagkarlsson.scheduler.Scheduler;
+import com.github.kagkarlsson.scheduler.SchedulerName;
 import com.github.kagkarlsson.scheduler.StopSchedulerExtension;
 import com.github.kagkarlsson.scheduler.helper.TestableRegistry;
 import com.github.kagkarlsson.scheduler.task.CompletionHandler;
@@ -29,7 +30,7 @@ public class DeadExecutionTest {
 
     @Test
     public void test_dead_execution() {
-        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(20), () -> {
             CustomTask<Void> customTask = Tasks.custom("custom-a", Void.class)
                 .execute((taskInstance, executionContext) -> new CompletionHandler<Void>() {
                     @Override
@@ -45,6 +46,7 @@ public class DeadExecutionTest {
             Scheduler scheduler = Scheduler.create(postgres.getDataSource(), customTask)
                 .pollingInterval(Duration.ofMillis(100))
                 .heartbeatInterval(Duration.ofMillis(100))
+                .schedulerName(new SchedulerName.Fixed("test"))
                 .statsRegistry(registry)
                 .build();
             stopScheduler.register(scheduler);

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/ExecutorPoolTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/ExecutorPoolTest.java
@@ -3,6 +3,7 @@ package com.github.kagkarlsson.scheduler.functional;
 import co.unruly.matchers.TimeMatchers;
 import com.github.kagkarlsson.scheduler.EmbeddedPostgresqlExtension;
 import com.github.kagkarlsson.scheduler.Scheduler;
+import com.github.kagkarlsson.scheduler.SchedulerName;
 import com.github.kagkarlsson.scheduler.StopSchedulerExtension;
 import com.github.kagkarlsson.scheduler.TestTasks;
 import com.github.kagkarlsson.scheduler.helper.TestableRegistry;
@@ -51,14 +52,14 @@ public class ExecutorPoolTest {
     }
 
     @Test
-    @Disabled //FIXLATER: Disabled because of flakiness. Need to investigate and re-enable 
+    @Disabled //FIXLATER: Disabled because of flakiness. Need to investigate and re-enable
     public void test_execute_until_none_left_high_volume() {
         testExecuteUntilNoneLeft(12, 4, 200);
     }
 
 
     private void testExecuteUntilNoneLeft(int pollingLimit, int threads, int executionsToRun) {
-        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(20), () -> {
 
             Instant now = Instant.now();
             OneTimeTask<Void> task = TestTasks.oneTime("onetime-a", Void.class, TestTasks.DO_NOTHING);
@@ -69,6 +70,7 @@ public class ExecutorPoolTest {
                 .pollingLimit(pollingLimit)
                 .threads(threads)
                 .pollingInterval(Duration.ofMinutes(1))
+                .schedulerName(new SchedulerName.Fixed("test"))
                 .statsRegistry(registry)
                 .build();
             stopScheduler.register(scheduler);

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/ExecutorPoolTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/ExecutorPoolTest.java
@@ -59,7 +59,7 @@ public class ExecutorPoolTest {
 
 
     private void testExecuteUntilNoneLeft(int pollingLimit, int threads, int executionsToRun) {
-        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(20), () -> {
+        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
 
             Instant now = Instant.now();
             OneTimeTask<Void> task = TestTasks.oneTime("onetime-a", Void.class, TestTasks.DO_NOTHING);

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/ImmediateExecutionTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/ImmediateExecutionTest.java
@@ -41,7 +41,7 @@ public class ImmediateExecutionTest {
 
     @Test
     public void test_immediate_execution() {
-        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(20), () -> {
+        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
 
             Instant now = Instant.now();
             OneTimeTask<Void> task = TestTasks.oneTime("onetime-a", Void.class, TestTasks.DO_NOTHING);

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/ImmediateExecutionTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/ImmediateExecutionTest.java
@@ -4,6 +4,7 @@ import co.unruly.matchers.TimeMatchers;
 import com.github.kagkarlsson.scheduler.DbUtils;
 import com.github.kagkarlsson.scheduler.EmbeddedPostgresqlExtension;
 import com.github.kagkarlsson.scheduler.Scheduler;
+import com.github.kagkarlsson.scheduler.SchedulerName;
 import com.github.kagkarlsson.scheduler.StopSchedulerExtension;
 import com.github.kagkarlsson.scheduler.TestTasks;
 import com.github.kagkarlsson.scheduler.helper.TestableRegistry;
@@ -40,7 +41,7 @@ public class ImmediateExecutionTest {
 
     @Test
     public void test_immediate_execution() {
-        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(20), () -> {
 
             Instant now = Instant.now();
             OneTimeTask<Void> task = TestTasks.oneTime("onetime-a", Void.class, TestTasks.DO_NOTHING);
@@ -52,6 +53,7 @@ public class ImmediateExecutionTest {
             Scheduler scheduler = Scheduler.create(postgres.getDataSource(), task)
                 .pollingInterval(Duration.ofMinutes(1))
                 .enableImmediateExecution()
+                .schedulerName(new SchedulerName.Fixed("test"))
                 .statsRegistry(registry)
                 .build();
             stopScheduler.register(scheduler);

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<developers>
 		<developer>
 			<name>Gustav Karlsson</name>
-			<email>gustav80@gmail.com</email>
+			<email>kagkarlsson@gmail.com</email>
 		</developer>
 	</developers>
 


### PR DESCRIPTION
db-scheduler was relying on autoCommit being enabled on the connections from the underlying `DataSource` as described in #97 . Now `commit` is called explicitly when `autoCommit=false`