### PR TITLE
Spring Boot: Adjust defaults to align with main library

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Configuration is mainly done via `application.properties`. Configuration of sche
 
 db-scheduler.enabled=true
 db-scheduler.heartbeat-interval=5m
-db-scheduler.polling-interval=30s
+db-scheduler.polling-interval=10s
 db-scheduler.polling-limit=
 db-scheduler.table-name=scheduled_tasks
 db-scheduler.immediate-execution-enabled=false

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
@@ -16,6 +16,7 @@
 package com.github.kagkarlsson.scheduler.boot.config;
 
 import com.github.kagkarlsson.scheduler.JdbcTaskRepository;
+import com.github.kagkarlsson.scheduler.SchedulerBuilder;
 import java.time.Duration;
 import java.util.Optional;
 import javax.validation.constraints.NotNull;
@@ -43,7 +44,7 @@ public class DbSchedulerProperties {
      */
     @DurationUnit(MINUTES)
     @NotNull
-    private Duration heartbeatInterval = Duration.ofMinutes(5);
+    private Duration heartbeatInterval = SchedulerBuilder.DEFAULT_HEARTBEAT_INTERVAL;
 
     /**
      * <p>Name of this scheduler-instance. The name is stored in the database when an execution is
@@ -75,7 +76,7 @@ public class DbSchedulerProperties {
      */
     @DurationUnit(SECONDS)
     @NotNull
-    private Duration pollingInterval = Duration.ofSeconds(30);
+    private Duration pollingInterval = SchedulerBuilder.DEFAULT_POLLING_INTERVAL;
 
     /**
      * <p>Maximum number of executions to fetch on a check for due executions.
@@ -93,7 +94,7 @@ public class DbSchedulerProperties {
      */
     @DurationUnit(HOURS)
     @NotNull
-    private Duration deleteUnresolvedAfter = Duration.ofDays(14);
+    private Duration deleteUnresolvedAfter = SchedulerBuilder.DEFAULT_DELETION_OF_UNRESOLVED_TASKS_DURATION;
 
     public boolean isEnabled() {
         return enabled;

--- a/db-scheduler-boot-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
+++ b/db-scheduler-boot-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
@@ -1,11 +1,15 @@
 package com.github.kagkarlsson.scheduler.boot.autoconfigure;
 
+import static com.github.kagkarlsson.scheduler.SchedulerBuilder.DEFAULT_DELETION_OF_UNRESOLVED_TASKS_DURATION;
+import static com.github.kagkarlsson.scheduler.SchedulerBuilder.DEFAULT_HEARTBEAT_INTERVAL;
+import static com.github.kagkarlsson.scheduler.SchedulerBuilder.DEFAULT_POLLING_INTERVAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import com.github.kagkarlsson.scheduler.Scheduler;
 import com.github.kagkarlsson.scheduler.boot.actuator.DbSchedulerHealthIndicator;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerCustomizer;
+import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerProperties;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerStarter;
 import com.github.kagkarlsson.scheduler.boot.config.startup.AbstractSchedulerStarter;
 import com.github.kagkarlsson.scheduler.boot.config.startup.ContextReadyStart;
@@ -62,6 +66,19 @@ public class DbSchedulerAutoConfigurationTest {
             ctx.getBean(Scheduler.class).getScheduledExecutions(execution -> {
                 fail("No scheduled executions should be present", execution);
             });
+        });
+    }
+
+    @Test
+    public void it_should_use_the_default_values_from_library() {
+        ctxRunner.run((AssertableApplicationContext ctx) -> {
+            assertThat(ctx).hasSingleBean(DataSource.class);
+            assertThat(ctx).hasSingleBean(Scheduler.class);
+
+            DbSchedulerProperties props = ctx.getBean(DbSchedulerProperties.class);
+            assertThat(props.getPollingInterval()).isEqualTo(DEFAULT_POLLING_INTERVAL);
+            assertThat(props.getHeartbeatInterval()).isEqualTo(DEFAULT_HEARTBEAT_INTERVAL);
+            assertThat(props.getDeleteUnresolvedAfter()).isEqualTo(DEFAULT_DELETION_OF_UNRESOLVED_TASKS_DURATION);
         });
     }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
@@ -38,6 +38,10 @@ public class SchedulerBuilder {
     private static final Logger LOG = LoggerFactory.getLogger(SchedulerBuilder.class);
     private static final int POLLING_CONCURRENCY_MULTIPLIER = 3;
 
+    public static final Duration DEFAULT_POLLING_INTERVAL = Duration.ofSeconds(10);
+    public static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMinutes(5);
+    public static final Duration DEFAULT_DELETION_OF_UNRESOLVED_TASKS_DURATION = Duration.ofDays(14);
+
     protected Clock clock = new SystemClock(); // if this is set, waiter-clocks must be updated
 
     protected final DataSource dataSource;
@@ -45,16 +49,16 @@ public class SchedulerBuilder {
     protected int executorThreads = 10;
     protected final List<Task<?>> knownTasks = new ArrayList<>();
     protected final List<OnStartup> startTasks = new ArrayList<>();
-    protected Waiter waiter = new Waiter(Duration.ofSeconds(10), clock);
+    protected Waiter waiter = new Waiter(DEFAULT_POLLING_INTERVAL, clock);
     protected int pollingLimit;
     protected boolean useDefaultPollingLimit;
     protected StatsRegistry statsRegistry = StatsRegistry.NOOP;
-    protected Duration heartbeatInterval = Duration.ofMinutes(5);
+    protected Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
     protected Serializer serializer = Serializer.DEFAULT_JAVA_SERIALIZER;
     protected String tableName = JdbcTaskRepository.DEFAULT_TABLE_NAME;
     protected boolean enableImmediateExecution = false;
     protected ExecutorService executorService;
-    protected Duration deleteUnresolvedAfter = Duration.ofDays(14);
+    protected Duration deleteUnresolvedAfter = DEFAULT_DELETION_OF_UNRESOLVED_TASKS_DURATION;
     protected JdbcCustomization jdbcCustomization = null;
 
     public SchedulerBuilder(DataSource dataSource, List<Task<?>> knownTasks) {

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<dependency-plugin.failOnWarning>true</dependency-plugin.failOnWarning>
 
 		<!-- Dependency versions -->
-		<spring-boot.version>2.2.6.RELEASE</spring-boot.version>
+		<spring-boot.version>2.3.3.RELEASE</spring-boot.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
Added public constants to `SchedulerBuilder`. When utilizing those constants the defaults in the starter will always be in sync the db-scheduler library. I've also bumped of Spring Boot to verify that we're good with the latest version.