### PR TITLE
Update existing execution for recurring task if schedule changes to more frequent

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,10 +259,9 @@ The time chosen will be the nearest time according to the `Schedule`, but still 
 
 To create the initial execution for a `RecurringTask`, the scheduler has a method `startTasks(...)` that takes a list of tasks
 that should be "started" if they do not already have an existing execution. The initial execution-time is determined by the `Schedule`.
-If the task already has a future execution, but an updated `Schedule` now indicates that the next execution-time is before
-the existing one, the existing execution will be rescheduled to the new execution-time.
-If the next execution-time is after the existing one, it will not be rescheduled. Any changes to the `Schedule`
-will then have effect only after the existing execution has run.
+If the task already has a future execution (i.e. has been started at least once before), but an updated `Schedule` now indicates another execution-time,
+the existing execution will be rescheduled to the new execution-time (with the exception of _non-deterministic_ schedules
+such as `FixedDelay` where new execution-time is further into the future).
 
 ### One-time tasks
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.kagkarlsson/db-scheduler/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.kagkarlsson/db-scheduler)
 [![License](http://img.shields.io/:license-apache-brightgreen.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 
-Task-scheduler for Java that was inspired by the need for a clustered `java.util.concurrent.ScheduledExecutorService` simpler than Quartz. 
+Task-scheduler for Java that was inspired by the need for a clustered `java.util.concurrent.ScheduledExecutorService` simpler than Quartz.
 
-As such, also appreciated by users ([link](https://github.com/kagkarlsson/db-scheduler/issues/115#issuecomment-649601944)): 
+As such, also appreciated by users ([link](https://github.com/kagkarlsson/db-scheduler/issues/115#issuecomment-649601944)):
 
 > Your lib rocks! I'm so glad I got rid of Quartz and replaced it by yours which is way easier to handle!
 >
-> [cbarbosa2](https://github.com/cbarbosa2) 
+> [cbarbosa2](https://github.com/cbarbosa2)
 
 See also [why not Quartz?](#why-db-scheduler-when-there-is-quartz)
 
@@ -238,6 +238,9 @@ db-scheduler.threads=10
 db-scheduler.delay-startup-until-context-ready=false
 ```
 
+## Interacting with scheduled executions using the SchedulerClient
+
+TODO
 
 ## How it works
 
@@ -250,9 +253,16 @@ Optimistic locking is used to guarantee that a one and only one scheduler-instan
 
 The term _recurring task_ is used for tasks that should be run regularly, according to some schedule (see ``Tasks.recurring(..)``).
 
-When the execution of a recurring task has finished, a `Schedule` is consulted to determine what the next time for execution should be, and a future task-execution is created for that time (i.e. it is _rescheduled_). The time chosen will be the nearest time according to the `Schedule`, but still in the future.
+When the execution of a recurring task has finished, a `Schedule` is consulted to determine what the next time for
+execution should be, and a future task-execution is created for that time (i.e. it is _rescheduled_).
+The time chosen will be the nearest time according to the `Schedule`, but still in the future.
 
-To create the initial execution for a `RecurringTask`, the scheduler has a method  `startTasks(...)` that takes a list of tasks that should be "started" if they do not already have a future execution.
+To create the initial execution for a `RecurringTask`, the scheduler has a method `startTasks(...)` that takes a list of tasks
+that should be "started" if they do not already have an existing execution. The initial execution-time is determined by the `Schedule`.
+If the task already has a future execution, but an updated `Schedule` now indicates that the next execution-time is before
+the existing one, the existing execution will be rescheduled to the new execution-time.
+If the next execution-time is after the existing one, it will not be rescheduled. Any changes to the `Schedule`
+will then have effect only after the existing execution has run.
 
 ### One-time tasks
 
@@ -288,7 +298,7 @@ When a dead execution is found, the `Task`is consulted to see what should be don
 ## Versions / upgrading
 
 ### Version 7.2
-* PR [#110](https://github.com/kagkarlsson/db-scheduler/pull/110) adds micrometer metrics support. Activated by setting `.statsRegistry(new MicrometerStatsRegistry(...))` on the builder. If you are using the Spring boot starter, the micrometer metrics will be added if you have micrometer on the classpath. 
+* PR [#110](https://github.com/kagkarlsson/db-scheduler/pull/110) adds micrometer metrics support. Activated by setting `.statsRegistry(new MicrometerStatsRegistry(...))` on the builder. If you are using the Spring boot starter, the micrometer metrics will be added if you have micrometer on the classpath.
 Contributions by [evenh](https://github.com/evenh).
 
 ### Version 7.1

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTask.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTask.java
@@ -29,14 +29,14 @@ public abstract class RecurringTask<T> extends Task<T> implements OnStartup {
     private ScheduleOnStartup<T> scheduleOnStartup;
 
     public RecurringTask(String name, Schedule schedule, Class<T> dataClass) {
-        this(name, schedule, dataClass, new ScheduleOnStartup<>(INSTANCE, null, schedule::getInitialExecutionTime), new FailureHandler.OnFailureReschedule<T>(schedule), new ReviveDeadExecution<>());
+        this(name, schedule, dataClass, new ScheduleRecurringOnStartup<>(INSTANCE, null, schedule), new FailureHandler.OnFailureReschedule<T>(schedule), new ReviveDeadExecution<>());
     }
 
     public RecurringTask(String name, Schedule schedule, Class<T> dataClass, T initialData) {
-        this(name, schedule, dataClass, new ScheduleOnStartup<>(INSTANCE, initialData, schedule::getInitialExecutionTime), new FailureHandler.OnFailureReschedule<T>(schedule), new ReviveDeadExecution<>());
+        this(name, schedule, dataClass, new ScheduleRecurringOnStartup<>(INSTANCE, initialData, schedule), new FailureHandler.OnFailureReschedule<T>(schedule), new ReviveDeadExecution<>());
     }
 
-    public RecurringTask(String name, Schedule schedule, Class<T> dataClass, ScheduleOnStartup<T> scheduleOnStartup, FailureHandler<T> failureHandler, DeadExecutionHandler<T> deadExecutionHandler) {
+    public RecurringTask(String name, Schedule schedule, Class<T> dataClass, ScheduleRecurringOnStartup<T> scheduleOnStartup, FailureHandler<T> failureHandler, DeadExecutionHandler<T> deadExecutionHandler) {
         super(name, dataClass, failureHandler, deadExecutionHandler);
         onComplete = new OnCompleteReschedule<>(schedule);
         this.scheduleOnStartup = scheduleOnStartup;
@@ -45,7 +45,7 @@ public abstract class RecurringTask<T> extends Task<T> implements OnStartup {
     @Override
     public void onStartup(Scheduler scheduler, Clock clock) {
         if (scheduleOnStartup != null) {
-                scheduleOnStartup.apply(scheduler, clock, this);
+            scheduleOnStartup.apply(scheduler, clock, this);
         }
     }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleOnStartup.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleOnStartup.java
@@ -19,34 +19,6 @@ import com.github.kagkarlsson.scheduler.Clock;
 import com.github.kagkarlsson.scheduler.Scheduler;
 import com.github.kagkarlsson.scheduler.task.Task;
 
-import java.time.Instant;
-import java.util.function.Function;
-
-class ScheduleOnStartup<T> {
-    String instance;
-    T data;
-    Function<Instant, Instant> firstExecutionTime;
-
-    ScheduleOnStartup(String instance) {
-        this(instance, null);
-    }
-
-    ScheduleOnStartup(String instance, T data) {
-        this(instance, data, Function.identity());
-    }
-
-    ScheduleOnStartup(String instance, T data, Function<Instant, Instant> firstExecutionTime) {
-        this.firstExecutionTime = firstExecutionTime;
-        this.instance = instance;
-        this.data = data;
-    }
-
-    public void apply(Scheduler scheduler, Clock clock, Task<T> task) {
-        if (data == null) {
-            scheduler.schedule(task.instance(instance), firstExecutionTime.apply(clock.now()));
-        } else {
-            scheduler.schedule(task.instance(instance, data), firstExecutionTime.apply(clock.now()));
-        }
-    }
-
+public interface ScheduleOnStartup<T> {
+    void apply(Scheduler scheduler, Clock clock, Task<T> task);
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleOnceOnStartup.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleOnceOnStartup.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) Gustav Karlsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.kagkarlsson.scheduler.task.helper;
+
+import com.github.kagkarlsson.scheduler.Clock;
+import com.github.kagkarlsson.scheduler.Scheduler;
+import com.github.kagkarlsson.scheduler.task.Task;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+
+import java.time.Instant;
+import java.util.function.Function;
+
+class ScheduleOnceOnStartup<T> implements ScheduleOnStartup<T> {
+    private String instance;
+    private T data;
+    private Function<Instant, Instant> firstExecutionTime;
+
+    ScheduleOnceOnStartup(String instance) {
+        this(instance, null);
+    }
+
+    ScheduleOnceOnStartup(String instance, T data) {
+        this(instance, data, Function.identity());
+    }
+
+    ScheduleOnceOnStartup(String instance, T data, Function<Instant, Instant> firstExecutionTime) {
+        this.firstExecutionTime = firstExecutionTime;
+        this.instance = instance;
+        this.data = data;
+    }
+
+    public void apply(Scheduler scheduler, Clock clock, Task<T> task) {
+        scheduler.schedule(getSchedulableInstance(task), firstExecutionTime.apply(clock.now()));
+    }
+
+    private TaskInstance<T> getSchedulableInstance(Task<T> task) {
+        if (data == null) {
+            return task.instance(instance);
+        } else {
+            return task.instance(instance, data);
+        }
+    }
+}

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleRecurringOnStartup.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleRecurringOnStartup.java
@@ -84,7 +84,9 @@ class ScheduleRecurringOnStartup<T> implements ScheduleOnStartup<T> {
 
         } else if (preexistingExecutionTime.isAfter(nextExecutionTimeRelativeToNow)) {
             // Schedules: FixedDelay
-            // the schedule has likely been updated, rescheduling to next execution-time according to schedule
+            // The schedule has likely been updated, rescheduling to next execution-time according to schedule
+            // We cannot reschedule if new execution-time is further into the future than existing since that may cause
+            // us to never run executions if scheduler restarts is more frequent than the fixed-delay duration
 
             LOG.info("Rescheduling task-instance '{}' because non-deterministic Schedule seem to have been updated to " +
                     "a more frequent one. Previous execution-time: {}, new execution-time: {}",

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleRecurringOnStartup.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleRecurringOnStartup.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) Gustav Karlsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.kagkarlsson.scheduler.task.helper;
+
+import com.github.kagkarlsson.scheduler.Clock;
+import com.github.kagkarlsson.scheduler.ScheduledExecution;
+import com.github.kagkarlsson.scheduler.Scheduler;
+import com.github.kagkarlsson.scheduler.task.ExecutionComplete;
+import com.github.kagkarlsson.scheduler.task.Task;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import com.github.kagkarlsson.scheduler.task.schedule.Schedule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.Optional;
+
+class ScheduleRecurringOnStartup<T> implements ScheduleOnStartup<T> {
+    private static final Logger LOG = LoggerFactory.getLogger(ScheduleRecurringOnStartup.class);
+    private Schedule schedule;
+    private String instance;
+    private T data;
+
+    ScheduleRecurringOnStartup(String instance, T data, Schedule schedule) {
+        this.instance = instance;
+        this.data = data;
+        this.schedule = schedule;
+    }
+
+    @Override
+    public void apply(Scheduler scheduler, Clock clock, Task<T> task) {
+        final TaskInstance<T> instanceWithoutData = task.instance(this.instance);
+        final Optional<ScheduledExecution<Object>> preexistingExecution = scheduler.getScheduledExecution(instanceWithoutData);
+
+        if (preexistingExecution.isPresent()) {
+            final Instant nextExecutionTime = schedule.getNextExecutionTime(ExecutionComplete.simulatedSuccess(clock.now()));
+
+            if (preexistingExecution.get().getExecutionTime().isAfter(nextExecutionTime)) {
+                // the schedule has likely been updated, rescheduling to next execution-time according to schedule
+
+                LOG.info("Rescheduling task-instance '{}' because Schedule seem to have been updated. " +
+                        "Previous execution-time: {}, new execution-time: {}",
+                    instanceWithoutData, preexistingExecution.get().getExecutionTime(), nextExecutionTime);
+                // Intentionally leaving out data here, since we do not want to update existing data
+                scheduler.reschedule(instanceWithoutData, nextExecutionTime);
+
+            } else {
+                LOG.debug("Task-instance '{}' is already scheduled, skipping schedule-on-startup.", instanceWithoutData);
+            }
+
+        } else {
+            final Instant initialExecutionTime = schedule.getInitialExecutionTime(clock.now());
+            LOG.info("Creating initial execution for task-instance '{}'. Next execution-time: {}", instanceWithoutData, initialExecutionTime);
+            scheduler.schedule(getSchedulableInstance(task), initialExecutionTime);
+        }
+    }
+
+    private TaskInstance<T> getSchedulableInstance(Task<T> task) {
+        if (data == null) {
+            return task.instance(instance);
+        } else {
+            return task.instance(instance, data);
+        }
+    }
+
+}

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/Tasks.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/Tasks.java
@@ -21,7 +21,6 @@ import com.github.kagkarlsson.scheduler.task.schedule.Schedule;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 public class Tasks {
     public static final Duration DEFAULT_RETRY_INTERVAL = Duration.ofMinutes(5);
@@ -53,7 +52,7 @@ public class Tasks {
         private Class<T> dataClass;
         private FailureHandler<T> onFailure;
         private DeadExecutionHandler<T> onDeadExecution;
-        private ScheduleOnStartup<T> scheduleOnStartup;
+        private ScheduleRecurringOnStartup<T> scheduleOnStartup;
 
         public RecurringTaskBuilder(String name, Schedule schedule, Class<T> dataClass) {
             this.name = name;
@@ -61,7 +60,7 @@ public class Tasks {
             this.dataClass = dataClass;
             this.onFailure = new FailureHandler.OnFailureReschedule<>(schedule);
             this.onDeadExecution = new DeadExecutionHandler.ReviveDeadExecution<>();
-            this.scheduleOnStartup = new ScheduleOnStartup<>(RecurringTask.INSTANCE, null, schedule::getInitialExecutionTime);
+            this.scheduleOnStartup = new ScheduleRecurringOnStartup<>(RecurringTask.INSTANCE, null, schedule);
         }
 
         public RecurringTaskBuilder<T> onFailureReschedule() {
@@ -85,7 +84,7 @@ public class Tasks {
         }
 
         public RecurringTaskBuilder<T> initialData(T initialData) {
-            this.scheduleOnStartup = new ScheduleOnStartup<>(RecurringTask.INSTANCE, initialData, schedule::getInitialExecutionTime);
+            this.scheduleOnStartup = new ScheduleRecurringOnStartup<>(RecurringTask.INSTANCE, initialData, schedule);
             return this;
         }
 
@@ -178,7 +177,7 @@ public class Tasks {
         }
 
         public TaskBuilder<T> scheduleOnStartup(String instance, T initialData, Function<Instant,Instant> firstExecutionTime) {
-            this.onStartup = new ScheduleOnStartup<T>(instance, initialData, firstExecutionTime);
+            this.onStartup = new ScheduleOnceOnStartup<T>(instance, initialData, firstExecutionTime);
             return this;
         }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/CronSchedule.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/CronSchedule.java
@@ -66,4 +66,9 @@ public class CronSchedule implements Schedule {
         }
         return nextTime.get().toInstant();
     }
+
+    @Override
+    public boolean isDeterministic() {
+        return true;
+    }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/Daily.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/Daily.java
@@ -68,6 +68,11 @@ public class Daily implements Schedule {
     }
 
     @Override
+    public boolean isDeterministic() {
+        return true;
+    }
+
+    @Override
     public final boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Daily)) return false;

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/FixedDelay.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/FixedDelay.java
@@ -65,6 +65,12 @@ public class FixedDelay implements Schedule {
     }
 
     @Override
+    public boolean isDeterministic() {
+        // Only deterministic if relative to a certain instant
+        return false;
+    }
+
+    @Override
     public final boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof FixedDelay)) return false;

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/Schedule.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/Schedule.java
@@ -30,4 +30,6 @@ public interface Schedule {
         return getNextExecutionTime(ExecutionComplete.simulatedSuccess(now));
     }
 
+    boolean isDeterministic();
+
 }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/RecurringTaskTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/RecurringTaskTest.java
@@ -1,6 +1,5 @@
 package com.github.kagkarlsson.scheduler.functional;
 
-import com.github.kagkarlsson.scheduler.DbUtils;
 import com.github.kagkarlsson.scheduler.EmbeddedPostgresqlExtension;
 import com.github.kagkarlsson.scheduler.ScheduledExecution;
 import com.github.kagkarlsson.scheduler.TestTasks;
@@ -20,22 +19,24 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import static co.unruly.matchers.OptionalMatchers.contains;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RecurringTaskTest {
 
     public static final ZoneId ZONE = ZoneId.systemDefault();
     private static final LocalDate DATE = LocalDate.of(2018, 3, 1);
     private static final LocalTime TIME = LocalTime.of(8, 0);
+    public static final String RECURRING_A = "recurring-a";
     private SettableClock clock;
 
     @RegisterExtension
     public EmbeddedPostgresqlExtension postgres = new EmbeddedPostgresqlExtension();
-
 
     @BeforeEach
     public void setUp() {
@@ -46,37 +47,126 @@ public class RecurringTaskTest {
     @Test
     public void should_have_starttime_according_to_schedule_by_default() {
 
-        RecurringTask<Void> recurringTask = Tasks.recurring("recurring-a", Schedules.daily(LocalTime.of(23, 59)))
-                .execute(TestTasks.DO_NOTHING);
+        RecurringTask<Void> recurringTask = Tasks.recurring(RECURRING_A, Schedules.daily(LocalTime.of(23, 59)))
+            .execute(TestTasks.DO_NOTHING);
 
-        ManualScheduler scheduler = TestHelper.createManualScheduler(postgres.getDataSource())
-                .clock(clock)
-                .startTasks(Arrays.asList(recurringTask))
-                .build();
-
+        ManualScheduler scheduler = manualSchedulerFor(singletonList(recurringTask));
         scheduler.start();
 
-        Optional<ScheduledExecution<Object>> firstExecution = scheduler.getScheduledExecution(TaskInstanceId.of("recurring-a", RecurringTask.INSTANCE));
-        assertThat(firstExecution.map(ScheduledExecution::getExecutionTime),
-                contains(ZonedDateTime.of(DATE, LocalTime.of(23, 59), ZONE).toInstant()));
+        assertScheduled(scheduler, RECURRING_A, LocalTime.of(23, 59));
     }
 
     @Test
     public void should_have_starttime_now_if_overridden_by_schedule() {
 
-        RecurringTask<Void> recurringTask = Tasks.recurring("recurring-a", Schedules.fixedDelay(Duration.ofHours(1)))
-                .execute(TestTasks.DO_NOTHING);
+        RecurringTask<Void> recurringTask = Tasks.recurring(RECURRING_A, Schedules.fixedDelay(Duration.ofHours(1)))
+            .execute(TestTasks.DO_NOTHING);
 
-        ManualScheduler scheduler = TestHelper.createManualScheduler(postgres.getDataSource())
-                .clock(clock)
-                .startTasks(Arrays.asList(recurringTask))
-                .build();
+        ManualScheduler scheduler = manualSchedulerFor(singletonList(recurringTask));
         scheduler.start();
 
-        Optional<ScheduledExecution<Object>> firstExecution = scheduler.getScheduledExecution(TaskInstanceId.of("recurring-a", RecurringTask.INSTANCE));
-
-        assertThat(firstExecution.map(ScheduledExecution::getExecutionTime),
-                contains(ZonedDateTime.of(DATE, TIME, ZONE).toInstant()));
+        assertScheduled(scheduler, RECURRING_A, TIME);
     }
+
+    @Test
+    public void should_update_preexisting_exeutions_with_new_schedule_if_new_next_execution_time_before_preexisting() {
+        RecurringTask<Void> recurringTask = Tasks.recurring(RECURRING_A, Schedules.daily(LocalTime.of(23, 59)))
+            .execute(TestTasks.DO_NOTHING);
+
+        ManualScheduler scheduler = manualSchedulerFor(singletonList(recurringTask));
+
+        scheduler.start();
+        assertScheduled(scheduler, RECURRING_A, LocalTime.of(23, 59));
+
+        // Add an additional execution-time to the daily schedule
+        RecurringTask<Void> recurringTaskNewSchedule = Tasks.recurring(RECURRING_A,
+            Schedules.daily(
+                LocalTime.of(12, 0),
+                LocalTime.of(23, 59)))
+            .execute(TestTasks.DO_NOTHING);
+
+        ManualScheduler schedulerUpdatedTask = manualSchedulerFor(singletonList(recurringTaskNewSchedule));
+
+        // Simulate restart with updated schedule for task, execution now already exists
+        schedulerUpdatedTask.start();
+
+        assertScheduled(schedulerUpdatedTask, RECURRING_A, LocalTime.of(12, 0));
+    }
+
+    @Test
+    public void should_not_update_preexisting_exeutions_with_new_schedule_if_new_next_execution_time_after_preexisting() {
+        RecurringTask<Void> recurringTask = Tasks.recurring(RECURRING_A, Schedules.daily(LocalTime.of(12, 0)))
+            .execute(TestTasks.DO_NOTHING);
+
+        ManualScheduler scheduler = manualSchedulerFor(singletonList(recurringTask));
+
+        scheduler.start();
+        assertScheduled(scheduler, RECURRING_A, LocalTime.of(12, 0));
+
+        // Add an additional execution-time to the daily schedule
+        RecurringTask<Void> recurringTaskNewSchedule = Tasks.recurring(RECURRING_A,
+            Schedules.daily(
+                LocalTime.of(12, 0),
+                LocalTime.of(23, 59)))
+            .execute(TestTasks.DO_NOTHING);
+
+        ManualScheduler schedulerUpdatedTask = manualSchedulerFor(singletonList(recurringTaskNewSchedule));
+
+        // Simulate restart with updated schedule for task, execution now already exists
+        schedulerUpdatedTask.start();
+
+        // Should have unchanged execution-time
+        assertScheduled(schedulerUpdatedTask, RECURRING_A, LocalTime.of(12, 0));
+    }
+
+    @Test
+    public void should_not_update_data_of_preexisting_exeutions_even_if_rescheduling_because_of_updated_schedule() {
+        RecurringTask<Integer> recurringTask = Tasks.recurring(RECURRING_A, Schedules.daily(LocalTime.of(23, 59)), Integer.class)
+            .initialData(1)
+            .execute((taskInstance, executionContext) -> {});
+
+        ManualScheduler scheduler = manualSchedulerFor(singletonList(recurringTask));
+
+        scheduler.start();
+        assertScheduled(scheduler, RECURRING_A, LocalTime.of(23, 59), 1);
+
+        // Add an additional execution-time to the daily schedule
+        RecurringTask<Integer> recurringTaskNewSchedule = Tasks.recurring(RECURRING_A,
+            Schedules.daily(
+                LocalTime.of(12, 0),
+                LocalTime.of(23, 59)), Integer.class)
+            .initialData(2)
+            .execute((taskInstance, executionContext) -> {});
+
+        ManualScheduler schedulerUpdatedTask = manualSchedulerFor(singletonList(recurringTaskNewSchedule));
+
+        // Simulate restart with updated schedule for task, execution now already exists
+        schedulerUpdatedTask.start();
+
+        assertScheduled(schedulerUpdatedTask, RECURRING_A, LocalTime.of(12, 0), 1); // unchanged data
+    }
+
+    private void assertScheduled(ManualScheduler scheduler, String taskName, LocalTime expectedExecutionTime) {
+        assertScheduled(scheduler, taskName, expectedExecutionTime, null);
+    }
+
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    private void assertScheduled(ManualScheduler scheduler, String taskName, LocalTime expectedExecutionTime, Object taskData) {
+        Optional<ScheduledExecution<Object>> firstExecution = scheduler.getScheduledExecution(TaskInstanceId.of(taskName, RecurringTask.INSTANCE));
+        assertThat(firstExecution.map(ScheduledExecution::getExecutionTime),
+            contains(ZonedDateTime.of(DATE, expectedExecutionTime, ZONE).toInstant()));
+        if (taskData != null) {
+            assertEquals(taskData, firstExecution.get().getData());
+        }
+    }
+
+    private ManualScheduler manualSchedulerFor(List<RecurringTask<?>> recurringTasks) {
+        return TestHelper.createManualScheduler(postgres.getDataSource())
+            .clock(clock)
+            .startTasks(recurringTasks)
+            .build();
+    }
+
+
 
 }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/RecurringTaskTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/RecurringTaskTest.java
@@ -94,7 +94,7 @@ public class RecurringTaskTest {
     }
 
     @Test
-    public void should_not_update_preexisting_exeutions_with_new_schedule_if_new_next_execution_time_after_preexisting() {
+    public void should_update_preexisting_exeutions_with_new_deterministic_schedule_if_new_next_execution_time_after_preexisting() {
         RecurringTask<Void> recurringTask = Tasks.recurring(RECURRING_A, Schedules.daily(LocalTime.of(12, 0)))
             .execute(TestTasks.DO_NOTHING);
 
@@ -103,11 +103,8 @@ public class RecurringTaskTest {
         scheduler.start();
         assertScheduled(scheduler, RECURRING_A, LocalTime.of(12, 0));
 
-        // Add an additional execution-time to the daily schedule
         RecurringTask<Void> recurringTaskNewSchedule = Tasks.recurring(RECURRING_A,
-            Schedules.daily(
-                LocalTime.of(12, 0),
-                LocalTime.of(23, 59)))
+            Schedules.daily(LocalTime.of(23, 59)))
             .execute(TestTasks.DO_NOTHING);
 
         ManualScheduler schedulerUpdatedTask = manualSchedulerFor(singletonList(recurringTaskNewSchedule));
@@ -116,7 +113,7 @@ public class RecurringTaskTest {
         schedulerUpdatedTask.start();
 
         // Should have unchanged execution-time
-        assertScheduled(schedulerUpdatedTask, RECURRING_A, LocalTime.of(12, 0));
+        assertScheduled(schedulerUpdatedTask, RECURRING_A, LocalTime.of(23, 59));
     }
 
     @Test

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleRecurringOnStartupTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleRecurringOnStartupTest.java
@@ -1,0 +1,86 @@
+package com.github.kagkarlsson.scheduler.task.helper;
+
+import com.github.kagkarlsson.scheduler.ScheduledExecution;
+import com.github.kagkarlsson.scheduler.task.Execution;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import com.github.kagkarlsson.scheduler.task.schedule.Schedule;
+import com.github.kagkarlsson.scheduler.testhelper.SettableClock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static co.unruly.matchers.OptionalMatchers.empty;
+import static com.github.kagkarlsson.scheduler.task.helper.ScheduleRecurringOnStartup.differenceGreaterThan;
+import static com.github.kagkarlsson.scheduler.task.schedule.Schedules.daily;
+import static com.github.kagkarlsson.scheduler.task.schedule.Schedules.fixedDelay;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ScheduleRecurringOnStartupTest {
+
+    private static final ZoneId ZONE = ZoneId.systemDefault();
+    private static final LocalDate DATE = LocalDate.of(2018, 3, 1);
+    private static final LocalTime TIME_INSTANT_A = LocalTime.of(8, 0);
+    private static final Instant UPCOMING_INSTANT_A = ZonedDateTime.of(DATE, TIME_INSTANT_A, ZONE).toInstant();
+    private static final Instant NOW = UPCOMING_INSTANT_A.minus(Duration.ofHours(1));
+
+    private static final String INSTANCE = "instance";
+    private static final TaskInstance<Void> TASK_INSTANCE = new TaskInstance<>("recurring-a", INSTANCE);
+    private SettableClock clock;
+
+    @BeforeEach
+    void setUp() {
+        clock = new SettableClock();
+        clock.set(NOW);
+    }
+
+    @Test
+    void checkForNewExecutionTime_no_new_execution_time_if_execution_imminent() {
+        assertNotUpdatedExecutionTime(scheduled(NOW.plus(Duration.ofSeconds(1))), daily(TIME_INSTANT_A.plusMinutes(1)));
+        assertUpdatedExecutionTime(scheduled(NOW.plus(Duration.ofSeconds(11))), daily(TIME_INSTANT_A.plusMinutes(1)));
+    }
+
+    @Test
+    void checkForNewExecutionTime_updated_if_deterministic_schedule_change() {
+        assertNotUpdatedExecutionTime(scheduled(UPCOMING_INSTANT_A), daily(TIME_INSTANT_A));
+        assertNotUpdatedExecutionTime(scheduled(UPCOMING_INSTANT_A), daily(TIME_INSTANT_A.plus(Duration.ofMillis(20)))); // requires 1s diff between instants
+        assertUpdatedExecutionTime(scheduled(UPCOMING_INSTANT_A), daily(TIME_INSTANT_A.plus(Duration.ofSeconds(20))));
+        assertUpdatedExecutionTime(scheduled(UPCOMING_INSTANT_A), daily(TIME_INSTANT_A.minus(Duration.ofSeconds(20))));
+    }
+
+    @Test
+    void checkForNewExecutionTime_updated_if_non_deterministic_schedule_change_to_sooner() {
+        assertNotUpdatedExecutionTime(scheduled(UPCOMING_INSTANT_A), fixedDelay(Duration.ofDays(1)));
+        assertUpdatedExecutionTime(scheduled(UPCOMING_INSTANT_A), fixedDelay(Duration.ofMinutes(1)));
+    }
+
+    private void assertUpdatedExecutionTime(ScheduledExecution<Object> scheduled, Schedule newSchedule) {
+        final ScheduleRecurringOnStartup<Void> unit = new ScheduleRecurringOnStartup<>(INSTANCE, null, newSchedule);
+        assertThat(unit.checkForNewExecutionTime(clock, TASK_INSTANCE, scheduled), not(empty()));
+    }
+
+    private void assertNotUpdatedExecutionTime(ScheduledExecution<Object> scheduled, Schedule newSchedule) {
+        final ScheduleRecurringOnStartup<Void> unit = new ScheduleRecurringOnStartup<>(INSTANCE, null, newSchedule);
+        assertThat(unit.checkForNewExecutionTime(clock, TASK_INSTANCE, scheduled), empty());
+    }
+
+    @Test
+    void test_differenceGreaterThan() {
+        assertTrue(differenceGreaterThan(clock.now(), clock.now().minusSeconds(10), Duration.ofSeconds(1)));
+        assertTrue(differenceGreaterThan(clock.now(), clock.now().plusSeconds(10), Duration.ofSeconds(1)));
+
+        assertFalse(differenceGreaterThan(clock.now(), clock.now().minusSeconds(10), Duration.ofSeconds(11)));
+        assertFalse(differenceGreaterThan(clock.now(), clock.now().plusSeconds(10), Duration.ofSeconds(11)));
+    }
+
+    private ScheduledExecution<Object> scheduled(Instant executionTime) {
+        return new ScheduledExecution<>(Object.class, new Execution(executionTime, TASK_INSTANCE));
+    }
+}


### PR DESCRIPTION
If a `Schedule` for a `RecurringTask` is updated, update the future execution with the new execution-time to avoid having to wait for the execution to run to have execution-times based on new `Schedule`.

* For _deterministic_  schedule (Cron, Daily), update future execution for all changes
* For _non-deterministic_  schedule (FixedDelay), update future execution only if new execution-time is closer to `now()`

