### PR TITLE
Fix Spring Boot 2.2.0 deprecation (2.4.0 is coming)

### DIFF
--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
@@ -37,7 +37,7 @@ import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
-import org.springframework.boot.actuate.autoconfigure.health.HealthIndicatorAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.actuate.health.HealthIndicator;
@@ -58,7 +58,7 @@ import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy;
 @AutoConfigurationPackage
 @AutoConfigureAfter({
     DataSourceAutoConfiguration.class,
-    HealthIndicatorAutoConfiguration.class,
+    HealthContributorAutoConfiguration.class,
     MetricsAutoConfiguration.class,
     CompositeMeterRegistryAutoConfiguration.class,
 })
@@ -161,6 +161,7 @@ public class DbSchedulerAutoConfiguration {
     @ConditionalOnBean(Scheduler.class)
     @Bean
     public HealthIndicator dbScheduler(Scheduler scheduler) {
+        log.debug("Exposing health indicator for db-scheduler");
         return new DbSchedulerHealthIndicator(scheduler);
     }
 

--- a/db-scheduler-boot-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
+++ b/db-scheduler-boot-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
@@ -28,7 +28,7 @@ import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.actuate.autoconfigure.health.HealthIndicatorAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -109,7 +109,7 @@ public class DbSchedulerAutoConfigurationTest {
     @Test
     public void it_should_autoconfigure_a_health_check() {
         ctxRunner
-            .withConfiguration(AutoConfigurations.of(HealthIndicatorAutoConfiguration.class))
+            .withConfiguration(AutoConfigurations.of(HealthContributorAutoConfiguration.class))
             .run((AssertableApplicationContext ctx) -> {
                 assertThat(ctx).hasSingleBean(DbSchedulerHealthIndicator.class);
             });

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<dependency-plugin.failOnWarning>true</dependency-plugin.failOnWarning>
 
 		<!-- Dependency versions -->
-		<spring-boot.version>2.3.3.RELEASE</spring-boot.version>
+		<spring-boot.version>2.3.4.RELEASE</spring-boot.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
Since we already depend on Spring Boot 2.2+ (and using 2.3.x), I've took the liberty to modifiy the autoconfiguration to not depend on deprecated classes. Spring Boot 2.4 is scheduled for November 2020 and will remove deprecations from 2.2.0 (including `HealthIndicatorAutoConfiguration`).

See https://github.com/spring-projects/spring-boot/issues/22034