### PR TITLE
Don't run AutodetectJdbcCustomization unless needed

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
@@ -167,7 +167,7 @@ public class SchedulerBuilder {
         }
 
         final TaskResolver taskResolver = new TaskResolver(statsRegistry, clock, knownTasks);
-        final JdbcCustomization jdbcCustomization = ofNullable(this.jdbcCustomization).orElse(new AutodetectJdbcCustomization(dataSource));
+        final JdbcCustomization jdbcCustomization = ofNullable(this.jdbcCustomization).orElseGet(() -> new AutodetectJdbcCustomization(dataSource));
         final JdbcTaskRepository taskRepository = new JdbcTaskRepository(dataSource, jdbcCustomization, tableName, taskResolver, schedulerName, serializer);
 
         ExecutorService candidateExecutorService = executorService;


### PR DESCRIPTION
I noticed while debugging something else that the [`AutodetectJdbcCustomization constructor`](https://github.com/kagkarlsson/db-scheduler/blob/89626e6d1942d5e8ba6df4cdb758c72c50f0aa27/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java#L34) is initialized by the builder every time, even if `JdbcCustomization` is already set. Since the constructor performs interactions with the DB it is better to put this in `orElseGet()` to prevent it unless needed.