### PR TITLE
Configurable commit behavior for when autocommit=false

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ The scheduler is created using the `Scheduler.create(...)` builder. The builder 
 | `shutdownMaxWait(Duration)`  | `30min`  | How long the scheduler will wait before interrupting executor-service threads. If you find yourself using this, consider if it is possible to instead regularly check `executionContext.getSchedulerState().isShuttingDown()` in the ExecutionHandler and abort long-running task. |
 | `.deleteUnresolvedAfter(Duration)`  | `14d`  | The time after which executions with unknown tasks are automatically deleted. These can typically be old recurring tasks that are not in use anymore. This is non-zero to prevent accidental removal of tasks through a configuration error (missing known-tasks) and problems during rolling upgrades. |
 | `.jdbcCustomization(JdbcCustomization)`  | auto  | db-scheduler tries to auto-detect the database used to see if any jdbc-interactions need to be customized. This method is an escape-hatch to allow for setting `JdbcCustomizations` explicitly. |
+| `.commitWhenAutocommitDisabled(boolean)`  | false  | By default no commit is issued on DataSource Connections. If auto-commit is disabled, it is assumed that transactions are handled by an external transaction-manager. Set this property to `true` to override this behavior and have the Scheduler always issue commits. |
 
 
 

--- a/db-scheduler/pom.xml
+++ b/db-scheduler/pom.xml
@@ -19,7 +19,7 @@
         <hsqldb.version>2.3.3</hsqldb.version>
         <java8-matchers.version>1.6</java8-matchers.version>
         <equals-verifier.version>3.1.12</equals-verifier.version>
-        <micro-jdbc.version>0.2</micro-jdbc.version>
+        <micro-jdbc.version>0.3</micro-jdbc.version>
         <otj-pg-embedded.version>0.11.4</otj-pg-embedded.version>
         <postgresql.version>9.4.1207</postgresql.version>
         <slf4j.version>1.7.7</slf4j.version>

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/JdbcTaskRepository.java
@@ -57,19 +57,19 @@ public class JdbcTaskRepository implements TaskRepository {
     private final String tableName;
     private final JdbcCustomization jdbcCustomization;
 
-    public JdbcTaskRepository(DataSource dataSource, String tableName, TaskResolver taskResolver, SchedulerName schedulerSchedulerName) {
-        this(dataSource, new AutodetectJdbcCustomization(dataSource), tableName, taskResolver, schedulerSchedulerName, Serializer.DEFAULT_JAVA_SERIALIZER);
+    public JdbcTaskRepository(DataSource dataSource, boolean commitWhenAutocommitDisabled, String tableName, TaskResolver taskResolver, SchedulerName schedulerSchedulerName) {
+        this(dataSource, commitWhenAutocommitDisabled, new AutodetectJdbcCustomization(dataSource), tableName, taskResolver, schedulerSchedulerName, Serializer.DEFAULT_JAVA_SERIALIZER);
     }
 
-    public JdbcTaskRepository(DataSource dataSource, JdbcCustomization jdbcCustomization, String tableName, TaskResolver taskResolver, SchedulerName schedulerSchedulerName) {
-        this(dataSource, jdbcCustomization, tableName, taskResolver, schedulerSchedulerName, Serializer.DEFAULT_JAVA_SERIALIZER);
+    public JdbcTaskRepository(DataSource dataSource, boolean commitWhenAutocommitDisabled, JdbcCustomization jdbcCustomization, String tableName, TaskResolver taskResolver, SchedulerName schedulerSchedulerName) {
+        this(dataSource, commitWhenAutocommitDisabled, jdbcCustomization, tableName, taskResolver, schedulerSchedulerName, Serializer.DEFAULT_JAVA_SERIALIZER);
     }
 
-    public JdbcTaskRepository(DataSource dataSource, JdbcCustomization jdbcCustomization, String tableName, TaskResolver taskResolver, SchedulerName schedulerSchedulerName, Serializer serializer) {
+    public JdbcTaskRepository(DataSource dataSource, boolean commitWhenAutocommitDisabled, JdbcCustomization jdbcCustomization, String tableName, TaskResolver taskResolver, SchedulerName schedulerSchedulerName, Serializer serializer) {
         this.tableName = tableName;
         this.taskResolver = taskResolver;
         this.schedulerSchedulerName = schedulerSchedulerName;
-        this.jdbcRunner = new JdbcRunner(dataSource);
+        this.jdbcRunner = new JdbcRunner(dataSource, commitWhenAutocommitDisabled);
         this.serializer = serializer;
         this.jdbcCustomization = jdbcCustomization;
     }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
@@ -61,7 +61,8 @@ public class SchedulerBuilder {
     protected ExecutorService executorService;
     protected Duration deleteUnresolvedAfter = DEFAULT_DELETION_OF_UNRESOLVED_TASKS_DURATION;
     protected JdbcCustomization jdbcCustomization = null;
-    private Duration shutdownMaxWait = SHUTDOWN_MAX_WAIT;
+    protected Duration shutdownMaxWait = SHUTDOWN_MAX_WAIT;
+    protected boolean commitWhenAutocommitDisabled = false;
 
     public SchedulerBuilder(DataSource dataSource, List<Task<?>> knownTasks) {
         this.dataSource = dataSource;
@@ -157,6 +158,11 @@ public class SchedulerBuilder {
         return this;
     }
 
+    public SchedulerBuilder commitWhenAutocommitDisabled(boolean commitWhenAutocommitDisabled) {
+        this.commitWhenAutocommitDisabled = commitWhenAutocommitDisabled;
+        return this;
+    }
+
     public Scheduler build() {
         if (pollingLimit < executorThreads) {
             LOG.warn("Polling-limit is less than number of threads. Should be equal or higher.");
@@ -168,7 +174,8 @@ public class SchedulerBuilder {
 
         final TaskResolver taskResolver = new TaskResolver(statsRegistry, clock, knownTasks);
         final JdbcCustomization jdbcCustomization = ofNullable(this.jdbcCustomization).orElse(new AutodetectJdbcCustomization(dataSource));
-        final JdbcTaskRepository taskRepository = new JdbcTaskRepository(dataSource, jdbcCustomization, tableName, taskResolver, schedulerName, serializer);
+        final JdbcTaskRepository schedulerTaskRepository = new JdbcTaskRepository(dataSource, true, jdbcCustomization, tableName, taskResolver, schedulerName, serializer);
+        final JdbcTaskRepository clientTaskRepository = new JdbcTaskRepository(dataSource, commitWhenAutocommitDisabled, jdbcCustomization, tableName, taskResolver, schedulerName, serializer);
 
         ExecutorService candidateExecutorService = executorService;
         if (candidateExecutorService == null) {
@@ -182,7 +189,7 @@ public class SchedulerBuilder {
             enableImmediateExecution,
             tableName,
             schedulerName.getName());
-        return new Scheduler(clock, taskRepository, taskResolver, executorThreads, candidateExecutorService,
+        return new Scheduler(clock, schedulerTaskRepository, clientTaskRepository, taskResolver, executorThreads, candidateExecutorService,
                 schedulerName, waiter, heartbeatInterval, enableImmediateExecution, statsRegistry, pollingLimit,
             deleteUnresolvedAfter, shutdownMaxWait, startTasks);
     }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
@@ -147,6 +147,7 @@ public interface SchedulerClient {
 
             TaskRepository taskRepository = new JdbcTaskRepository(
                 dataSource,
+                false,
                 ofNullable(jdbcCustomization).orElse(new DefaultJdbcCustomization()),
                 tableName,
                 taskResolver,

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/ManualScheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/ManualScheduler.java
@@ -30,8 +30,8 @@ public class ManualScheduler extends Scheduler {
     private static final Logger LOG = LoggerFactory.getLogger(ManualScheduler.class);
     private final SettableClock clock;
 
-    ManualScheduler(SettableClock clock, TaskRepository taskRepository, TaskResolver taskResolver, int maxThreads, ExecutorService executorService, SchedulerName schedulerName, Waiter waiter, Duration heartbeatInterval, boolean executeImmediately, StatsRegistry statsRegistry, int pollingLimit, Duration deleteUnresolvedAfter, List<OnStartup> onStartup) {
-        super(clock, taskRepository, taskResolver, maxThreads, executorService, schedulerName, waiter, heartbeatInterval, executeImmediately, statsRegistry, pollingLimit, deleteUnresolvedAfter, Duration.ZERO, onStartup);
+    ManualScheduler(SettableClock clock, TaskRepository schedulerTaskRepository, TaskRepository clientTaskRepository, TaskResolver taskResolver, int maxThreads, ExecutorService executorService, SchedulerName schedulerName, Waiter waiter, Duration heartbeatInterval, boolean executeImmediately, StatsRegistry statsRegistry, int pollingLimit, Duration deleteUnresolvedAfter, List<OnStartup> onStartup) {
+        super(clock, schedulerTaskRepository, clientTaskRepository, taskResolver, maxThreads, executorService, schedulerName, waiter, heartbeatInterval, executeImmediately, statsRegistry, pollingLimit, deleteUnresolvedAfter, Duration.ZERO, onStartup);
         this.clock = clock;
     }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
@@ -66,9 +66,10 @@ public class TestHelper {
 
         public ManualScheduler build() {
             final TaskResolver taskResolver = new TaskResolver(statsRegistry, clock, knownTasks);
-            final JdbcTaskRepository taskRepository = new JdbcTaskRepository(dataSource, new DefaultJdbcCustomization(), tableName, taskResolver, new SchedulerName.Fixed("manual"), serializer);
+            final JdbcTaskRepository schedulerTaskRepository = new JdbcTaskRepository(dataSource, true, new DefaultJdbcCustomization(), tableName, taskResolver, new SchedulerName.Fixed("manual"), serializer);
+            final JdbcTaskRepository clientTaskRepository = new JdbcTaskRepository(dataSource, commitWhenAutocommitDisabled, new DefaultJdbcCustomization(), tableName, taskResolver, new SchedulerName.Fixed("manual"), serializer);
 
-            return new ManualScheduler(clock, taskRepository, taskResolver, executorThreads, new DirectExecutorService(), schedulerName, waiter, heartbeatInterval, enableImmediateExecution, statsRegistry, pollingLimit, deleteUnresolvedAfter, startTasks);
+            return new ManualScheduler(clock, schedulerTaskRepository, clientTaskRepository, taskResolver, executorThreads, new DirectExecutorService(), schedulerName, waiter, heartbeatInterval, enableImmediateExecution, statsRegistry, pollingLimit, deleteUnresolvedAfter, startTasks);
         }
 
         public ManualScheduler start() {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/CustomTableNameTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/CustomTableNameTest.java
@@ -36,7 +36,7 @@ public class CustomTableNameTest {
         oneTimeTask = TestTasks.oneTime("OneTime", Void.class, TestTasks.DO_NOTHING);
         List<Task<?>> knownTasks = new ArrayList<>();
         knownTasks.add(oneTimeTask);
-        taskRepository = new JdbcTaskRepository(DB.getDataSource(), CUSTOM_TABLENAME, new TaskResolver(StatsRegistry.NOOP, knownTasks), new SchedulerName.Fixed(SCHEDULER_NAME));
+        taskRepository = new JdbcTaskRepository(DB.getDataSource(), false, CUSTOM_TABLENAME, new TaskResolver(StatsRegistry.NOOP, knownTasks), new SchedulerName.Fixed(SCHEDULER_NAME));
 
         DbUtils.runSqlResource("postgresql_custom_tablename.sql").accept(DB.getDataSource());
     }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
@@ -56,9 +56,10 @@ public class DeadExecutionsTest {
 
         TaskResolver taskResolver = new TaskResolver(StatsRegistry.NOOP, oneTimeTask, nonCompleting);
 
-        jdbcTaskRepository = new JdbcTaskRepository(DB.getDataSource(), DEFAULT_TABLE_NAME, taskResolver, new SchedulerName.Fixed("scheduler1"));
+        jdbcTaskRepository = new JdbcTaskRepository(DB.getDataSource(), false, DEFAULT_TABLE_NAME, taskResolver, new SchedulerName.Fixed("scheduler1"));
 
         scheduler = new Scheduler(settableClock,
+            jdbcTaskRepository,
             jdbcTaskRepository,
             taskResolver,
             1,

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
@@ -54,7 +54,7 @@ public class JdbcTaskRepositoryTest {
         knownTasks.add(alternativeOneTimeTask);
         testableRegistry = new TestableRegistry(true, Collections.emptyList());
         taskResolver = new TaskResolver(testableRegistry, knownTasks);
-        taskRepository = new JdbcTaskRepository(DB.getDataSource(), DEFAULT_TABLE_NAME, taskResolver, new SchedulerName.Fixed(SCHEDULER_NAME));
+        taskRepository = new JdbcTaskRepository(DB.getDataSource(), false, DEFAULT_TABLE_NAME, taskResolver, new SchedulerName.Fixed(SCHEDULER_NAME));
     }
 
     @Test
@@ -307,7 +307,7 @@ public class JdbcTaskRepositoryTest {
         createDeadExecution(oneTimeTask.instance("id1"), timeDied);
 
         TaskResolver taskResolverMissingTask = new TaskResolver(testableRegistry);
-        JdbcTaskRepository repoMissingTask = new JdbcTaskRepository(DB.getDataSource(), DEFAULT_TABLE_NAME, taskResolverMissingTask, new SchedulerName.Fixed(SCHEDULER_NAME));
+        JdbcTaskRepository repoMissingTask = new JdbcTaskRepository(DB.getDataSource(), false, DEFAULT_TABLE_NAME, taskResolverMissingTask, new SchedulerName.Fixed(SCHEDULER_NAME));
 
         assertThat(taskResolverMissingTask.getUnresolved(), hasSize(0));
         assertEquals(0, testableRegistry.getCount(SchedulerStatsEvent.UNRESOLVED_TASK));

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
@@ -47,8 +47,8 @@ public class SchedulerTest {
     private Scheduler schedulerFor(ExecutorService executor, Task<?> ... tasks) {
         final StatsRegistry statsRegistry = StatsRegistry.NOOP;
         TaskResolver taskResolver = new TaskResolver(statsRegistry, clock, Arrays.asList(tasks));
-        JdbcTaskRepository taskRepository = new JdbcTaskRepository(postgres.getDataSource(), DEFAULT_TABLE_NAME, taskResolver, new SchedulerName.Fixed("scheduler1"));
-        return new Scheduler(clock, taskRepository, taskResolver, 1, executor, new SchedulerName.Fixed("name"), new Waiter(Duration.ZERO), Duration.ofSeconds(1), false, statsRegistry, 10_000, Duration.ofDays(14), Duration.ZERO, new ArrayList<>());
+        JdbcTaskRepository taskRepository = new JdbcTaskRepository(postgres.getDataSource(), false, DEFAULT_TABLE_NAME, taskResolver, new SchedulerName.Fixed("scheduler1"));
+        return new Scheduler(clock, taskRepository, taskRepository, taskResolver, 1, executor, new SchedulerName.Fixed("name"), new Waiter(Duration.ZERO), Duration.ofSeconds(1), false, statsRegistry, 10_000, Duration.ofDays(14), Duration.ZERO, new ArrayList<>());
     }
 
     @Test

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/CompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/CompatibilityTest.java
@@ -61,6 +61,7 @@ public abstract class CompatibilityTest {
     private ExecutionCompletedCondition completed12Condition;
 
     public abstract DataSource getDataSource();
+    public abstract boolean commitWhenAutocommitDisabled();
 
     @BeforeEach
     public void setUp() {
@@ -130,7 +131,7 @@ public abstract class CompatibilityTest {
         taskResolver.addTask(oneTime);
 
         DataSource dataSource = getDataSource();
-        final JdbcTaskRepository jdbcTaskRepository = new JdbcTaskRepository(dataSource, DEFAULT_TABLE_NAME, taskResolver, new SchedulerName.Fixed("scheduler1"));
+        final JdbcTaskRepository jdbcTaskRepository = new JdbcTaskRepository(dataSource, commitWhenAutocommitDisabled(), DEFAULT_TABLE_NAME, taskResolver, new SchedulerName.Fixed("scheduler1"));
 
         final Instant now = Instant.now();
 
@@ -169,7 +170,7 @@ public abstract class CompatibilityTest {
         taskResolver.addTask(recurringWithData);
 
         DataSource dataSource = getDataSource();
-        final JdbcTaskRepository jdbcTaskRepository = new JdbcTaskRepository(dataSource, DEFAULT_TABLE_NAME, taskResolver, new SchedulerName.Fixed("scheduler1"));
+        final JdbcTaskRepository jdbcTaskRepository = new JdbcTaskRepository(dataSource, commitWhenAutocommitDisabled(), DEFAULT_TABLE_NAME, taskResolver, new SchedulerName.Fixed("scheduler1"));
 
         final Instant now = Instant.now();
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/MssqlCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/MssqlCompatibilityTest.java
@@ -38,4 +38,9 @@ public class MssqlCompatibilityTest extends CompatibilityTest {
     public DataSource getDataSource() {
         return pooledDatasource;
     }
+
+    @Override
+    public boolean commitWhenAutocommitDisabled() {
+        return false;
+    }
 }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/MysqlCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/MysqlCompatibilityTest.java
@@ -38,4 +38,9 @@ public class MysqlCompatibilityTest extends CompatibilityTest {
     public DataSource getDataSource() {
         return pooledDatasource;
     }
+
+    @Override
+    public boolean commitWhenAutocommitDisabled() {
+        return false;
+    }
 }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/NoAutoCommitPostgresqlCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/NoAutoCommitPostgresqlCompatibilityTest.java
@@ -45,4 +45,9 @@ public class NoAutoCommitPostgresqlCompatibilityTest extends CompatibilityTest {
         return pooledDatasource;
     }
 
+    @Override
+    public boolean commitWhenAutocommitDisabled() {
+        return true;
+    }
+
 }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/Oracle11gCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/Oracle11gCompatibilityTest.java
@@ -44,4 +44,9 @@ public class Oracle11gCompatibilityTest extends CompatibilityTest {
     public DataSource getDataSource() {
         return pooledDatasource;
     }
+
+    @Override
+    public boolean commitWhenAutocommitDisabled() {
+        return false;
+    }
 }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/PostgresqlCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/PostgresqlCompatibilityTest.java
@@ -27,4 +27,9 @@ public class PostgresqlCompatibilityTest extends CompatibilityTest {
         return postgres.getDataSource();
     }
 
+    @Override
+    public boolean commitWhenAutocommitDisabled() {
+        return false;
+    }
+
 }

--- a/examples/spring-boot-example/src/test/java/com/github/kagkarlsson/examples/boot/SmokeTest.java
+++ b/examples/spring-boot-example/src/test/java/com/github/kagkarlsson/examples/boot/SmokeTest.java
@@ -1,31 +1,50 @@
 package com.github.kagkarlsson.examples.boot;
 
+import static java.time.Duration.ofDays;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.kagkarlsson.scheduler.Scheduler;
 import com.github.kagkarlsson.scheduler.boot.actuator.DbSchedulerHealthIndicator;
 import com.github.kagkarlsson.scheduler.task.Task;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
 import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
 import com.github.kagkarlsson.scheduler.task.helper.RecurringTask;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.assertj.AssertableWebApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.context.ConfigurableWebApplicationContext;
+
+import java.time.Duration;
+import java.time.Instant;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class SmokeTest {
+    private static final Logger LOG = LoggerFactory.getLogger(SmokeTest.class);
+
+    AssertableWebApplicationContext ctx;
     @Autowired
     ConfigurableWebApplicationContext applicationContext;
-    AssertableWebApplicationContext ctx;
-
     @Autowired
     DbSchedulerHealthIndicator healthIndicator;
+    @Autowired
+    Task<Void> sampleOneTimeTask;
+    @Autowired
+    Scheduler scheduler;
+    @Autowired
+    TransactionTemplate tt;
 
     @BeforeEach
     public void setup() {
@@ -53,4 +72,25 @@ public class SmokeTest {
     public void it_should_be_healthy_after_startup() {
         assertThat(healthIndicator.health().getStatus()).isEqualTo(Status.UP);
     }
+
+    @Test
+    public void it_should_manage_transactions_for_scheduler_client() {
+        final TaskInstance<Void> instance1 = sampleOneTimeTask.instance("1");
+        final TaskInstance<Void> instance2 = sampleOneTimeTask.instance("2");
+        scheduler.schedule(instance1, Instant.now().plus(ofDays(1)));
+        assertTrue(scheduler.getScheduledExecution(instance1).isPresent());
+
+        try {
+            tt.execute(status -> {
+                scheduler.schedule(instance2, Instant.now().plus(ofDays(1)));
+                throw new SimulatedException();
+            });
+        } catch (SimulatedException e) {
+            LOG.info("Caught expected SimulatedException. Should rollback ongoing transation for instance2");
+        }
+
+        assertFalse(scheduler.getScheduledExecution(instance2).isPresent(), "instance2 should have been rolled back");
+    }
+
+    static class SimulatedException extends RuntimeException {}
 }


### PR DESCRIPTION
For SchedulerClient, change default behavior to not commit when datasource has autocommit=false to allow for external transaction-managers, like Spring.

This bug was introduced in version 7.1.