### PR TITLE
Scheduler client improvements

### DIFF
--- a/db-scheduler-boot-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
+++ b/db-scheduler-boot-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
@@ -63,7 +63,7 @@ public class DbSchedulerAutoConfigurationTest {
             assertThat(ctx).hasSingleBean(DataSource.class);
             assertThat(ctx).hasSingleBean(Scheduler.class);
 
-            ctx.getBean(Scheduler.class).getScheduledExecutions(execution -> {
+            ctx.getBean(Scheduler.class).fetchScheduledExecutions(execution -> {
                 fail("No scheduled executions should be present", execution);
             });
         });

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ScheduledExecution.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ScheduledExecution.java
@@ -26,12 +26,15 @@ public class ScheduledExecution<DATA_TYPE> {
         this.dataClass = dataClass;
         this.execution = execution;
     }
+
     public TaskInstanceId getTaskInstance() {
         return execution.taskInstance;
     }
+
     public Instant getExecutionTime() {
         return execution.getExecutionTime();
     }
+
     @SuppressWarnings("unchecked")
     public DATA_TYPE getData() {
         if (dataClass.isInstance(this.execution.taskInstance.getData())) {
@@ -39,6 +42,27 @@ public class ScheduledExecution<DATA_TYPE> {
         }
         throw new DataClassMismatchException();
     }
+
+    public Instant getLastSuccess() {
+        return execution.lastSuccess;
+    }
+
+    public Instant getLastFailure() {
+        return execution.lastFailure;
+    }
+
+    public int getConsecutiveFailures() {
+        return execution.consecutiveFailures;
+    }
+
+    public boolean isPicked() {
+        return execution.picked;
+    }
+
+    public String getPickedBy() {
+        return execution.pickedBy;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ScheduledExecutionsFilter.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ScheduledExecutionsFilter.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) Gustav Karlsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.kagkarlsson.scheduler;
+
+public class ScheduledExecutionsFilter {
+
+    private final boolean includePicked;
+
+    private ScheduledExecutionsFilter(boolean includePicked) {
+        this.includePicked = includePicked;
+    }
+
+    public static ScheduledExecutionsFilter all() {
+        return new ScheduledExecutionsFilter(true);
+    }
+
+    public static ScheduledExecutionsFilter excludePicked() {
+        return new ScheduledExecutionsFilter(false);
+    }
+
+    public boolean getIncludePicked() {
+        return includePicked;
+    }
+
+}

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -178,8 +178,18 @@ public class Scheduler implements SchedulerClient {
     }
 
     @Override
+    public void getScheduledExecutions(ScheduledExecutionsFilter filter, Consumer<ScheduledExecution<Object>> consumer) {
+        this.delegate.getScheduledExecutions(filter, consumer);
+    }
+
+    @Override
     public <T> void getScheduledExecutionsForTask(String taskName, Class<T> dataClass, Consumer<ScheduledExecution<T>> consumer) {
         this.delegate.getScheduledExecutionsForTask(taskName, dataClass, consumer);
+    }
+
+    @Override
+    public <T> void getScheduledExecutionsForTask(String taskName, Class<T> dataClass, ScheduledExecutionsFilter filter, Consumer<ScheduledExecution<T>> consumer) {
+        this.delegate.getScheduledExecutionsForTask(taskName, dataClass, filter, consumer);
     }
 
     @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -173,23 +173,23 @@ public class Scheduler implements SchedulerClient {
     }
 
     @Override
-    public void getScheduledExecutions(Consumer<ScheduledExecution<Object>> consumer) {
-        this.delegate.getScheduledExecutions(consumer);
+    public void fetchScheduledExecutions(Consumer<ScheduledExecution<Object>> consumer) {
+        this.delegate.fetchScheduledExecutions(consumer);
     }
 
     @Override
-    public void getScheduledExecutions(ScheduledExecutionsFilter filter, Consumer<ScheduledExecution<Object>> consumer) {
-        this.delegate.getScheduledExecutions(filter, consumer);
+    public void fetchScheduledExecutions(ScheduledExecutionsFilter filter, Consumer<ScheduledExecution<Object>> consumer) {
+        this.delegate.fetchScheduledExecutions(filter, consumer);
     }
 
     @Override
-    public <T> void getScheduledExecutionsForTask(String taskName, Class<T> dataClass, Consumer<ScheduledExecution<T>> consumer) {
-        this.delegate.getScheduledExecutionsForTask(taskName, dataClass, consumer);
+    public <T> void fetchScheduledExecutionsForTask(String taskName, Class<T> dataClass, Consumer<ScheduledExecution<T>> consumer) {
+        this.delegate.fetchScheduledExecutionsForTask(taskName, dataClass, consumer);
     }
 
     @Override
-    public <T> void getScheduledExecutionsForTask(String taskName, Class<T> dataClass, ScheduledExecutionsFilter filter, Consumer<ScheduledExecution<T>> consumer) {
-        this.delegate.getScheduledExecutionsForTask(taskName, dataClass, filter, consumer);
+    public <T> void fetchScheduledExecutionsForTask(String taskName, Class<T> dataClass, ScheduledExecutionsFilter filter, Consumer<ScheduledExecution<T>> consumer) {
+        this.delegate.fetchScheduledExecutionsForTask(taskName, dataClass, filter, consumer);
     }
 
     @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
@@ -268,7 +268,7 @@ public interface SchedulerClient {
 
         @Override
         public void fetchScheduledExecutions(Consumer<ScheduledExecution<Object>> consumer) {
-            fetchScheduledExecutions(ScheduledExecutionsFilter.excludePicked(), consumer);
+            fetchScheduledExecutions(ScheduledExecutionsFilter.all().withPicked(false), consumer);
         }
 
         @Override
@@ -279,7 +279,7 @@ public interface SchedulerClient {
 
         @Override
         public <T> void fetchScheduledExecutionsForTask(String taskName, Class<T> dataClass, Consumer<ScheduledExecution<T>> consumer) {
-            fetchScheduledExecutionsForTask(taskName, dataClass, ScheduledExecutionsFilter.excludePicked(), consumer);
+            fetchScheduledExecutionsForTask(taskName, dataClass, ScheduledExecutionsFilter.all().withPicked(false), consumer);
         }
 
         @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
@@ -89,24 +89,24 @@ public interface SchedulerClient {
      * @param consumer Consumer for the executions
      * @return void
      */
-    void getScheduledExecutions(Consumer<ScheduledExecution<Object>> consumer);
-    void getScheduledExecutions(ScheduledExecutionsFilter filter, Consumer<ScheduledExecution<Object>> consumer);
+    void fetchScheduledExecutions(Consumer<ScheduledExecution<Object>> consumer);
+    void fetchScheduledExecutions(ScheduledExecutionsFilter filter, Consumer<ScheduledExecution<Object>> consumer);
 
     /**
-     * @see #getScheduledExecutions(Consumer)
+     * @see #fetchScheduledExecutions(Consumer)
      */
-    default List<ScheduledExecution<Object>> getScheduledExecutionsAsList() {
+    default List<ScheduledExecution<Object>> getScheduledExecutions() {
         List<ScheduledExecution<Object>> executions = new ArrayList<>();
-        getScheduledExecutions(executions::add);
+        fetchScheduledExecutions(executions::add);
         return executions;
     }
 
     /**
-     * @see #getScheduledExecutions(Consumer)
+     * @see #fetchScheduledExecutions(Consumer)
      */
-    default List<ScheduledExecution<Object>> getScheduledExecutionsAsList(ScheduledExecutionsFilter filter) {
+    default List<ScheduledExecution<Object>> getScheduledExecutions(ScheduledExecutionsFilter filter) {
         List<ScheduledExecution<Object>> executions = new ArrayList<>();
-        getScheduledExecutions(filter, executions::add);
+        fetchScheduledExecutions(filter, executions::add);
         return executions;
     }
 
@@ -119,24 +119,24 @@ public interface SchedulerClient {
      * @param consumer  Consumer for the executions
      * @return void
      */
-    <T> void getScheduledExecutionsForTask(String taskName, Class<T> dataClass, Consumer<ScheduledExecution<T>> consumer);
-    <T> void getScheduledExecutionsForTask(String taskName, Class<T> dataClass, ScheduledExecutionsFilter filter, Consumer<ScheduledExecution<T>> consumer);
+    <T> void fetchScheduledExecutionsForTask(String taskName, Class<T> dataClass, Consumer<ScheduledExecution<T>> consumer);
+    <T> void fetchScheduledExecutionsForTask(String taskName, Class<T> dataClass, ScheduledExecutionsFilter filter, Consumer<ScheduledExecution<T>> consumer);
 
     /**
-     * @see #getScheduledExecutionsForTask(String, Class, Consumer)
+     * @see #fetchScheduledExecutionsForTask(String, Class, Consumer)
      */
-    default <T> List<ScheduledExecution<T>> getScheduledExecutionsForTaskAsList(String taskName, Class<T> dataClass) {
+    default <T> List<ScheduledExecution<T>> getScheduledExecutionsForTask(String taskName, Class<T> dataClass) {
         List<ScheduledExecution<T>> executions = new ArrayList<>();
-        getScheduledExecutionsForTask(taskName, dataClass, executions::add);
+        fetchScheduledExecutionsForTask(taskName, dataClass, executions::add);
         return executions;
     }
 
     /**
-     * @see #getScheduledExecutionsForTask(String, Class, Consumer)
+     * @see #fetchScheduledExecutionsForTask(String, Class, Consumer)
      */
-    default <T> List<ScheduledExecution<T>> getScheduledExecutionsForTaskAsList(String taskName, Class<T> dataClass, ScheduledExecutionsFilter filter) {
+    default <T> List<ScheduledExecution<T>> getScheduledExecutionsForTask(String taskName, Class<T> dataClass, ScheduledExecutionsFilter filter) {
         List<ScheduledExecution<T>> executions = new ArrayList<>();
-        getScheduledExecutionsForTask(taskName, dataClass, filter, executions::add);
+        fetchScheduledExecutionsForTask(taskName, dataClass, filter, executions::add);
         return executions;
     }
 
@@ -267,24 +267,24 @@ public interface SchedulerClient {
         }
 
         @Override
-        public void getScheduledExecutions(Consumer<ScheduledExecution<Object>> consumer) {
-            getScheduledExecutions(ScheduledExecutionsFilter.excludePicked(), consumer);
+        public void fetchScheduledExecutions(Consumer<ScheduledExecution<Object>> consumer) {
+            fetchScheduledExecutions(ScheduledExecutionsFilter.excludePicked(), consumer);
         }
 
         @Override
-        public void getScheduledExecutions(ScheduledExecutionsFilter filter, Consumer<ScheduledExecution<Object>> consumer) {
+        public void fetchScheduledExecutions(ScheduledExecutionsFilter filter, Consumer<ScheduledExecution<Object>> consumer) {
             taskRepository.getScheduledExecutions(filter,
                 execution -> consumer.accept(new ScheduledExecution<>(Object.class, execution)));
         }
 
         @Override
-        public <T> void getScheduledExecutionsForTask(String taskName, Class<T> dataClass, Consumer<ScheduledExecution<T>> consumer) {
-            getScheduledExecutionsForTask(taskName, dataClass, ScheduledExecutionsFilter.excludePicked(), consumer);
+        public <T> void fetchScheduledExecutionsForTask(String taskName, Class<T> dataClass, Consumer<ScheduledExecution<T>> consumer) {
+            fetchScheduledExecutionsForTask(taskName, dataClass, ScheduledExecutionsFilter.excludePicked(), consumer);
         }
 
         @Override
-        public <T> void getScheduledExecutionsForTask(String taskName, Class<T> dataClass, ScheduledExecutionsFilter filter,
-                                                      Consumer<ScheduledExecution<T>> consumer) {
+        public <T> void fetchScheduledExecutionsForTask(String taskName, Class<T> dataClass, ScheduledExecutionsFilter filter,
+                                                        Consumer<ScheduledExecution<T>> consumer) {
             taskRepository.getScheduledExecutions(filter, taskName,
                 execution -> consumer.accept(new ScheduledExecution<>(dataClass, execution)));
         }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -91,6 +92,15 @@ public interface SchedulerClient {
     void getScheduledExecutions(Consumer<ScheduledExecution<Object>> consumer);
 
     /**
+     * @see #getScheduledExecutions(Consumer)
+     */
+    default List<ScheduledExecution<Object>> getScheduledExecutionsAsList() {
+        List<ScheduledExecution<Object>> executions = new ArrayList<>();
+        getScheduledExecutions(executions::add);
+        return executions;
+    }
+
+    /**
      * Gets all scheduled executions for a task and supplies them to the provided Consumer. A Consumer is used to
      * avoid forcing the SchedulerClient to load all executions in memory. Currently running executions are not returned.
      *
@@ -100,6 +110,15 @@ public interface SchedulerClient {
      * @return void
      */
     <T> void getScheduledExecutionsForTask(String taskName, Class<T> dataClass, Consumer<ScheduledExecution<T>> consumer);
+
+    /**
+     * @see #getScheduledExecutionsForTask(String, Class, Consumer)
+     */
+    default <T> List<ScheduledExecution<T>> getScheduledExecutionsForTaskAsList(String taskName, Class<T> dataClass) {
+        List<ScheduledExecution<T>> executions = new ArrayList<>();
+        getScheduledExecutionsForTask(taskName, dataClass, executions::add);
+        return executions;
+    }
 
     /**
      * Gets the details for a specific scheduled execution. Currently running executions are also returned.

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
@@ -90,6 +90,7 @@ public interface SchedulerClient {
      * @return void
      */
     void getScheduledExecutions(Consumer<ScheduledExecution<Object>> consumer);
+    void getScheduledExecutions(ScheduledExecutionsFilter filter, Consumer<ScheduledExecution<Object>> consumer);
 
     /**
      * @see #getScheduledExecutions(Consumer)
@@ -97,6 +98,15 @@ public interface SchedulerClient {
     default List<ScheduledExecution<Object>> getScheduledExecutionsAsList() {
         List<ScheduledExecution<Object>> executions = new ArrayList<>();
         getScheduledExecutions(executions::add);
+        return executions;
+    }
+
+    /**
+     * @see #getScheduledExecutions(Consumer)
+     */
+    default List<ScheduledExecution<Object>> getScheduledExecutionsAsList(ScheduledExecutionsFilter filter) {
+        List<ScheduledExecution<Object>> executions = new ArrayList<>();
+        getScheduledExecutions(filter, executions::add);
         return executions;
     }
 
@@ -110,6 +120,7 @@ public interface SchedulerClient {
      * @return void
      */
     <T> void getScheduledExecutionsForTask(String taskName, Class<T> dataClass, Consumer<ScheduledExecution<T>> consumer);
+    <T> void getScheduledExecutionsForTask(String taskName, Class<T> dataClass, ScheduledExecutionsFilter filter, Consumer<ScheduledExecution<T>> consumer);
 
     /**
      * @see #getScheduledExecutionsForTask(String, Class, Consumer)
@@ -117,6 +128,15 @@ public interface SchedulerClient {
     default <T> List<ScheduledExecution<T>> getScheduledExecutionsForTaskAsList(String taskName, Class<T> dataClass) {
         List<ScheduledExecution<T>> executions = new ArrayList<>();
         getScheduledExecutionsForTask(taskName, dataClass, executions::add);
+        return executions;
+    }
+
+    /**
+     * @see #getScheduledExecutionsForTask(String, Class, Consumer)
+     */
+    default <T> List<ScheduledExecution<T>> getScheduledExecutionsForTaskAsList(String taskName, Class<T> dataClass, ScheduledExecutionsFilter filter) {
+        List<ScheduledExecution<T>> executions = new ArrayList<>();
+        getScheduledExecutionsForTask(taskName, dataClass, filter, executions::add);
         return executions;
     }
 
@@ -248,12 +268,25 @@ public interface SchedulerClient {
 
         @Override
         public void getScheduledExecutions(Consumer<ScheduledExecution<Object>> consumer) {
-            taskRepository.getScheduledExecutions(execution -> consumer.accept(new ScheduledExecution<>(Object.class, execution)));
+            getScheduledExecutions(ScheduledExecutionsFilter.excludePicked(), consumer);
+        }
+
+        @Override
+        public void getScheduledExecutions(ScheduledExecutionsFilter filter, Consumer<ScheduledExecution<Object>> consumer) {
+            taskRepository.getScheduledExecutions(filter,
+                execution -> consumer.accept(new ScheduledExecution<>(Object.class, execution)));
         }
 
         @Override
         public <T> void getScheduledExecutionsForTask(String taskName, Class<T> dataClass, Consumer<ScheduledExecution<T>> consumer) {
-            taskRepository.getScheduledExecutions(taskName, execution -> consumer.accept(new ScheduledExecution<>(dataClass, execution)));
+            getScheduledExecutionsForTask(taskName, dataClass, ScheduledExecutionsFilter.excludePicked(), consumer);
+        }
+
+        @Override
+        public <T> void getScheduledExecutionsForTask(String taskName, Class<T> dataClass, ScheduledExecutionsFilter filter,
+                                                      Consumer<ScheduledExecution<T>> consumer) {
+            taskRepository.getScheduledExecutions(filter, taskName,
+                execution -> consumer.accept(new ScheduledExecution<>(dataClass, execution)));
         }
 
         @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
@@ -27,8 +27,8 @@ public interface TaskRepository {
 
     boolean createIfNotExists(Execution execution);
     List<Execution> getDue(Instant now, int limit);
-    void getScheduledExecutions(Consumer<Execution> consumer);
-    void getScheduledExecutions(String taskName, Consumer<Execution> consumer);
+    void getScheduledExecutions(ScheduledExecutionsFilter filter, Consumer<Execution> consumer);
+    void getScheduledExecutions(ScheduledExecutionsFilter filter, String taskName, Consumer<Execution> consumer);
 
     void remove(Execution execution);
     boolean reschedule(Execution execution, Instant nextExecutionTime, Instant lastSuccess, Instant lastFailure, int consecutiveFailures);

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AndCondition.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AndCondition.java
@@ -13,28 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.kagkarlsson.scheduler;
+package com.github.kagkarlsson.scheduler.jdbc;
 
-import java.util.Optional;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 
-public class ScheduledExecutionsFilter {
+public interface AndCondition {
+    public String getQueryPart();
 
-    private Boolean pickedValue;
-
-    private ScheduledExecutionsFilter() {
-    }
-
-    public static ScheduledExecutionsFilter all() {
-        return new ScheduledExecutionsFilter();
-    }
-
-    public ScheduledExecutionsFilter withPicked(boolean pickedValue) {
-        this.pickedValue = pickedValue;
-        return this;
-    }
-
-    public Optional<Boolean> getPickedValue() {
-        return Optional.ofNullable(pickedValue);
-    }
-
+    public int setParameters(PreparedStatement p, int index) throws SQLException;
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/QueryBuilder.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/QueryBuilder.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) Gustav Karlsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.kagkarlsson.scheduler.jdbc;
+
+import com.github.kagkarlsson.jdbc.PreparedStatementSetter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Optional.empty;
+import static java.util.stream.Collectors.joining;
+
+public class QueryBuilder {
+    private final String tableName;
+    private final List<AndCondition> andConditions = new ArrayList<>();
+    private Optional<String> orderBy = empty();
+
+    public QueryBuilder(String tableName) {
+        this.tableName = tableName;
+    }
+
+    public static QueryBuilder selectFromTable(String tableName) {
+        return new QueryBuilder(tableName);
+    }
+
+    public QueryBuilder andCondition(AndCondition andCondition) {
+        andConditions.add(andCondition);
+        return this;
+    }
+
+    public QueryBuilder orderBy(String orderBy) {
+        this.orderBy = Optional.of(orderBy);
+        return this;
+    }
+
+    public String getQuery() {
+        StringBuilder s = new StringBuilder();
+        s.append("select * from ").append(tableName);
+
+        if (!andConditions.isEmpty()) {
+            s.append(" where ");
+            s.append(andConditions.stream().map(AndCondition::getQueryPart).collect(joining(" and ")));
+        }
+
+        orderBy.ifPresent(o -> s.append(" order by ").append(o));
+
+        return s.toString();
+    }
+
+    public PreparedStatementSetter getPreparedStatementSetter() {
+        return p -> {
+            int parameterIndex = 1;
+            for (AndCondition andCondition : andConditions) {
+                parameterIndex = andCondition.setParameters(p, parameterIndex);
+            }
+        };
+    }
+}

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
@@ -293,13 +293,15 @@ public class JdbcTaskRepositoryTest {
     @Test
     public void get_scheduled_by_task_name() {
         Instant now = TimeHelper.truncatedInstantNow();
-        taskRepository.createIfNotExists(new Execution(now.plus(new Random().nextInt(10), ChronoUnit.HOURS), oneTimeTask.instance("id" + 1)));
+        final Execution execution1 = new Execution(now.plus(new Random().nextInt(10), ChronoUnit.HOURS), oneTimeTask.instance("id" + 1));
+        taskRepository.createIfNotExists(execution1);
         taskRepository.createIfNotExists(new Execution(now.plus(new Random().nextInt(10), ChronoUnit.HOURS), oneTimeTask.instance("id" + 2)));
         taskRepository.createIfNotExists(new Execution(now.plus(new Random().nextInt(10), ChronoUnit.HOURS), alternativeOneTimeTask.instance("id" + 3)));
 
-        List<Execution> scheduledByTaskName = new ArrayList<>();
-        taskRepository.getScheduledExecutions(all().withPicked(false), oneTimeTask.getName(), scheduledByTaskName::add);
-        assertThat(scheduledByTaskName, hasSize(2));
+        taskRepository.pick(execution1, Instant.now());
+        assertThat(getScheduledExecutions(all().withPicked(true), oneTimeTask.getName()), hasSize(1));
+        assertThat(getScheduledExecutions(all().withPicked(false), oneTimeTask.getName()), hasSize(1));
+        assertThat(getScheduledExecutions(all(), oneTimeTask.getName()), hasSize(2));
 
         assertThat(getScheduledExecutions(all().withPicked(false), alternativeOneTimeTask.getName()), hasSize(1));
         assertThat(getScheduledExecutions(all().withPicked(false), "non-existing"), empty());

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
@@ -95,8 +95,10 @@ public class SchedulerClientTest {
         client.schedule(oneTimeTaskB.instance("12"), settableClock.now());
 
         assertThat(countAllExecutions(client), is(5));
+        assertThat(client.getScheduledExecutionsAsList().size(), is(5));
         assertThat(countExecutionsForTask(client, oneTimeTaskA.getName(), Void.class), is(2));
         assertThat(countExecutionsForTask(client, oneTimeTaskB.getName(), Void.class), is(3));
+        assertThat(client.getScheduledExecutionsForTaskAsList(oneTimeTaskB.getName(), Void.class).size(), is(3));
     }
 
     @Test

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
@@ -95,10 +95,10 @@ public class SchedulerClientTest {
         client.schedule(oneTimeTaskB.instance("12"), settableClock.now());
 
         assertThat(countAllExecutions(client), is(5));
-        assertThat(client.getScheduledExecutionsAsList().size(), is(5));
+        assertThat(client.getScheduledExecutions().size(), is(5));
         assertThat(countExecutionsForTask(client, oneTimeTaskA.getName(), Void.class), is(2));
         assertThat(countExecutionsForTask(client, oneTimeTaskB.getName(), Void.class), is(3));
-        assertThat(client.getScheduledExecutionsForTaskAsList(oneTimeTaskB.getName(), Void.class).size(), is(3));
+        assertThat(client.getScheduledExecutionsForTask(oneTimeTaskB.getName(), Void.class).size(), is(3));
     }
 
     @Test
@@ -133,13 +133,13 @@ public class SchedulerClientTest {
 
     private int countAllExecutions(SchedulerClient client) {
         AtomicInteger counter = new AtomicInteger(0);
-        client.getScheduledExecutions((ScheduledExecution<Object> execution) -> {counter.incrementAndGet();});
+        client.fetchScheduledExecutions((ScheduledExecution<Object> execution) -> {counter.incrementAndGet();});
         return counter.get();
     }
 
     private <T> int countExecutionsForTask(SchedulerClient client, String taskName, Class<T> dataClass) {
         AtomicInteger counter = new AtomicInteger(0);
-        client.getScheduledExecutionsForTask(taskName, dataClass, (ScheduledExecution<T> execution) -> {counter.incrementAndGet();});
+        client.fetchScheduledExecutionsForTask(taskName, dataClass, (ScheduledExecution<T> execution) -> {counter.incrementAndGet();});
         return counter.get();
     }
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/example/UnresolvedTaskMain.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/example/UnresolvedTaskMain.java
@@ -47,7 +47,7 @@ public class UnresolvedTaskMain {
         scheduler.start();
 
         IntStream.range(0, 5).forEach(i -> {
-            scheduler.getScheduledExecutions(e -> {});
+            scheduler.fetchScheduledExecutions(e -> {});
             scheduler.getFailingExecutions(Duration.ZERO);
         });
     }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/ExecutorPoolTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/ExecutorPoolTest.java
@@ -1,24 +1,18 @@
 package com.github.kagkarlsson.scheduler.functional;
 
-import ch.qos.logback.classic.Level;
 import co.unruly.matchers.TimeMatchers;
 import com.github.kagkarlsson.scheduler.EmbeddedPostgresqlExtension;
 import com.github.kagkarlsson.scheduler.Scheduler;
-import com.github.kagkarlsson.scheduler.SchedulerClient;
 import com.github.kagkarlsson.scheduler.SchedulerName;
 import com.github.kagkarlsson.scheduler.StopSchedulerExtension;
 import com.github.kagkarlsson.scheduler.TestTasks;
-import com.github.kagkarlsson.scheduler.helper.ChangeLogLevelsExtension;
-import com.github.kagkarlsson.scheduler.helper.ChangeLogLevelsExtension.LogLevelOverride;
 import com.github.kagkarlsson.scheduler.helper.TestableRegistry;
 import com.github.kagkarlsson.scheduler.task.ExecutionComplete;
 import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
 import com.github.kagkarlsson.scheduler.testhelper.SettableClock;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,7 +21,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -118,7 +111,7 @@ public class ExecutorPoolTest {
             .collect(Collectors.joining(","));
 
         List<String> scheduled = new ArrayList<>();
-        scheduler.getScheduledExecutions(se -> scheduled.add(se.getTaskInstance().getTaskName() + "_" + se.getTaskInstance().getId()));
+        scheduler.fetchScheduledExecutions(se -> scheduled.add(se.getTaskInstance().getTaskName() + "_" + se.getTaskInstance().getId()));
 
         return "Gave up waiting for condition. \n" +
             "Currently executing:\n" + currentlyExecuting +

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/jdbc/QueryBuilderTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/jdbc/QueryBuilderTest.java
@@ -1,0 +1,59 @@
+package com.github.kagkarlsson.scheduler.jdbc;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import static com.github.kagkarlsson.scheduler.jdbc.QueryBuilder.selectFromTable;
+import static org.junit.jupiter.api.Assertions.*;
+
+class QueryBuilderTest {
+
+    @Test
+    void test() {
+        assertNonWhitespaceEquals(
+            "select * from table1",
+            selectFromTable("table1").getQuery());
+
+        assertNonWhitespaceEquals(
+            "select * from table1 order by c1 asc",
+            selectFromTable("table1").orderBy("c1 asc").getQuery());
+
+        assertNonWhitespaceEquals(
+            "select * from table1 where field1=?",
+            selectFromTable("table1").andCondition(stringField("field1", "a")).getQuery());
+
+        assertNonWhitespaceEquals(
+            "select * from table1 where field1=? and field2=?",
+            selectFromTable("table1")
+                .andCondition(stringField("field1", "a"))
+                .andCondition(stringField("field2", "b"))
+                .getQuery());
+
+    }
+
+    private AndCondition stringField(String fieldname, String hasValue) {
+        return new AndCondition() {
+            @Override
+            public String getQueryPart() {
+                return fieldname + "=?";
+            }
+
+            @Override
+            public int setParameters(PreparedStatement p, int index) throws SQLException {
+                p.setString(index++, hasValue);
+                return index;
+            }
+        };
+    }
+
+    void assertNonWhitespaceEquals(String expected, String actual) {
+        assertEquals(normalize(expected), normalize(actual));
+    }
+
+    private String normalize(String expected) {
+        return expected.replaceAll("\\s+", " ");
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
 							<exclude>src/test/**</exclude>
 							<exclude>**/*.properties</exclude>
 							<exclude>**/*.sql</exclude>
+							<exclude>.github/**</exclude>
 						</excludes>
 						<failIfMissing>${failOnMissingHeader}</failIfMissing>
 					</configuration>


### PR DESCRIPTION
* Change `getScheduledExecutions(..)` to return `List<..>` instead of taking a `Consumer`.
* The `Consumer` variant is renamed to `fetchScheduledExecution`.
* Introduce a `ScheduledExecutionsFilter` for `getScheduledExecutions(..)` to allow specifying whether or not to return picked executions