### PR TITLE
Use explicit LIMIT in scheduler task polling query for PostgreSQL

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/JdbcTaskRepository.java
@@ -135,9 +135,9 @@ public class JdbcTaskRepository implements TaskRepository {
     @Override
     public List<Execution> getDue(Instant now, int limit) {
         final UnresolvedFilter unresolvedFilter = new UnresolvedFilter(taskResolver.getUnresolved());
-
+        final String explicitLimit = jdbcCustomization.supportsExplicitQueryLimitPart() ? jdbcCustomization.getQueryLimitPart(limit) : "";
         return jdbcRunner.query(
-                "select * from " + tableName + " where picked = ? and execution_time <= ? " + unresolvedFilter.andCondition() + " order by execution_time asc",
+                "select * from " + tableName + " where picked = ? and execution_time <= ? " + unresolvedFilter.andCondition() + " order by execution_time asc" + explicitLimit,
                 (PreparedStatement p) -> {
                     int index = 1;
                     p.setBoolean(index++, false);

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/JdbcTaskRepository.java
@@ -143,7 +143,9 @@ public class JdbcTaskRepository implements TaskRepository {
                     p.setBoolean(index++, false);
                     jdbcCustomization.setInstant(p, index++, now);
                     unresolvedFilter.setParameters(p, index);
-                    p.setMaxRows(limit);
+                    if (!jdbcCustomization.supportsExplicitQueryLimitPart()) {
+                        p.setMaxRows(limit);
+                    }
                 },
                 new ExecutionResultSetMapper()
         );

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
@@ -29,6 +29,7 @@ public class AutodetectJdbcCustomization implements JdbcCustomization {
 
     private static final Logger LOG = LoggerFactory.getLogger(AutodetectJdbcCustomization.class);
     public static final String MICROSOFT_SQL_SERVER = "Microsoft SQL Server";
+    public static final String POSTGRESQL = "PostgreSQL";
     private final JdbcCustomization jdbcCustomization;
 
     public AutodetectJdbcCustomization(DataSource dataSource) {
@@ -42,6 +43,9 @@ public class AutodetectJdbcCustomization implements JdbcCustomization {
             if (databaseProductName.equals(MICROSOFT_SQL_SERVER)) {
                 LOG.info("Using MSSQL jdbc-overrides.");
                 detectedCustomization = new MssqlJdbcCustomization();
+            } else if (databaseProductName.equals(POSTGRESQL)) {
+                LOG.info("Using PostgreSQL jdbc-overrides.");
+                detectedCustomization = new PostgreSqlJdbcCustomization();
             }
 
         } catch (SQLException e) {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
@@ -64,4 +64,14 @@ public class AutodetectJdbcCustomization implements JdbcCustomization {
     public Instant getInstant(ResultSet rs, String columnName) throws SQLException {
         return jdbcCustomization.getInstant(rs, columnName);
     }
+
+    @Override
+    public boolean supportsExplicitQueryLimitPart() {
+        return jdbcCustomization.supportsExplicitQueryLimitPart();
+    }
+
+    @Override
+    public String getQueryLimitPart(int limit) {
+        return jdbcCustomization.getQueryLimitPart(limit);
+    }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/DefaultJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/DefaultJdbcCustomization.java
@@ -34,4 +34,13 @@ public class DefaultJdbcCustomization implements JdbcCustomization {
         return Optional.ofNullable(rs.getTimestamp(columnName)).map(Timestamp::toInstant).orElse(null);
     }
 
+    @Override
+    public boolean supportsExplicitQueryLimitPart() {
+        return false;
+    }
+
+    @Override
+    public String getQueryLimitPart(int limit) {
+        return "";
+    }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcCustomization.java
@@ -25,11 +25,7 @@ public interface JdbcCustomization {
 
     Instant getInstant(ResultSet rs, String columnName) throws SQLException;
 
-    default boolean supportsExplicitQueryLimitPart() {
-        return false;
-    }
+    boolean supportsExplicitQueryLimitPart();
 
-    default String getQueryLimitPart(int limit) {
-        return "";
-    }
+    String getQueryLimitPart(int limit);
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MssqlJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MssqlJdbcCustomization.java
@@ -36,4 +36,13 @@ public class MssqlJdbcCustomization implements JdbcCustomization {
         return Optional.ofNullable(rs.getTimestamp(columnName)).map(Timestamp::toInstant).orElse(null);
     }
 
+    @Override
+    public boolean supportsExplicitQueryLimitPart() {
+        return false;
+    }
+
+    @Override
+    public String getQueryLimitPart(int limit) {
+        return "";
+    }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/PostgreSqlJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/PostgreSqlJdbcCustomization.java
@@ -15,21 +15,14 @@
  */
 package com.github.kagkarlsson.scheduler.jdbc;
 
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.time.Instant;
-
-public interface JdbcCustomization {
-    void setInstant(PreparedStatement p, int index, Instant value) throws SQLException;
-
-    Instant getInstant(ResultSet rs, String columnName) throws SQLException;
-
-    default boolean supportsExplicitQueryLimitPart() {
-        return false;
+public class PostgreSqlJdbcCustomization extends DefaultJdbcCustomization {
+    @Override
+    public boolean supportsExplicitQueryLimitPart() {
+        return true;
     }
 
-    default String getQueryLimitPart(int limit) {
-        return "";
+    @Override
+    public String getQueryLimitPart(int limit) {
+        return " LIMIT " + limit;
     }
 }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/jdbc/PostgreSqlJdbcCustomizationTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/jdbc/PostgreSqlJdbcCustomizationTest.java
@@ -1,0 +1,25 @@
+package com.github.kagkarlsson.scheduler.jdbc;
+
+import com.github.kagkarlsson.scheduler.EmbeddedPostgresqlExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PostgreSqlJdbcCustomizationTest {
+    @RegisterExtension
+    public EmbeddedPostgresqlExtension postgres = new EmbeddedPostgresqlExtension();
+
+    AutodetectJdbcCustomization jdbcCustomization = new AutodetectJdbcCustomization(postgres.getDataSource());
+
+    @Test
+    void test() {
+        assertTrue(jdbcCustomization.supportsExplicitQueryLimitPart());
+        Arrays.asList(1, 5, 20, 100).forEach(
+            it -> assertEquals(jdbcCustomization.getQueryLimitPart(it), " LIMIT " + it)
+        );
+    }
+}


### PR DESCRIPTION
Fixes behaviour described in https://github.com/kagkarlsson/db-scheduler/issues/164