### PR TITLE
Add module db-scheduler-mongo

### DIFF
--- a/db-scheduler-mongo/README.md
+++ b/db-scheduler-mongo/README.md
@@ -1,0 +1,35 @@
+# db-scheduler-mongo
+
+Module adding mongodb support for db-scheduler
+
+## Principle
+
+This module provides 3 main components :
+
+- `MongoTaskRepository`, a mongo implementation of `TaskRepository`
+- `MongoSchedulerBuilder`, a builder to make it easy to create a scheduler with the mongo repository
+- `MongoScheduler`, a scheduler extending the `Scheduler`, particularly the `create` method
+
+This module aims to be the less intrusive as possible regarding the main project modules.
+
+## Usage
+
+1. Add maven dependency :
+ ```xml
+<dependency>
+    <groupId>com.github.kagkarlsson</groupId>
+    <artifactId>db-scheduler-mongo</artifactId>
+    <version>master-SNAPSHOT</version>
+</dependency>
+```
+
+2. Instantiate and start the scheduler
+```java
+final Scheduler scheduler = MongoScheduler
+    .create(mongoClient, "scheduler-database", "scheduler-collection",
+    knownTasks).build();
+
+scheduler.start();
+```
+
+3. Use the scheduler as detailed in the main documentation

--- a/db-scheduler-mongo/pom.xml
+++ b/db-scheduler-mongo/pom.xml
@@ -13,11 +13,6 @@
   <name>db-scheduler: Mongodb support</name>
   <description>Module providing Mongodb support for db-scheduler</description>
 
-  <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>com.github.kagkarlsson</groupId>

--- a/db-scheduler-mongo/pom.xml
+++ b/db-scheduler-mongo/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>db-scheduler-parent</artifactId>
+    <groupId>com.github.kagkarlsson</groupId>
+    <version>master-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>db-scheduler-mongo</artifactId>
+  <name>db-scheduler: Mongodb support</name>
+  <description>Module providing Mongodb support for db-scheduler</description>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.github.kagkarlsson</groupId>
+      <artifactId>db-scheduler</artifactId>
+      <version>master-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mongodb</groupId>
+      <artifactId>mongo-java-driver</artifactId>
+      <version>3.12.7</version>
+    </dependency>
+
+    <!--  Tests dependencies  -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.30</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>de.flapdoodle.embed</groupId>
+      <artifactId>de.flapdoodle.embed.mongo</artifactId>
+      <version>3.0.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/db-scheduler-mongo/src/main/java/com/github/kagkarlsson/scheduler/MongoScheduler.java
+++ b/db-scheduler-mongo/src/main/java/com/github/kagkarlsson/scheduler/MongoScheduler.java
@@ -1,0 +1,41 @@
+package com.github.kagkarlsson.scheduler;
+
+import com.github.kagkarlsson.scheduler.stats.StatsRegistry;
+import com.github.kagkarlsson.scheduler.task.OnStartup;
+import com.github.kagkarlsson.scheduler.task.Task;
+import com.mongodb.MongoClient;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+public class MongoScheduler extends Scheduler {
+
+    protected MongoScheduler(Clock clock,
+        TaskRepository schedulerTaskRepository,
+        TaskRepository clientTaskRepository, TaskResolver taskResolver, int threadpoolSize,
+        ExecutorService executorService,
+        SchedulerName schedulerName, Waiter executeDueWaiter, Duration heartbeatInterval,
+        boolean enableImmediateExecution,
+        StatsRegistry statsRegistry, int pollingLimit,
+        Duration deleteUnresolvedAfter, Duration shutdownMaxWait,
+        List<OnStartup> onStartup) {
+        super(clock, schedulerTaskRepository, clientTaskRepository, taskResolver, threadpoolSize,
+            executorService, schedulerName, executeDueWaiter, heartbeatInterval,
+            enableImmediateExecution,
+            statsRegistry, pollingLimit, deleteUnresolvedAfter, shutdownMaxWait, onStartup);
+    }
+
+    public static MongoSchedulerBuilder create(MongoClient mongoClient, String database,
+        String collection, Task<?>... knownTasks) {
+        List<Task<?>> knownTasksList = new ArrayList<>();
+        knownTasksList.addAll(Arrays.asList(knownTasks));
+        return create(mongoClient, database, collection, knownTasksList);
+    }
+
+    public static MongoSchedulerBuilder create(MongoClient mongoClient, String database,
+        String collection, List<Task<?>> knownTasks) {
+        return new MongoSchedulerBuilder(mongoClient, database, collection, knownTasks);
+    }
+}

--- a/db-scheduler-mongo/src/main/java/com/github/kagkarlsson/scheduler/MongoSchedulerBuilder.java
+++ b/db-scheduler-mongo/src/main/java/com/github/kagkarlsson/scheduler/MongoSchedulerBuilder.java
@@ -1,0 +1,75 @@
+package com.github.kagkarlsson.scheduler;
+
+import static com.github.kagkarlsson.scheduler.ExecutorUtils.defaultThreadFactoryWithPrefix;
+import static com.github.kagkarlsson.scheduler.Scheduler.THREAD_PREFIX;
+
+import com.github.kagkarlsson.scheduler.task.Task;
+import com.mongodb.MongoClient;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MongoSchedulerBuilder extends SchedulerBuilder {
+    private static final Logger LOG = LoggerFactory.getLogger(MongoSchedulerBuilder.class);
+
+    private final MongoClient mongoClient;
+
+    private final String databaseName;
+
+    /**
+     * Scheduler builder for mongo database
+     *
+     * Example using the database 'scheduler-database' and the collection 'scheduler-collection' :
+     * SchedulerBuilder builder = new MongoSchedulerBuilder(mongoTools.getClient(),
+     *             "scheduler-database", knownTasks).tableName("scheduler-collection")
+     *
+     * @param mongoClient - object handling mongo connection
+     * @param databaseName - mongo database name
+     * @param knownTasks - list of known tasks
+     */
+    protected MongoSchedulerBuilder(MongoClient mongoClient, String databaseName, String collection,
+        List<Task<?>> knownTasks) {
+        super(null, knownTasks);
+        this.mongoClient = mongoClient;
+        this.databaseName = databaseName;
+        this.tableName = collection;
+    }
+
+    @Override
+    public Scheduler build() {
+        if (pollingLimit < executorThreads) {
+            LOG.warn("Polling-limit is less than number of threads. Should be equal or higher.");
+        }
+
+        if (schedulerName == null) {
+            schedulerName = new SchedulerName.Hostname();
+        }
+
+        final TaskResolver taskResolver = new TaskResolver(statsRegistry, clock, knownTasks);
+
+        final MongoTaskRepository mongoTaskRepository = new MongoTaskRepository(taskResolver,
+            schedulerName, serializer, databaseName, tableName, mongoClient);
+        final MongoTaskRepository clientTaskRepository = new MongoTaskRepository(taskResolver,
+            schedulerName, serializer, databaseName, tableName, mongoClient);
+
+        ExecutorService candidateExecutorService = executorService;
+        if (candidateExecutorService == null) {
+            candidateExecutorService = Executors
+                .newFixedThreadPool(executorThreads, defaultThreadFactoryWithPrefix(THREAD_PREFIX + "-"));
+        }
+
+        LOG.info("Creating scheduler with configuration: threads={}, pollInterval={}s, heartbeat={}s enable-immediate-execution={}, table-name={}, name={}",
+            executorThreads,
+            waiter.getWaitDuration().getSeconds(),
+            heartbeatInterval.getSeconds(),
+            enableImmediateExecution,
+            tableName,
+            schedulerName.getName());
+
+        return new MongoScheduler(clock, mongoTaskRepository, clientTaskRepository, taskResolver, executorThreads, candidateExecutorService,
+            schedulerName, waiter, heartbeatInterval, enableImmediateExecution, statsRegistry, pollingLimit,
+            deleteUnresolvedAfter, shutdownMaxWait, startTasks);
+    }
+}

--- a/db-scheduler-mongo/src/main/java/com/github/kagkarlsson/scheduler/MongoTaskRepository.java
+++ b/db-scheduler-mongo/src/main/java/com/github/kagkarlsson/scheduler/MongoTaskRepository.java
@@ -1,0 +1,434 @@
+package com.github.kagkarlsson.scheduler;
+
+import static com.github.kagkarlsson.scheduler.TaskEntity.Fields;
+import static com.mongodb.client.model.Filters.and;
+import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Filters.lt;
+import static com.mongodb.client.model.Filters.lte;
+import static com.mongodb.client.model.Filters.ne;
+import static com.mongodb.client.model.Filters.nin;
+import static com.mongodb.client.model.Filters.or;
+import static com.mongodb.client.model.Sorts.ascending;
+import static com.mongodb.client.model.Updates.combine;
+import static com.mongodb.client.model.Updates.inc;
+import static com.mongodb.client.model.Updates.set;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+import com.github.kagkarlsson.scheduler.TaskResolver.UnresolvedTask;
+import com.github.kagkarlsson.scheduler.task.Execution;
+import com.github.kagkarlsson.scheduler.task.Task;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoWriteException;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.FindOneAndUpdateOptions;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.ReturnDocument;
+import com.mongodb.client.result.DeleteResult;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.bson.Document;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.bson.conversions.Bson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MongoTaskRepository implements TaskRepository {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoTaskRepository.class);
+    private final TaskResolver taskResolver;
+    private final SchedulerName schedulerSchedulerName;
+    private final Serializer serializer;
+
+    private final MongoCollection<TaskEntity> collection;
+
+    public MongoTaskRepository(TaskResolver taskResolver,
+        SchedulerName schedulerSchedulerName,
+        Serializer serializer, String databaseName, String tableName, MongoClient mongoClient) {
+        this.taskResolver = taskResolver;
+        this.schedulerSchedulerName = schedulerSchedulerName;
+        this.serializer = serializer;
+
+        CodecRegistry pojoCodecRegistry = fromRegistries(
+            MongoClientSettings.getDefaultCodecRegistry(),
+            fromProviders(PojoCodecProvider.builder().automatic(true).build()));
+
+        MongoDatabase db = mongoClient.getDatabase(databaseName)
+            .withCodecRegistry(pojoCodecRegistry);
+
+        this.collection = db.getCollection(tableName, TaskEntity.class);
+
+        // Create unique index for (taskName, taskInstance)
+        uniqueIndexCreation();
+    }
+
+    private void uniqueIndexCreation() {
+        LOG.info("Enforce uniqueness");
+        IndexOptions indexOption = new IndexOptions();
+        indexOption.unique(true);
+        Document fields = new Document();
+        fields.append(Fields.taskName, 1);
+        fields.append(Fields.taskInstance, 1);
+        this.collection.createIndex(fields, indexOption);
+    }
+
+    @Override
+    public boolean createIfNotExists(Execution execution) {
+        LOG.debug("Creation request for execution {}", execution);
+        // Search criterion : taskName, taskInstance
+        final Bson query = buildFilterFromExecution(execution, false);
+        Optional<TaskEntity> taskEntityOpt = toEntity(execution);
+        if (taskEntityOpt.isEmpty()) {
+            return false;
+        }
+        TaskEntity taskEntity = taskEntityOpt.get();
+        taskEntity.setPicked(false);
+        taskEntity.setVersion(1L);
+
+        boolean created = false;
+        try {
+            this.collection.insertOne(taskEntity);
+            created = true;
+        } catch (MongoWriteException e) {
+            LOG.error("Error while saving {} into database", execution, e);
+            // Exception is chained only if it is not related to a duplicate key error
+            if (!ErrorCategory.fromErrorCode(e.getCode()).equals(ErrorCategory.DUPLICATE_KEY)) {
+                throw e;
+            }
+        }
+
+        // Return true if no object was found
+        return created;
+    }
+
+    @Override
+    public List<Execution> getDue(Instant now, int limit) {
+        final Bson pickedFilter = eq(Fields.picked, false);
+        final Bson timeFilter = lte(Fields.executionTime, now);
+        final Optional<Bson> unresolvedFilter = conditionsForUnresolved();
+
+        final List<Bson> filters = new ArrayList<>();
+        filters.add(pickedFilter);
+        filters.add(timeFilter);
+        unresolvedFilter.ifPresent(filters::add);
+
+        final FindIterable<TaskEntity> tasks = this.collection.find(and(filters))
+            .sort(ascending(Fields.executionTime)).limit(limit);
+
+        return StreamSupport.stream(tasks.spliterator(), false).map(this::toExecution)
+            .filter(Optional::isPresent).map(Optional::get)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public void getScheduledExecutions(
+        ScheduledExecutionsFilter filter,
+        Consumer<Execution> consumer) {
+        LOG.debug("Executions request for {}", filter);
+        final Optional<Bson> unresolvedFilter = conditionsForUnresolved();
+        final Optional<Bson> executionFilter = conditionForFilter(filter);
+        final List<Bson> filters = new ArrayList<>();
+        unresolvedFilter.ifPresent(filters::add);
+        executionFilter.ifPresent(filters::add);
+
+        final FindIterable<TaskEntity> tasks = this.collection.find(and(filters))
+            .sort(ascending(Fields.executionTime));
+
+        StreamSupport.stream(tasks.spliterator(), false).map(this::toExecution)
+            .filter(Optional::isPresent).map(Optional::get).forEach(consumer);
+    }
+
+    private Optional<Bson> conditionForFilter(ScheduledExecutionsFilter filter) {
+        Optional<Bson> bsonFilter = Optional.empty();
+
+        if (filter.getPickedValue().isPresent()) {
+            bsonFilter = Optional.of(eq(Fields.picked, filter.getPickedValue().get()));
+        }
+
+        return bsonFilter;
+    }
+
+    private Optional<Bson> conditionsForUnresolved() {
+        List<TaskResolver.UnresolvedTask> unresolvedTasks = this.taskResolver.getUnresolved();
+        Optional<Bson> filter = Optional.empty();
+        if (!unresolvedTasks.isEmpty()) {
+            List<String> unresolvedTaskNames = unresolvedTasks.stream()
+                .map(UnresolvedTask::getTaskName).collect(Collectors.toList());
+            filter = Optional
+                .of(nin(Fields.taskName, unresolvedTaskNames));
+        }
+        return filter;
+    }
+
+    @Override
+    public void getScheduledExecutions(
+        ScheduledExecutionsFilter filter, String taskName,
+        Consumer<Execution> consumer) {
+
+        final Bson taskNameCondition = eq(Fields.taskName, taskName);
+        final Optional<Bson> pickedCondition = conditionForFilter(filter);
+        final Optional<Bson> unresolvedTaskCondition = conditionsForUnresolved();
+
+        final List<Bson> filters = new ArrayList<>();
+        filters.add(taskNameCondition);
+        pickedCondition.ifPresent(filters::add);
+        unresolvedTaskCondition.ifPresent(filters::add);
+
+        final Bson sortAscExecution = ascending(Fields.executionTime);
+        final FindIterable<TaskEntity> tasks = this.collection
+            .find(and(filters), TaskEntity.class).sort(sortAscExecution);
+
+        StreamSupport.stream(tasks.spliterator(), false).map(this::toExecution)
+            .filter(Optional::isPresent).map(Optional::get).forEach(consumer);
+    }
+
+    @Override
+    public void remove(Execution execution) {
+        final Bson filter = buildFilterFromExecution(execution);
+
+        this.collection.deleteOne(filter);
+    }
+
+    /**
+     * Build basic search filter from execution taking into account the following fields : -
+     * taskName - taskInstance - version
+     *
+     * @param execution - execution from which task name and task instance are extracted
+     * @return Bson filter
+     */
+    private Bson buildFilterFromExecution(Execution execution) {
+        return buildFilterFromExecution(execution, true);
+    }
+
+    /**
+     * Build basic search filter from execution taking into account the following fields : -
+     * taskName - taskInstance - version
+     *
+     * @param execution   - execution from which task name and task instance are extracted
+     * @param withVersion - flag to add version to the filter
+     * @return Bson filter
+     */
+    private Bson buildFilterFromExecution(Execution execution, boolean withVersion) {
+        return buildFilterFromParams(execution.taskInstance.getTaskName(),
+            execution.taskInstance.getId(), execution.version, withVersion);
+    }
+
+    private Bson buildFilterFromParams(String taskName, String taskInstance, Long version,
+        boolean withVersion) {
+        final Bson taskNameCondition = eq(Fields.taskName, taskName);
+        final Bson taskInstanceCondition = eq(Fields.taskInstance, taskInstance);
+
+        List<Bson> filters = new ArrayList<>();
+        filters.add(taskNameCondition);
+        filters.add(taskInstanceCondition);
+        if (withVersion) {
+            final Bson taskVersion = eq(Fields.version, version);
+            filters.add(taskVersion);
+        }
+
+        return and(filters);
+    }
+
+    @Override
+    public boolean reschedule(Execution execution, Instant nextExecutionTime,
+        Instant lastSuccess, Instant lastFailure, int consecutiveFailures) {
+        return rescheduleInternal(execution, nextExecutionTime, null, lastSuccess, lastFailure,
+            consecutiveFailures);
+    }
+
+    @Override
+    public boolean reschedule(Execution execution, Instant nextExecutionTime, Object newData,
+        Instant lastSuccess, Instant lastFailure, int consecutiveFailures) {
+        return rescheduleInternal(execution, nextExecutionTime, newData, lastSuccess,
+            lastFailure, consecutiveFailures);
+
+    }
+
+    private boolean rescheduleInternal(Execution execution, Instant nextExecutionTime,
+        Object data, Instant lastSuccess, Instant lastFailure, int consecutiveFailures) {
+
+        final FindOneAndUpdateOptions options = new FindOneAndUpdateOptions();
+        options.upsert(false);
+
+        Bson update = combine(set(Fields.executionTime, nextExecutionTime),
+            set(Fields.taskData, serializer.serialize(data)),
+            set(Fields.lastSuccess, lastSuccess), set(Fields.lastFailure, lastFailure),
+            set(Fields.consecutiveFailures, consecutiveFailures),
+            inc(Fields.version, 1));
+
+        final TaskEntity document = this.collection
+            .findOneAndUpdate(buildFilterFromExecution(execution), update, options);
+
+        return !Objects.isNull(document);
+    }
+
+    @Override
+    public Optional<Execution> pick(Execution e, Instant timePicked) {
+        // update where picked is true, task_name, task_instance, version
+        final Bson filterNameInstanceVersion = buildFilterFromExecution(e);
+        final Bson filters = and(filterNameInstanceVersion, eq(Fields.picked, false));
+
+        final FindOneAndUpdateOptions options = new FindOneAndUpdateOptions();
+        options.returnDocument(ReturnDocument.AFTER);
+        options.upsert(false);
+
+        Bson update = combine(set(Fields.picked, true),
+            set(Fields.pickedBy, StringUtils.truncate(schedulerSchedulerName.getName(), 50)),
+            set(Fields.lastHeartbeat, timePicked),
+            inc(Fields.version, 1));
+
+        TaskEntity document = this.collection.findOneAndUpdate(filters, update, options);
+
+        return toExecution(document);
+    }
+
+    @Override
+    public List<Execution> getDeadExecutions(Instant olderThan) {
+        final List<Bson> filterList = new ArrayList<>();
+        filterList.add(eq(Fields.picked, true));
+        filterList.add(lte(Fields.lastHeartbeat, olderThan));
+
+        final Optional<Bson> unresolvedFilter = conditionsForUnresolved();
+        unresolvedFilter.ifPresent(filterList::add);
+
+        final Bson filters = and(filterList);
+
+        FindIterable<TaskEntity> tasks = this.collection.find(filters)
+            .sort(ascending(Fields.lastHeartbeat));
+
+        return StreamSupport.stream(tasks.spliterator(), false).map(this::toExecution)
+            .filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
+    }
+
+    @Override
+    public void updateHeartbeat(Execution execution, Instant heartbeatTime) {
+        final FindOneAndUpdateOptions options = new FindOneAndUpdateOptions();
+        options.upsert(false);
+        final Bson update = set(Fields.lastHeartbeat, heartbeatTime);
+
+        this.collection.findOneAndUpdate(buildFilterFromExecution(execution), update, options);
+    }
+
+    @Override
+    public List<Execution> getExecutionsFailingLongerThan(Duration interval) {
+        final Bson filterFailureNoSuccess = and(ne(Fields.lastFailure, null),
+            eq(Fields.lastSuccess, null));
+        final Instant boundary = Instant.now().minus(interval);
+        final Bson filterFailureOldSuccess = and(ne(Fields.lastFailure, null),
+            lt(Fields.lastSuccess, boundary));
+
+        final Bson filters = or(filterFailureNoSuccess, filterFailureOldSuccess);
+
+        FindIterable<TaskEntity> tasks = this.collection.find(filters);
+
+        return StreamSupport.stream(tasks.spliterator(), false).map(this::toExecution)
+            .filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<Execution> getExecution(String taskName, String taskInstanceId) {
+        final Bson filters = buildFilterFromParams(taskName, taskInstanceId, null, false);
+
+        return toExecution(this.collection.find(filters).first());
+    }
+
+    @Override
+    public int removeExecutions(String taskName) {
+        final Bson filter = eq(Fields.taskName, taskName);
+
+        final DeleteResult deleted = this.collection.deleteMany(filter);
+
+        return Long.valueOf(deleted.getDeletedCount()).intValue();
+    }
+
+    /**
+     * Mapping method to get an Entity from an Execution
+     *
+     * @param in - Execution to map
+     * @return TaskEntity mapped from execution
+     */
+    private Optional<TaskEntity> toEntity(Execution in) {
+        if (in == null) {
+            return Optional.empty();
+        }
+
+        TaskEntity out = new TaskEntity();
+        Optional<TaskInstance<?>> taskInstanceOpt = Optional
+            .ofNullable(in.taskInstance);
+        taskInstanceOpt.map(TaskInstance::getTaskName).ifPresent(out::setTaskName);
+        taskInstanceOpt.map(TaskInstance::getId).ifPresent(out::setTaskInstance);
+        taskInstanceOpt.map(TaskInstance::getData).map(serializer::serialize)
+            .ifPresent(out::setTaskData);
+
+        out.setExecutionTime(in.getExecutionTime());
+        out.setPicked(in.isPicked());
+        out.setPickedBy(in.pickedBy);
+        out.setLastFailure(in.lastFailure);
+        out.setLastSuccess(in.lastSuccess);
+        out.setLastHeartbeat(in.lastHeartbeat);
+        out.setVersion(in.version);
+
+        return Optional.of(out);
+    }
+
+    /**
+     * Mapping method to get an Execution from a TaskEntity
+     *
+     * @param in - entity to map
+     * @return execution mapped
+     */
+    private Optional<Execution> toExecution(TaskEntity in) {
+        if (Objects.isNull(in)) {
+            return Optional.empty();
+        }
+
+        String taskName = in.getTaskName();
+        Optional<Task> task = taskResolver.resolve(taskName);
+        Supplier dataSupplier = () -> null;
+        if (task.isPresent()) {
+            dataSupplier = memoize(
+                () -> serializer.deserialize(task.get().getDataClass(), in.getTaskData()));
+        }
+
+        TaskInstance taskInstance = new TaskInstance(taskName, in.getTaskInstance(), dataSupplier);
+
+        return Optional
+            .of(new Execution(in.getExecutionTime(), taskInstance, in.isPicked(), in.getPickedBy(),
+                in.getLastSuccess(), in.getLastFailure(), in.getConsecutiveFailures(),
+                in.getLastHeartbeat(), in.getVersion()));
+    }
+
+    private static <T> Supplier<T> memoize(Supplier<T> original) {
+        return new Supplier<>() {
+            Supplier<T> delegate = this::firstTime;
+            boolean initialized;
+
+            public T get() {
+                return delegate.get();
+            }
+
+            private synchronized T firstTime() {
+                if (!initialized) {
+                    T value = original.get();
+                    delegate = () -> value;
+                    initialized = true;
+                }
+                return delegate.get();
+            }
+        };
+    }
+}

--- a/db-scheduler-mongo/src/main/java/com/github/kagkarlsson/scheduler/MongoTaskRepository.java
+++ b/db-scheduler-mongo/src/main/java/com/github/kagkarlsson/scheduler/MongoTaskRepository.java
@@ -92,7 +92,7 @@ public class MongoTaskRepository implements TaskRepository {
         // Search criterion : taskName, taskInstance
         final Bson query = buildFilterFromExecution(execution, false);
         Optional<TaskEntity> taskEntityOpt = toEntity(execution);
-        if (taskEntityOpt.isEmpty()) {
+        if (!taskEntityOpt.isPresent()) {
             return false;
         }
         TaskEntity taskEntity = taskEntityOpt.get();
@@ -413,7 +413,7 @@ public class MongoTaskRepository implements TaskRepository {
     }
 
     private static <T> Supplier<T> memoize(Supplier<T> original) {
-        return new Supplier<>() {
+        return new Supplier<T>() {
             Supplier<T> delegate = this::firstTime;
             boolean initialized;
 

--- a/db-scheduler-mongo/src/main/java/com/github/kagkarlsson/scheduler/TaskEntity.java
+++ b/db-scheduler-mongo/src/main/java/com/github/kagkarlsson/scheduler/TaskEntity.java
@@ -1,0 +1,174 @@
+package com.github.kagkarlsson.scheduler;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Objects;
+
+public class TaskEntity {
+
+    private String taskName;
+    private String taskInstance;
+    private byte[] taskData;
+    private Instant executionTime;
+    private boolean picked;
+    private String pickedBy;
+    private Instant lastSuccess;
+    private Instant lastFailure;
+    private int consecutiveFailures;
+    private Instant lastHeartbeat;
+    private long version;
+
+    public static class Fields {
+        public static final String taskName = "taskName";
+        public static final String taskInstance = "taskInstance";
+        public static final String taskData = "taskData";
+        public static final String executionTime = "executionTime";
+        public static final String picked = "picked";
+        public static final String pickedBy = "pickedBy";
+        public static final String lastSuccess = "lastSuccess";
+        public static final String lastFailure = "lastFailure";
+        public static final String consecutiveFailures = "consecutiveFailures";
+        public static final String lastHeartbeat = "lastHeartbeat";
+        public static final String version = "version";
+
+    }
+
+    public String getTaskName() {
+        return taskName;
+    }
+
+    public void setTaskName(String taskName) {
+        this.taskName = taskName;
+    }
+
+    public String getTaskInstance() {
+        return taskInstance;
+    }
+
+    public void setTaskInstance(String taskInstance) {
+        this.taskInstance = taskInstance;
+    }
+
+    public byte[] getTaskData() {
+        return taskData;
+    }
+
+    public void setTaskData(byte[] taskData) {
+        this.taskData = taskData;
+    }
+
+    public Instant getExecutionTime() {
+        return executionTime;
+    }
+
+    public void setExecutionTime(Instant executionTime) {
+        this.executionTime = executionTime;
+    }
+
+    public boolean isPicked() {
+        return picked;
+    }
+
+    public void setPicked(boolean picked) {
+        this.picked = picked;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    public void setVersion(long version) {
+        this.version = version;
+    }
+
+    public String getPickedBy() {
+        return pickedBy;
+    }
+
+    public void setPickedBy(String pickedBy) {
+        this.pickedBy = pickedBy;
+    }
+
+    public Instant getLastSuccess() {
+        return lastSuccess;
+    }
+
+    public void setLastSuccess(Instant lastSuccess) {
+        this.lastSuccess = lastSuccess;
+    }
+
+    public Instant getLastFailure() {
+        return lastFailure;
+    }
+
+    public void setLastFailure(Instant lastFailure) {
+        this.lastFailure = lastFailure;
+    }
+
+    public int getConsecutiveFailures() {
+        return consecutiveFailures;
+    }
+
+    public void setConsecutiveFailures(int consecutiveFailures) {
+        this.consecutiveFailures = consecutiveFailures;
+    }
+
+    public Instant getLastHeartbeat() {
+        return lastHeartbeat;
+    }
+
+    public void setLastHeartbeat(Instant lastHeartbeat) {
+        this.lastHeartbeat = lastHeartbeat;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        TaskEntity that = (TaskEntity) o;
+        return picked == that.picked && pickedBy == that.pickedBy
+            && consecutiveFailures == that.consecutiveFailures && version == that.version
+            && Objects.equals(taskName, that.taskName) && Objects
+            .equals(taskInstance, that.taskInstance) && Arrays.equals(taskData, that.taskData)
+            && Objects.equals(executionTime, that.executionTime) && Objects
+            .equals(lastSuccess, that.lastSuccess) && Objects
+            .equals(lastFailure, that.lastFailure) && Objects
+            .equals(lastHeartbeat, that.lastHeartbeat);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects
+            .hash(super.hashCode(), taskName, taskInstance, executionTime, picked, pickedBy,
+                lastSuccess,
+                lastFailure, consecutiveFailures, lastHeartbeat, version);
+        result = 31 * result + Arrays.hashCode(taskData);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TaskEntity{" +
+            "taskName='" + taskName + '\'' +
+            ", taskInstance='" + taskInstance + '\'' +
+            ", taskData=" + Arrays.toString(taskData) +
+            ", executionTime=" + executionTime +
+            ", picked=" + picked +
+            ", pickedBy=" + pickedBy +
+            ", lastSuccess=" + lastSuccess +
+            ", lastFailure=" + lastFailure +
+            ", consecutiveFailures=" + consecutiveFailures +
+            ", lastHeartbeat=" + lastHeartbeat +
+            ", version=" + version +
+            '}';
+    }
+
+
+}

--- a/db-scheduler-mongo/src/test/java/com/github/kagkarlsson/scheduler/EmebddedMongodbExtension.java
+++ b/db-scheduler-mongo/src/test/java/com/github/kagkarlsson/scheduler/EmebddedMongodbExtension.java
@@ -1,0 +1,83 @@
+package com.github.kagkarlsson.scheduler;
+
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+import com.github.kagkarlsson.scheduler.utils.TestUtils;
+import com.github.kagkarlsson.scheduler.utils.TestUtils.MongoTools;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import java.io.IOException;
+import org.bson.Document;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EmebddedMongodbExtension implements AfterEachCallback, AfterAllCallback {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EmebddedMongodbExtension.class);
+
+    private MongoTools mongoTools;
+    private MongoCollection<TaskEntity> collection;
+    private MongoDatabase db;
+
+    public EmebddedMongodbExtension() {
+        this("db-scheduler", "db-scheduler");
+    }
+
+    public EmebddedMongodbExtension(String collectionName, String databaseName) {
+        try {
+            mongoTools = TestUtils.startEmbeddedMongo();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        db = this.getDatabase(databaseName);
+        collection = this.getCollection(db, collectionName);
+    }
+
+    private MongoDatabase getDatabase(String databaseName) {
+        CodecRegistry pojoCodecRegistry = fromRegistries(
+            MongoClientSettings.getDefaultCodecRegistry(),
+            fromProviders(PojoCodecProvider.builder().automatic(true).build()));
+
+        return mongoTools.getClient().getDatabase(databaseName)
+            .withCodecRegistry(pojoCodecRegistry);
+    }
+
+    private MongoCollection<TaskEntity> getCollection(MongoDatabase db,
+        String collectionName) {
+        MongoCollection<TaskEntity> collection = db
+            .getCollection(collectionName, TaskEntity.class);
+        return collection;
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) throws Exception {
+        LOG.info("Delete collection");
+        this.collection.deleteMany(new Document());
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) throws Exception {
+        LOG.info("Kill embedded mongo");
+        this.mongoTools.getMongodProcess().stop();
+    }
+
+    public MongoCollection<TaskEntity> getCollection() {
+        return collection;
+    }
+
+    public MongoDatabase getDb() {
+        return db;
+    }
+
+    public MongoClient getMongoClient() {
+        return this.mongoTools.getClient();
+    }
+}

--- a/db-scheduler-mongo/src/test/java/com/github/kagkarlsson/scheduler/MongoSchedulerTest.java
+++ b/db-scheduler-mongo/src/test/java/com/github/kagkarlsson/scheduler/MongoSchedulerTest.java
@@ -1,0 +1,47 @@
+package com.github.kagkarlsson.scheduler;
+
+import com.github.kagkarlsson.scheduler.task.ExecutionContext;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
+import com.github.kagkarlsson.scheduler.task.helper.Tasks;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MongoSchedulerTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoSchedulerTest.class);
+
+    @RegisterExtension
+    public static EmebddedMongodbExtension mongo = new EmebddedMongodbExtension();
+
+    @Test
+    void schedulerOneTimeTest() {
+        SchedulerBuilder builder = MongoScheduler
+            .create(mongo.getMongoClient(), "database", "collection");
+
+        AtomicInteger count = new AtomicInteger();
+
+        OneTimeTask<Object> task = Tasks
+            .oneTime("task", Object.class).execute((TaskInstance<Object> inst,
+                ExecutionContext ctx) -> {
+                LOG.info("Execution");
+                count.addAndGet(1);
+            });
+
+        builder.knownTasks.add(task);
+        builder.executorService(MoreExecutors.newDirectExecutorService());
+
+        Scheduler scheduler = builder.build();
+        scheduler.schedule(task.instance("instance-1"), Instant.now());
+
+        scheduler.executeDue();
+
+        Assertions.assertThat(count).hasValue(1);
+    }
+}

--- a/db-scheduler-mongo/src/test/java/com/github/kagkarlsson/scheduler/MongoTaskRepositoryTest.java
+++ b/db-scheduler-mongo/src/test/java/com/github/kagkarlsson/scheduler/MongoTaskRepositoryTest.java
@@ -1,0 +1,669 @@
+package com.github.kagkarlsson.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.kagkarlsson.scheduler.TaskResolver.UnresolvedTask;
+import com.github.kagkarlsson.scheduler.task.Execution;
+import com.github.kagkarlsson.scheduler.task.Task;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import com.github.kagkarlsson.scheduler.utils.ExecutionBuilder;
+import com.github.kagkarlsson.scheduler.utils.TestUtils;
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoBulkWriteException;
+import com.mongodb.MongoWriteException;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.MongoIterable;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class MongoTaskRepositoryTest {
+
+    @Mock
+    private TaskResolver taskResolver;
+
+    @Mock
+    private SchedulerName schedulerName;
+
+    @Mock
+    private Serializer serializer;
+
+    private MongoTaskRepository repository;
+
+    @RegisterExtension
+    protected static EmebddedMongodbExtension emebddedMongodbExtension = new EmebddedMongodbExtension();
+
+    @BeforeEach
+    void init() throws IOException {
+        // Mock task resolver
+        Task taskResolved = Mockito.mock(Task.class);
+        Mockito.lenient().when(taskResolved.getDataClass()).thenReturn(SimpleData.class);
+        Mockito.lenient().when(taskResolver.resolve(Mockito.anyString()))
+            .thenReturn(Optional.of(taskResolved));
+
+        repository = new MongoTaskRepository(taskResolver, schedulerName, serializer,
+            "db-scheduler", "db-scheduler", emebddedMongodbExtension.getMongoClient());
+    }
+
+    @Test
+    void testCreateIfNotExistsOk() {
+        Execution execution = new ExecutionBuilder().taskName("idTask").taskInstanceId("idInstance")
+            .build();
+
+        boolean created = repository.createIfNotExists(execution);
+
+        assertThat(created).isTrue();
+
+        MongoDatabase db = this.emebddedMongodbExtension.getDb();
+
+        MongoIterable<String> collections = db.listCollectionNames();
+
+        assertThat(collections.iterator().hasNext()).isTrue();
+        String collectionName = collections.iterator().next();
+        assertThat(collectionName).isEqualTo("db-scheduler");
+
+        // Check presence in collection
+        MongoCollection<TaskEntity> collection = this.emebddedMongodbExtension.getCollection();
+
+        TaskEntity taskEntity = collection.find().first();
+
+        assertThat(taskEntity).isNotNull();
+        assertThat(taskEntity.getTaskName()).isEqualTo("idTask");
+        assertThat(taskEntity.getTaskInstance()).isEqualTo("idInstance");
+    }
+
+    @Test
+    void testCreateIfNotExistsKo() {
+        Execution execution = new ExecutionBuilder().taskName("idTask").taskInstanceId("idInstance")
+            .build();
+
+        TaskEntity taskEntityInitial = new TaskEntity();
+        taskEntityInitial.setTaskInstance("idInstance");
+        taskEntityInitial.setTaskName("idTask");
+
+        this.emebddedMongodbExtension.getCollection().insertOne(taskEntityInitial);
+
+        boolean created = repository.createIfNotExists(execution);
+        // Check that no execution is created because it already exists
+        assertThat(created).isFalse();
+    }
+
+    @Test
+    void testGetDueOk() {
+        TaskEntityBuilder builder = TaskEntityBuilder.aTaskEntity().picked(false)
+            .taskInstance("taskInstance")
+            .executionTime(Instant.now().minus(10, ChronoUnit.MINUTES));
+
+        UnresolvedTask unresolvedTask = Mockito.mock(UnresolvedTask.class);
+        Mockito.when(unresolvedTask.getTaskName()).thenReturn("unresolved");
+
+        Mockito.when(taskResolver.getUnresolved()).thenReturn(Arrays.asList(unresolvedTask));
+
+        // Insert test data in mongo
+        // | Task name  | Task instance | picked | execution time | Should be selected |
+        // |------------|---------------|--------|----------------|--------------------|
+        // | name-1     | taskInstance  | false  | now - 1m       | true               |
+        // | name-2     | taskInstance  | false  | now - 2m       | true               |
+        // | name-3     | taskInstance  | false  | now + 5m       | true               |
+        // | name-4     | taskInstance  | true   | now            | false              |
+        // | unresolved | taskInstance  | false  | now - 1m       | false              |
+        List<TaskEntity> entities = Arrays
+            .asList(builder.taskName("name-1")
+                    .executionTime(Instant.now().minus(1, ChronoUnit.MINUTES))
+                    .build(), builder.taskName("name-2")
+                    .executionTime(Instant.now().minus(2, ChronoUnit.MINUTES))
+                    .build(),
+                builder.taskName("name-3")
+                    .executionTime(Instant.now().plus(5, ChronoUnit.MINUTES))
+                    .build(),
+                builder.taskName("name-4").executionTime(Instant.now()).picked(true).build(),
+                builder.taskName("unresolved")
+                    .executionTime(Instant.now().minus(1, ChronoUnit.MINUTES)).picked(false)
+                    .build());
+
+        // Insert 4 executions, 3 of them are not picked, 2 of those are in the past
+        // 1 of them is picked and in the past
+        this.emebddedMongodbExtension.getCollection().insertMany(entities);
+
+        // ACT
+        List<Execution> executions = repository.getDue(Instant.now(), 10);
+
+        // Check that only name-1 and name-2 are ins the returned list
+        assertThat(executions).isNotEmpty();
+        assertThat(executions).hasSize(2);
+        List<String> taskName = executions.stream().map(e -> e.taskInstance)
+            .map(TaskInstance::getTaskName).collect(
+                Collectors.toList());
+
+        assertThat(taskName).containsExactly("name-2", "name-1");
+    }
+
+    @Test
+    void testScheduledExecutions() {
+        // Insert test data in mongo
+        // | Task name | Task instance | picked | execution time | Should be selected |
+        // |-----------|---------------|--------|----------------|--------------------|
+        // | task-1    | instance-1    | false  | now + 1m       | yes (order 2)      |
+        // | task-1    | instance-2    | false  | now - 1m       | yes (order 1)      |
+        // | task-1    | instance-3    | true   | now - 15m      | no                 |
+        // | task-2    | instance-1b   | false  | now + 2m       | yes (order 3)      |
+        TaskEntityBuilder builder = TaskEntityBuilder.aTaskEntity().picked(false);
+        List<TaskEntity> entities = Arrays
+            .asList(builder.taskName("task-1").taskInstance("instance-1")
+                    .executionTime(Instant.now().plus(1, ChronoUnit.MINUTES))
+                    .build(),
+                builder.taskName("task-1").taskInstance("instance-2")
+                    .executionTime(Instant.now().minus(1, ChronoUnit.MINUTES))
+                    .build(),
+                builder.taskName("task-1").picked(true).taskInstance("instance-3")
+                    .executionTime(Instant.now().minus(15, ChronoUnit.MINUTES))
+                    .build(),
+                builder.taskName("task-2").picked(false).taskInstance("instance-1b")
+                    .executionTime(Instant.now().plus(2, ChronoUnit.MINUTES))
+                    .build());
+
+        this.emebddedMongodbExtension.getCollection().insertMany(entities);
+
+        ScheduledExecutionsFilter filter = ScheduledExecutionsFilter.all().withPicked(false);
+        List<Execution> executions = new ArrayList<>();
+
+        // Call method
+        repository.getScheduledExecutions(filter, executions::add);
+
+        // Assertions
+        assertThat(executions).isNotEmpty();
+        assertThat(executions).hasSize(3);
+
+        List<String> taskInstances = executions.stream().map(e -> e.taskInstance)
+            .map(TaskInstance::getId)
+            .collect(Collectors.toList());
+
+        assertThat(taskInstances).containsExactly("instance-2", "instance-1", "instance-1b");
+    }
+
+    @Test
+    void testScheduledExecutionsWithPicekd() {
+        // Insert test data in mongo
+        // | Task name | Task instance | picked | execution time | Should be selected |
+        // |-----------|---------------|--------|----------------|--------------------|
+        // | task-1    | instance-1    | false  | now + 1m       | no                 |
+        // | task-1    | instance-2    | false  | now - 1m       | no                 |
+        // | task-1    | instance-3    | true   | now - 15m      | yes                |
+        TaskEntityBuilder builder = TaskEntityBuilder.aTaskEntity().picked(false);
+        List<TaskEntity> entities = Arrays
+            .asList(builder.taskName("task-1").taskInstance("instance-1")
+                    .executionTime(Instant.now().plus(1, ChronoUnit.MINUTES))
+                    .build(),
+                builder.taskName("task-1").taskInstance("instance-2")
+                    .executionTime(Instant.now().minus(1, ChronoUnit.MINUTES))
+                    .build(),
+                builder.taskName("task-1").picked(true).taskInstance("instance-3")
+                    .executionTime(Instant.now().minus(15, ChronoUnit.MINUTES))
+                    .build());
+
+        this.emebddedMongodbExtension.getCollection().insertMany(entities);
+
+        ScheduledExecutionsFilter filter = ScheduledExecutionsFilter.all().withPicked(true);
+        List<Execution> executions = new ArrayList<>();
+
+        // Call method
+        repository.getScheduledExecutions(filter, executions::add);
+
+        // Assertions
+        assertThat(executions).isNotEmpty();
+        assertThat(executions).hasSize(1);
+
+        List<String> taskInstances = executions.stream().map(e -> e.taskInstance)
+            .map(TaskInstance::getId)
+            .collect(Collectors.toList());
+
+        assertThat(taskInstances).containsExactly("instance-3");
+    }
+
+
+    @Test
+    void testScheduledExecutionsWithTaskName() {
+        // Insert test data in mongo
+        // | Task name | Task instance | picked | execution time | Should be selected |
+        // |-----------|---------------|--------|----------------|--------------------|
+        // | task-1    | instance-1    | false  | now + 1m       | yes (order 2)      |
+        // | task-1    | instance-2    | false  | now - 1m       | yes (order 1)      |
+        // | task-1    | instance-3    | true   | now - 15m      | no                 |
+        // | task-2    | instance-1    | false  | now - 15m      | no                 |
+        TaskEntityBuilder builder = TaskEntityBuilder.aTaskEntity().picked(false);
+        List<TaskEntity> entities = Arrays
+            .asList(builder.taskName("task-1").taskInstance("instance-1")
+                    .executionTime(Instant.now().plus(1, ChronoUnit.MINUTES))
+                    .build(),
+                builder.taskName("task-1").taskInstance("instance-2")
+                    .executionTime(Instant.now().minus(1, ChronoUnit.MINUTES))
+                    .build(),
+                builder.taskName("task-1").picked(true).taskInstance("instance-3")
+                    .executionTime(Instant.now().minus(15, ChronoUnit.MINUTES))
+                    .build(),
+                builder.taskName("task-2").picked(false).taskInstance("instance-1")
+                    .executionTime(Instant.now().minus(15, ChronoUnit.MINUTES))
+                    .build());
+
+        this.emebddedMongodbExtension.getCollection().insertMany(entities);
+        // Build method parameter for call
+        ScheduledExecutionsFilter filter = ScheduledExecutionsFilter.all().withPicked(false);
+        List<Execution> executions = new ArrayList<>();
+
+        // Call method
+        repository.getScheduledExecutions(filter, "task-1", executions::add);
+
+        // Assertions
+        assertThat(executions).isNotEmpty();
+        assertThat(executions).hasSize(2);
+
+        List<String> taskInstances = executions.stream().map(e -> e.taskInstance)
+            .map(TaskInstance::getId)
+            .collect(Collectors.toList());
+
+        assertThat(taskInstances).containsExactly("instance-2", "instance-1");
+    }
+
+    @Test
+    void testScheduledExecutionsWithTaskNameAndPicked() {
+        // Insert test data in mongo
+        // | Task name | Task instance | picked | execution time | Should be selected |
+        // |-----------|---------------|--------|----------------|--------------------|
+        // | task-1    | instance-1    | false  | now + 1m       | no                 |
+        // | task-1    | instance-2    | true   | now - 1m       | yes                |
+        // | task-2    | instance-1    | true   | now - 1m       | no                 |
+        TaskEntityBuilder builder = TaskEntityBuilder.aTaskEntity().picked(false);
+        List<TaskEntity> entities = Arrays
+            .asList(builder.taskName("task-1").taskInstance("instance-1")
+                    .executionTime(Instant.now().plus(1, ChronoUnit.MINUTES))
+                    .build(),
+                builder.taskName("task-1").picked(true).taskInstance("instance-2")
+                    .executionTime(Instant.now().minus(15, ChronoUnit.MINUTES))
+                    .build(),
+                builder.taskName("task-2").picked(true).taskInstance("instance-1")
+                    .executionTime(Instant.now().minus(15, ChronoUnit.MINUTES))
+                    .build());
+
+        this.emebddedMongodbExtension.getCollection().insertMany(entities);
+        // Build method parameter for call
+        ScheduledExecutionsFilter filter = ScheduledExecutionsFilter.all().withPicked(true);
+        List<Execution> executions = new ArrayList<>();
+
+        // Call method
+        repository.getScheduledExecutions(filter, "task-1", executions::add);
+
+        // Assertions
+        assertThat(executions).isNotEmpty();
+        assertThat(executions).hasSize(1);
+
+        List<String> taskInstances = executions.stream().map(e -> e.taskInstance)
+            .map(TaskInstance::getId)
+            .collect(Collectors.toList());
+
+        assertThat(taskInstances).containsExactly("instance-2");
+    }
+
+    @Test
+    void testRemove() {
+        // Insert test data in mongo
+        // | Task name | Task instance | version | picked | Should be deleted |
+        // |-----------|---------------|---------|--------|-------------------|
+        // | task-1    | instance-1    | 0       | false  | no                |
+        // | task-1    | instance-2    | 1       | true   | yes               |
+        TaskEntityBuilder builder = TaskEntityBuilder.aTaskEntity().taskName("task-1");
+
+        List<TaskEntity> entities = Arrays
+            .asList(builder.version(0L).picked(false).taskInstance("instance-1").build(),
+                builder.version(1).picked(true).taskInstance("instance-2").build());
+        this.emebddedMongodbExtension.getCollection().insertMany(entities);
+
+        // Parameter construction
+        Execution execution = new ExecutionBuilder().taskName("task-1").taskInstanceId("instance-2")
+            .version(1L).build();
+
+        repository.remove(execution);
+
+        List<TaskEntity> tasks = StreamSupport
+            .stream(Spliterators.spliteratorUnknownSize(
+                this.emebddedMongodbExtension.getCollection().find().iterator(),
+                Spliterator.ORDERED), false).collect(Collectors.toList());
+
+        assertThat(tasks).isNotEmpty();
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).getVersion()).isEqualTo(0);
+    }
+
+    @Test
+    void testRescheduleWithDataOk() {
+        // Insert test data in mongo
+        TaskEntity task = TaskEntityBuilder.aTaskEntity().taskName("name-1")
+            .taskInstance("taskInstance")
+            .executionTime(Instant.now()).consecutiveFailures(3).version(12)
+            .build();
+        this.emebddedMongodbExtension.getCollection().insertOne(task);
+
+        // Build method parameter
+        SimpleData dataContent = new SimpleData("content");
+
+        Execution execution = new ExecutionBuilder().taskName("name-1").version(12)
+            .taskInstanceId("taskInstance").build();
+
+        // Mock serializer
+        byte[] serializedData = dataContent.getDataContent().getBytes(StandardCharsets.UTF_8);
+        Mockito.when(serializer.serialize(dataContent))
+            .thenReturn(serializedData);
+
+        Instant nextExecutionTime = Instant.now().plus(1, ChronoUnit.HOURS);
+        Instant lastSuccess = Instant.now().minus(30, ChronoUnit.MINUTES);
+        Instant lastFailure = Instant.now().minus(1, ChronoUnit.HOURS);
+
+        boolean updated = repository
+            .reschedule(execution, nextExecutionTime, dataContent, lastSuccess, lastFailure, 4);
+
+        assertThat(updated).isTrue();
+
+        // Retrieve actual object in database
+        TaskEntity actual = this.emebddedMongodbExtension.getCollection().find().first();
+        // Test if task is correctly updated with parameters
+        assertThat(actual).isNotEqualTo(task);
+        assertThat(actual.getVersion()).isEqualTo(execution.version + 1);
+        assertThat(actual.getExecutionTime())
+            .isEqualTo(TestUtils.truncateInstant(nextExecutionTime));
+        assertThat(actual.getLastSuccess()).isEqualTo(TestUtils.truncateInstant(lastSuccess));
+        assertThat(actual.getLastFailure()).isEqualTo(TestUtils.truncateInstant(lastFailure));
+        assertThat(actual.getTaskData()).isEqualTo(serializedData);
+        assertThat(actual.getConsecutiveFailures()).isEqualTo(4);
+    }
+
+    @Test
+    void testRescheduledWithoutData() {
+        // Insert test data in mongo
+        TaskEntity task = TaskEntityBuilder.aTaskEntity().taskName("name-1")
+            .taskInstance("taskInstance")
+            .executionTime(Instant.now()).consecutiveFailures(3).version(12)
+            .build();
+        this.emebddedMongodbExtension.getCollection().insertOne(task);
+
+        // Build method parameter
+        Execution execution = new ExecutionBuilder().taskName("name-1").version(12)
+            .taskInstanceId("taskInstance").build();
+
+        Instant nextExecutionTime = Instant.now().plus(1, ChronoUnit.HOURS);
+        Instant lastSuccess = Instant.now().minus(30, ChronoUnit.MINUTES);
+        Instant lastFailure = Instant.now().minus(1, ChronoUnit.HOURS);
+
+        // Execute
+        boolean updated = repository
+            .reschedule(execution, nextExecutionTime, lastSuccess, lastFailure, 4);
+
+        assertThat(updated).isTrue();
+    }
+
+    @Test
+    void testNotRescheduled() {
+        // Build method parameter
+        Execution execution = new ExecutionBuilder().taskName("name-1").version(12)
+            .taskInstanceId("taskInstance").build();
+
+        Instant nextExecutionTime = Instant.now().plus(1, ChronoUnit.HOURS);
+        Instant lastSuccess = Instant.now().minus(30, ChronoUnit.MINUTES);
+        Instant lastFailure = Instant.now().minus(1, ChronoUnit.HOURS);
+
+        // Execute
+        boolean updated = repository
+            .reschedule(execution, nextExecutionTime, lastSuccess, lastFailure, 4);
+
+        assertThat(updated).isFalse();
+    }
+
+    @Test
+    void testPickedFound() {
+        // Insert test data in mongo
+        int version = 0;
+        TaskEntity task = TaskEntityBuilder.aTaskEntity().taskName("name-1")
+            .taskInstance("taskInstance").executionTime(Instant.now())
+            .picked(false).version(version).taskData("test".getBytes()).build();
+        this.emebddedMongodbExtension.getCollection().insertOne(task);
+
+        // Build method parameter
+        Execution execution = new ExecutionBuilder().taskName("name-1").version(version)
+            .taskInstanceId("taskInstance").build();
+
+        Instant timePicked = Instant.now();
+
+        SimpleData simpleData = new SimpleData("data");
+        Mockito.when(serializer.deserialize(Mockito.eq(SimpleData.class), Mockito.any()))
+            .thenReturn(simpleData);
+
+
+        Mockito.when(schedulerName.getName()).thenReturn("schedulerName");
+        Optional<Execution> executionOpt = repository.pick(execution, timePicked);
+
+        assertThat(executionOpt).isPresent();
+        assertThat(executionOpt.get().picked).isTrue();
+        assertThat(executionOpt.get().pickedBy).isEqualTo("schedulerName");
+        assertThat(executionOpt.get().lastHeartbeat)
+            .isEqualTo(timePicked.truncatedTo(ChronoUnit.MILLIS));
+        assertThat(executionOpt.get().version).isEqualTo(version + 1);
+
+        assertThat(executionOpt.get().taskInstance.getData()).isNotNull();
+        assertThat(executionOpt.get().taskInstance.getData()).isInstanceOf(SimpleData.class);
+    }
+
+    @Test
+    void testPickedNotFound() {
+        // Build method parameter
+        Execution execution = new ExecutionBuilder().taskName("name-1").version(0)
+            .taskInstanceId("taskInstance").build();
+
+        Mockito.when(schedulerName.getName()).thenReturn("schedulerName");
+        Optional<Execution> executionOpt = repository.pick(execution, Instant.now());
+
+        assertThat(executionOpt).isNotPresent();
+    }
+
+    @Test
+    void testGetDeadExecutions() {
+        TaskEntityBuilder shouldBePickedBuilder = TaskEntityBuilder.aTaskEntity().picked(true)
+            .taskName("task-1")
+            .lastHeartbeat(Instant.now().minus(1, ChronoUnit.HOURS));
+
+        TaskEntityBuilder shouldNotBePickedBuilder = TaskEntityBuilder.aTaskEntity().picked(true)
+            .taskName("task-1")
+            .lastHeartbeat(Instant.now().minus(10, ChronoUnit.MINUTES));
+
+        // Insert test data in mongo
+        // | Task name | Task instance | picked | execution time | Should be selected | Order |
+        // |-----------|---------------|--------|----------------|--------------------|-------|
+        // | task-1    | instance-1    | true   | now - 1h       | yes                | 2     |
+        // | task-1    | instance-2    | true   | now - 2h       | yes                | 1     |
+        // | task-1    | instance-3    | true   | now - 10m      | no                 |       |
+        // | task-1    | instance-4    | false  | now - 1h       | no                 |       |
+        List<TaskEntity> entities = Arrays
+            .asList(shouldBePickedBuilder.taskInstance("instance-1").build(),
+                shouldBePickedBuilder.taskInstance("instance-2")
+                    .lastHeartbeat(Instant.now().minus(2, ChronoUnit.HOURS))
+                    .build(),
+                shouldNotBePickedBuilder.taskInstance("instance-3").build(),
+                shouldNotBePickedBuilder.taskInstance("instance-4").picked(false)
+                    .lastHeartbeat(Instant.now().minus(1, ChronoUnit.HOURS))
+                    .build());
+
+        this.emebddedMongodbExtension.getCollection().insertMany(entities);
+
+        // Act
+        Instant olderThan = Instant.now().minus(30, ChronoUnit.MINUTES);
+        List<Execution> actual = repository.getDeadExecutions(olderThan);
+
+        assertThat(actual).hasSize(2);
+        assertThat(actual.stream().map(e -> e.taskInstance).map(TaskInstance::getId))
+            .containsExactly("instance-2", "instance-1");
+    }
+
+    @Test
+    void testUpdateHeartbeat() {
+        // Build entity to insert in databse
+        Instant initialHeartBeat = Instant.now()
+            .minus(1, ChronoUnit.HOURS);
+        TaskEntity task = TaskEntityBuilder.aTaskEntity().taskName("task-1")
+            .taskInstance("instance-1").version(12)
+            .lastHeartbeat(initialHeartBeat).build();
+
+        this.emebddedMongodbExtension.getCollection().insertOne(task);
+
+        // Build arguments
+        Execution execution = new ExecutionBuilder().taskName("task-1").taskInstanceId("instance-1")
+            .version(12).build();
+        Instant newHeartbeat = Instant.now();
+
+        repository.updateHeartbeat(execution, newHeartbeat);
+
+        TaskEntity actual = this.emebddedMongodbExtension.getCollection().find().first();
+        assertThat(actual).isNotEqualTo(task);
+        assertThat(actual.getLastHeartbeat()).isEqualTo(TestUtils.truncateInstant(newHeartbeat));
+    }
+
+    @Test
+    void testGetExecutionsFailingLongerThan() {
+        TaskEntityBuilder taskBuilder = TaskEntityBuilder.aTaskEntity().taskName("task-1")
+            .lastFailure(Instant.now());
+
+        // Insert test data in mongo
+        // | Task name | Task instance | last hearbeat | last failure | Should be selected |
+        // |-----------|---------------|---------------|--------------|--------------------|
+        // | task-1    | instance-1    | null          | now          | yes                |
+        // | task-1    | instance-2    | now - 1h      | now          | yes                |
+        // | task-1    | instance-3    | now - 10m     | now          | no                 |
+        // | task-1    | instance-4    | now - 1h      | null         | no                 |
+        List<TaskEntity> entities = Arrays.asList(taskBuilder.taskInstance("instance-1").build(),
+            taskBuilder.taskInstance("instance-2")
+                .lastSuccess(Instant.now().minus(1, ChronoUnit.HOURS)).build(),
+            taskBuilder.taskInstance("instance-3")
+                .lastSuccess(Instant.now().minus(10, ChronoUnit.MINUTES))
+                .build(),
+            taskBuilder.taskInstance("instance-4")
+                .lastSuccess(Instant.now().minus(1, ChronoUnit.HOURS))
+                .lastFailure(null).build());
+
+        this.emebddedMongodbExtension.getCollection().insertMany(entities);
+
+        // Build argument
+        Duration interval = Duration.ofMinutes(30);
+        List<Execution> actual = repository.getExecutionsFailingLongerThan(interval);
+
+        assertThat(actual).hasSize(2);
+        assertThat(actual.stream().map(e -> e.taskInstance).map(TaskInstance::getId))
+            .containsExactlyInAnyOrder("instance-1", "instance-2");
+    }
+
+    @Test
+    void testGetExecutionFound() {
+        // Insert data in database
+        TaskEntity entity = TaskEntityBuilder.aTaskEntity().taskName("task-1")
+            .taskInstance("instance-1").build();
+
+        this.emebddedMongodbExtension.getCollection().insertOne(entity);
+
+        // Call method
+        Optional<Execution> actual = repository.getExecution("task-1", "instance-1");
+
+        assertThat(actual).isPresent();
+    }
+
+    @Test
+    void testGetExecutionNotFound() {
+        // Call method
+        Optional<Execution> actual = repository.getExecution("task-1", "instance-1");
+
+        assertThat(actual).isNotPresent();
+    }
+
+    @Test
+    void testRemoveExecutions() {
+        TaskEntityBuilder builder = TaskEntityBuilder.aTaskEntity().taskName("task-1");
+
+        List<TaskEntity> entities = Arrays.asList(builder.taskInstance("instance-1").build(),
+            builder.taskInstance("instance-2").build(), builder.taskInstance("instance-3").build(),
+            builder.taskName("task-2").taskInstance("instance-1").build());
+        this.emebddedMongodbExtension.getCollection().insertMany(entities);
+
+        // Call method
+        int deletedCount = repository.removeExecutions("task-1");
+
+        assertThat(deletedCount).isEqualTo(3);
+
+        List<TaskEntity> actual = StreamSupport
+            .stream(this.emebddedMongodbExtension.getCollection().find().spliterator(), false)
+            .collect(Collectors.toList());
+
+        assertThat(actual).hasSize(1);
+        assertThat(actual.get(0).getTaskName()).isEqualTo("task-2");
+    }
+
+    @Test
+    void testIndexUniqueness() {
+        TaskEntityBuilder builder = TaskEntityBuilder.aTaskEntity().taskInstance("instance")
+            .taskName("task");
+
+        List<TaskEntity> entities = Arrays.asList(builder.build(), builder.build());
+        MongoBulkWriteException bulkException = Assertions
+            .assertThrows(MongoBulkWriteException.class,
+                () -> this.emebddedMongodbExtension.getCollection().insertMany(entities));
+
+        MongoWriteException exception = Assertions
+            .assertThrows(MongoWriteException.class,
+                () -> this.emebddedMongodbExtension.getCollection().insertOne(builder.build()));
+
+        List<TaskEntity> actualEntities = StreamSupport
+            .stream(this.emebddedMongodbExtension.getCollection().find().spliterator(), false)
+            .collect(Collectors.toList());
+
+        // Check exception
+        ErrorCategory category = ErrorCategory.fromErrorCode(exception.getCode());
+        assertThat(category).isEqualTo(ErrorCategory.DUPLICATE_KEY);
+
+        // Check that only one document was inserted
+        assertThat(bulkException.getWriteResult().getInsertedCount()).isEqualTo(1);
+        assertThat(actualEntities).hasSize(1);
+    }
+
+    /**
+     * Simple object to hold test data
+     */
+    private class SimpleData {
+
+        private String dataContent;
+
+        public String getDataContent() {
+            return dataContent;
+        }
+
+        public void setDataContent(String dataContent) {
+            this.dataContent = dataContent;
+        }
+
+        public SimpleData(String dataContent) {
+            this.dataContent = dataContent;
+        }
+    }
+}

--- a/db-scheduler-mongo/src/test/java/com/github/kagkarlsson/scheduler/TaskEntityBuilder.java
+++ b/db-scheduler-mongo/src/test/java/com/github/kagkarlsson/scheduler/TaskEntityBuilder.java
@@ -1,0 +1,96 @@
+package com.github.kagkarlsson.scheduler;
+
+import java.time.Instant;
+
+public final class TaskEntityBuilder {
+
+    private String taskName;
+    private String taskInstance;
+    private byte[] taskData;
+    private Instant executionTime;
+    private boolean picked;
+    private String pickedBy;
+    private Instant lastSuccess;
+    private Instant lastFailure;
+    private int consecutiveFailures;
+    private Instant lastHeartbeat;
+    private long version;
+
+    private TaskEntityBuilder() {
+    }
+
+    public static TaskEntityBuilder aTaskEntity() {
+        return new TaskEntityBuilder();
+    }
+
+    public TaskEntityBuilder taskName(String taskName) {
+        this.taskName = taskName;
+        return this;
+    }
+
+    public TaskEntityBuilder taskInstance(String taskInstance) {
+        this.taskInstance = taskInstance;
+        return this;
+    }
+
+    public TaskEntityBuilder taskData(byte[] taskData) {
+        this.taskData = taskData;
+        return this;
+    }
+
+    public TaskEntityBuilder executionTime(Instant executionTime) {
+        this.executionTime = executionTime;
+        return this;
+    }
+
+    public TaskEntityBuilder picked(boolean picked) {
+        this.picked = picked;
+        return this;
+    }
+
+    public TaskEntityBuilder pickedBy(String pickedBy) {
+        this.pickedBy = pickedBy;
+        return this;
+    }
+
+    public TaskEntityBuilder lastSuccess(Instant lastSuccess) {
+        this.lastSuccess = lastSuccess;
+        return this;
+    }
+
+    public TaskEntityBuilder lastFailure(Instant lastFailure) {
+        this.lastFailure = lastFailure;
+        return this;
+    }
+
+    public TaskEntityBuilder consecutiveFailures(int consecutiveFailures) {
+        this.consecutiveFailures = consecutiveFailures;
+        return this;
+    }
+
+    public TaskEntityBuilder lastHeartbeat(Instant lastHeartbeat) {
+        this.lastHeartbeat = lastHeartbeat;
+        return this;
+    }
+
+    public TaskEntityBuilder version(long version) {
+        this.version = version;
+        return this;
+    }
+
+    public TaskEntity build() {
+        TaskEntity taskEntity = new TaskEntity();
+        taskEntity.setTaskName(taskName);
+        taskEntity.setTaskInstance(taskInstance);
+        taskEntity.setTaskData(taskData);
+        taskEntity.setExecutionTime(executionTime);
+        taskEntity.setPicked(picked);
+        taskEntity.setPickedBy(pickedBy);
+        taskEntity.setLastSuccess(lastSuccess);
+        taskEntity.setLastFailure(lastFailure);
+        taskEntity.setConsecutiveFailures(consecutiveFailures);
+        taskEntity.setLastHeartbeat(lastHeartbeat);
+        taskEntity.setVersion(version);
+        return taskEntity;
+    }
+}

--- a/db-scheduler-mongo/src/test/java/com/github/kagkarlsson/scheduler/example/MongoDbSimpleTaskMain.java
+++ b/db-scheduler-mongo/src/test/java/com/github/kagkarlsson/scheduler/example/MongoDbSimpleTaskMain.java
@@ -1,0 +1,87 @@
+package com.github.kagkarlsson.scheduler.example;
+
+import com.github.kagkarlsson.scheduler.MongoScheduler;
+import com.github.kagkarlsson.scheduler.MongoSchedulerBuilder;
+import com.github.kagkarlsson.scheduler.MongoTaskRepository;
+import com.github.kagkarlsson.scheduler.Scheduler;
+import com.github.kagkarlsson.scheduler.SchedulerBuilder;
+import com.github.kagkarlsson.scheduler.task.ExecutionContext;
+import com.github.kagkarlsson.scheduler.task.Task;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
+import com.github.kagkarlsson.scheduler.task.helper.Tasks;
+import com.github.kagkarlsson.scheduler.utils.TestUtils;
+import com.github.kagkarlsson.scheduler.utils.TestUtils.MongoTools;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MongoDbSimpleTaskMain {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoTaskRepository.class);
+
+    public static void main(String[] args) throws IOException {
+        LOG.info("Starting demo app ...");
+        MongoTools mongoTools = TestUtils.startEmbeddedMongo();
+
+        // Simple Task
+        OneTimeTask<SampleTaskData> oneTimeTask = Tasks.oneTime("one-time", SampleTaskData.class)
+            .execute((TaskInstance<SampleTaskData> inst, ExecutionContext ctx) -> {
+                LOG.info("Trigger of execution {}, with data {}", ctx.getExecution(), inst);
+            });
+
+        // Instantiation of mongodb based scheduler
+        List<Task<?>> knownTasks = new ArrayList<>();
+        // Register the one time task to scheduler
+        knownTasks.add(oneTimeTask);
+
+        SchedulerBuilder builder = MongoScheduler
+            .create(mongoTools.getClient(), "scheduler-database", "scheduler-collection",
+                knownTasks).pollingInterval(Duration.ofSeconds(5));
+        Scheduler scheduler = builder.build();
+        // Start scheduler
+        scheduler.start();
+        // Start one time task
+        scheduler.schedule(oneTimeTask.instance("test-instance"),
+            Instant.now().plus(5, ChronoUnit.SECONDS));
+
+        Document task = mongoTools.getClient().getDatabase("scheduler-database")
+            .getCollection("scheduler-collection").find().first();
+        LOG.info("Task found {}", task);
+
+        // Proper shutdown of the scheduler
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            LOG.info("Received shutdown signal.");
+            scheduler.stop();
+            mongoTools.getMongodExecutable().stop();
+            mongoTools.getMongodProcess().stop();
+        }));
+
+    }
+
+    public static class SampleTaskData {
+
+        private String taskContent;
+
+        public String getTaskContent() {
+            return taskContent;
+        }
+
+        public void setTaskContent(String taskContent) {
+            this.taskContent = taskContent;
+        }
+
+        @Override
+        public String toString() {
+            return "SampleTaskData{" +
+                "taskContent='" + taskContent + '\'' +
+                '}';
+        }
+    }
+}

--- a/db-scheduler-mongo/src/test/java/com/github/kagkarlsson/scheduler/utils/ExecutionBuilder.java
+++ b/db-scheduler-mongo/src/test/java/com/github/kagkarlsson/scheduler/utils/ExecutionBuilder.java
@@ -1,0 +1,87 @@
+package com.github.kagkarlsson.scheduler.utils;
+
+import com.github.kagkarlsson.scheduler.task.Execution;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import java.time.Instant;
+import java.util.function.Supplier;
+
+public class ExecutionBuilder {
+
+    private Instant executionTime;
+    private Instant lastSuccess;
+    private Instant lastFailure;
+    private Instant lastHeartBeat;
+    private byte data[] = {};
+    private String taskName;
+    private String taskInstanceId;
+    private boolean picked;
+    private String pickedBy;
+    private int consecutiveFailures;
+    private long version;
+
+    public ExecutionBuilder executionTime(Instant executionTime) {
+        this.executionTime = executionTime;
+        return this;
+    }
+
+    public ExecutionBuilder lastSuccess(Instant lastSuccess) {
+        this.lastSuccess = lastSuccess;
+        return this;
+    }
+
+    public ExecutionBuilder lastFailure(Instant lastFailure) {
+        this.lastFailure = lastFailure;
+        return this;
+    }
+
+    public ExecutionBuilder lastHeartBeat(Instant lastHeartBeat) {
+        this.lastHeartBeat = lastHeartBeat;
+        return this;
+    }
+
+    public ExecutionBuilder data(byte[] data) {
+        this.data = data;
+        return this;
+    }
+
+    public ExecutionBuilder taskName(String taskName) {
+        this.taskName = taskName;
+        return this;
+    }
+
+    public ExecutionBuilder taskInstanceId(String taskInstanceId) {
+        this.taskInstanceId = taskInstanceId;
+        return this;
+    }
+
+    public ExecutionBuilder picked(boolean picked) {
+        this.picked = picked;
+        return this;
+    }
+
+    public ExecutionBuilder pickedBy(String pickedBy) {
+        this.pickedBy = pickedBy;
+        return this;
+    }
+
+    public ExecutionBuilder consecutiveFailures(int consecutiveFailures) {
+        this.consecutiveFailures = consecutiveFailures;
+        return this;
+    }
+
+    public ExecutionBuilder version(long version) {
+        this.version = version;
+        return this;
+    }
+
+    public ExecutionBuilder() {
+
+    }
+
+    public Execution build() {
+        Supplier dataSupplier = () -> data;
+        TaskInstance taskInstance = new TaskInstance(taskName, taskInstanceId, dataSupplier);
+        return new Execution(executionTime, taskInstance, picked, pickedBy, lastSuccess,
+            lastFailure, consecutiveFailures, lastHeartBeat, version);
+    }
+}

--- a/db-scheduler-mongo/src/test/java/com/github/kagkarlsson/scheduler/utils/TestUtils.java
+++ b/db-scheduler-mongo/src/test/java/com/github/kagkarlsson/scheduler/utils/TestUtils.java
@@ -1,0 +1,77 @@
+package com.github.kagkarlsson.scheduler.utils;
+
+import com.mongodb.MongoClient;
+import de.flapdoodle.embed.mongo.MongodExecutable;
+import de.flapdoodle.embed.mongo.MongodProcess;
+import de.flapdoodle.embed.mongo.MongodStarter;
+import de.flapdoodle.embed.mongo.config.MongodConfig;
+import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.process.runtime.Network;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class TestUtils {
+
+    public static class MongoTools {
+
+        MongoClient client;
+        MongodExecutable mongodExecutable;
+        MongodProcess mongodProcess;
+
+        public MongoClient getClient() {
+            return client;
+        }
+
+        public void setClient(MongoClient client) {
+            this.client = client;
+        }
+
+        public MongodExecutable getMongodExecutable() {
+            return mongodExecutable;
+        }
+
+        public void setMongodExecutable(MongodExecutable mongodExecutable) {
+            this.mongodExecutable = mongodExecutable;
+        }
+
+        public MongodProcess getMongodProcess() {
+            return mongodProcess;
+        }
+
+        public void setMongodProcess(MongodProcess mongodProcess) {
+            this.mongodProcess = mongodProcess;
+        }
+    }
+
+    public static MongoTools startEmbeddedMongo() throws IOException {
+        MongodStarter starter = MongodStarter.getDefaultInstance();
+
+        int port = Network.getFreeServerPort();
+        MongodConfig mongodConfig = MongodConfig.builder()
+            .version(Version.Main.PRODUCTION)
+            .net(new Net(port, Network.localhostIsIPv6()))
+            .build();
+        MongodExecutable mongodExecutable = starter.prepare(mongodConfig);
+        MongodProcess mongod = mongodExecutable.start();
+
+        MongoClient mongoClient = new MongoClient("localhost", port);
+
+        MongoTools mongoTools = new MongoTools();
+        mongoTools.setClient(mongoClient);
+        mongoTools.setMongodExecutable(mongodExecutable);
+        mongoTools.setMongodProcess(mongod);
+
+        return mongoTools;
+    }
+
+    public static Instant truncateInstant(Instant instant) {
+        return instant.truncatedTo(ChronoUnit.MILLIS);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,8 @@
 		<module>db-scheduler</module>
 		<module>db-scheduler-boot-starter</module>
         <module>examples</module>
-    </modules>
+    <module>db-scheduler-mongo</module>
+  </modules>
 
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Hi,

I developped a specific module to implement a TaskRepository for MongoDB.
It relies on atomic operations, so that concurrency is handled. An index also ensures that tasks are unique.

I tried to keep things as separated as possible from the existing codebase. The only code alteration is in the parent pom.xml.

Thank you for your comments and for your great work.