### PR TITLE
Add some toStrings to 

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/CompletionHandler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/CompletionHandler.java
@@ -49,6 +49,12 @@ public interface CompletionHandler<T> {
             LOG.debug("Rescheduling task {} to {}", executionComplete.getExecution().taskInstance, nextExecution);
             executionOperations.reschedule(executionComplete, nextExecution);
         }
+
+        @Override
+        public String toString() {
+            return "OnCompleteReschedule with " + schedule;
+        }
+
     }
 
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/Task.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/Task.java
@@ -56,7 +56,7 @@ public abstract class Task<T> implements ExecutionHandler<T> {
 
     @Override
     public String toString() {
-        return "Task " + "task=" + getName();
+        return "Task " + "name=" + getName();
     }
 
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/CustomTask.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/CustomTask.java
@@ -36,4 +36,9 @@ public abstract class CustomTask<T> extends Task<T> implements OnStartup {
                 scheduleOnStartup.apply(scheduler, clock, this);
         }
     }
+
+    @Override
+    public String toString() {
+        return "CustomTask name=" + getName();
+    }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/OneTimeTask.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/OneTimeTask.java
@@ -40,4 +40,9 @@ public abstract class OneTimeTask<T> extends Task<T> {
 
     public abstract void executeOnce(TaskInstance<T> taskInstance, ExecutionContext executionContext);
 
+    @Override
+    public String toString() {
+        return "OneTimeTask name=" + getName();
+    }
+
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTask.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTask.java
@@ -57,4 +57,9 @@ public abstract class RecurringTask<T> extends Task<T> implements OnStartup {
 
     public abstract void executeRecurringly(TaskInstance<T> taskInstance, ExecutionContext executionContext);
 
+    @Override
+    public String toString() {
+        return "RecurringTask name=" + getName() + ", scheduled using " + onComplete;
+    }
+
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTask.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTask.java
@@ -59,7 +59,7 @@ public abstract class RecurringTask<T> extends Task<T> implements OnStartup {
 
     @Override
     public String toString() {
-        return "RecurringTask name=" + getName() + ", scheduled using " + onComplete;
+        return "RecurringTask name=" + getName() + ", onComplete=" + onComplete;
     }
 
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/CronSchedule.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/CronSchedule.java
@@ -36,10 +36,12 @@ import java.util.Optional;
 public class CronSchedule implements Schedule {
 
     private static final Logger LOG = LoggerFactory.getLogger(CronSchedule.class);
-    private final ExecutionTime cronExecutionTime;
+    private final String pattern;
     private final ZoneId zoneId;
+    private final ExecutionTime cronExecutionTime;
 
     public CronSchedule(String pattern, ZoneId zoneId) {
+        this.pattern = pattern;
         CronParser parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.SPRING));
         Cron cron = parser.parse(pattern);
         this.cronExecutionTime = ExecutionTime.forCron(cron);
@@ -70,5 +72,10 @@ public class CronSchedule implements Schedule {
     @Override
     public boolean isDeterministic() {
         return true;
+    }
+
+    @Override
+    public String toString() {
+        return "CronSchedule pattern=" + pattern + ", zone=" + zoneId;
     }
 }


### PR DESCRIPTION
Small contribution. Basically adding some more informative toString implementations to:
- `CronSchedule`, because it was missing. Already present in Daily and FixedDelay.
- Task implementations: adds the _type_ of task (RecurringTask, OneTimeTask etc), and also try to output some information about rescheduling from RecurringTask.
- Keeping the toString in `Task` to have a base toString for custom derivations from Task. Small fix from `task=` to `name=` to align with what seemed to be the existing style/format.

As the toString implementation for RecurringTask may seem a little... assuming perhaps (?), I am open to suggestions on how to better structure it, if you see any problems with it.

A bit on the side, but I also wanted to bring [ThreeTen Extra](https://www.threeten.org/threeten-extra/) and its [AmountFormats](https://www.threeten.org/threeten-extra/apidocs/org.threeten.extra/org/threeten/extra/AmountFormats.html) to your attention for some more human-readable outputting of `Duration`. Small, focused and stable library. I assume it could be easily shaded as you already do with cronutils. You would need to include the `/org/threeten/extra/wordbased_en.properties` resource. I can open up a separate issue for it if you want, but wanted to mention it here in the context of more informative toStrings and logging.