### PR TITLE
Spring Boot Devtools-friendly default task data serializer

### DIFF
--- a/db-scheduler-boot-starter/pom.xml
+++ b/db-scheduler-boot-starter/pom.xml
@@ -30,6 +30,10 @@
         <!-- Spring dependencies -->
         <dependency>
             <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Default java serializer does not work correctly with Spring Boot Devtools. During deserialization `ClassCastException`s are thrown. That is because `ObjectInputStream` does not use correct class loader (classloaders in devtools are more complicated). See: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#using-boot-devtools-known-restart-limitations