### PR TITLE
Adding the ability to trigger task run manually.

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/DueExecutionsBatch.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/DueExecutionsBatch.java
@@ -15,27 +15,39 @@
  */
 package com.github.kagkarlsson.scheduler;
 
+import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
+
 
 class DueExecutionsBatch {
 
     private static final Logger LOG = LoggerFactory.getLogger(DueExecutionsBatch.class);
     private final int generationNumber;
     private final AtomicInteger executionsLeftInBatch;
+    private final CompletableFuture<BatchCompletionResult> onBatchComplete;
     private int threadpoolSize;
     private boolean possiblyMoreExecutionsInDb;
     private boolean stale = false;
     private boolean triggeredExecuteDue;
 
-    public DueExecutionsBatch(int threadpoolSize, int generationNumber, int executionsAdded, boolean possiblyMoreExecutionsInDb) {
+    public DueExecutionsBatch(int threadpoolSize, int generationNumber, int executionsAdded,
+        boolean possiblyMoreExecutionsInDb) {
+        this(threadpoolSize, generationNumber, executionsAdded, possiblyMoreExecutionsInDb, new CompletableFuture<>());
+    }
+
+    public DueExecutionsBatch(int threadpoolSize, int generationNumber, int executionsAdded,
+        boolean possiblyMoreExecutionsInDb, CompletableFuture<BatchCompletionResult> onBatchComplete) {
         this.threadpoolSize = threadpoolSize;
         this.generationNumber = generationNumber;
         this.possiblyMoreExecutionsInDb = possiblyMoreExecutionsInDb;
         this.executionsLeftInBatch = new AtomicInteger(executionsAdded);
+        this.onBatchComplete = onBatchComplete;
+        if (this.executionsLeftInBatch.get() == 0) {
+            this.onBatchComplete.complete(new BatchCompletionResult(false));
+        }
     }
 
     public void markBatchAsStale() {
@@ -50,15 +62,19 @@ class DueExecutionsBatch {
         // May be called concurrently by multiple threads
         executionsLeftInBatch.decrementAndGet();
 
-        LOG.trace("Batch state: generationNumber:{}, stale:{}, triggeredExecuteDue:{}, possiblyMoreExecutionsInDb:{}, executionsLeftInBatch:{}, ratio-trigger:{}",
-                generationNumber, stale, triggeredExecuteDue, possiblyMoreExecutionsInDb, executionsLeftInBatch.get(), (threadpoolSize * Scheduler.TRIGGER_NEXT_BATCH_WHEN_AVAILABLE_THREADS_RATIO));
-        if (!stale
-                && !triggeredExecuteDue
-                && possiblyMoreExecutionsInDb
-                && executionsLeftInBatch.get() <= (threadpoolSize * Scheduler.TRIGGER_NEXT_BATCH_WHEN_AVAILABLE_THREADS_RATIO)) {
+        LOG.trace(
+            "Batch state: generationNumber:{}, stale:{}, triggeredExecuteDue:{}, possiblyMoreExecutionsInDb:{}, executionsLeftInBatch:{}, ratio-trigger:{}",
+            generationNumber, stale, triggeredExecuteDue, possiblyMoreExecutionsInDb, executionsLeftInBatch.get(),
+            (threadpoolSize * Scheduler.TRIGGER_NEXT_BATCH_WHEN_AVAILABLE_THREADS_RATIO));
+        if (!stale && !triggeredExecuteDue && possiblyMoreExecutionsInDb && executionsLeftInBatch.get() <= (
+            threadpoolSize * Scheduler.TRIGGER_NEXT_BATCH_WHEN_AVAILABLE_THREADS_RATIO)) {
             LOG.trace("Triggering check for new batch.");
             triggerCheckForNewBatch.run();
             triggeredExecuteDue = true;
+        }
+
+        if (executionsLeftInBatch.get() == 0) {
+            onBatchComplete.complete(new BatchCompletionResult(possiblyMoreExecutionsInDb));
         }
     }
 
@@ -68,5 +84,17 @@ class DueExecutionsBatch {
 
     public int getGenerationNumber() {
         return generationNumber;
+    }
+
+    public static class BatchCompletionResult {
+        private final boolean possiblyMoreExecutionsInDb;
+
+        BatchCompletionResult(boolean possiblyMoreExecutionsInDb) {
+            this.possiblyMoreExecutionsInDb = possiblyMoreExecutionsInDb;
+        }
+
+        public boolean possiblyMoreExecutionsInDb() {
+            return possiblyMoreExecutionsInDb;
+        }
     }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
@@ -68,6 +68,7 @@ public class SchedulerBuilder {
     protected boolean commitWhenAutocommitDisabled = false;
     protected LogLevel logLevel = DEFAULT_FAILURE_LOG_LEVEL;
     protected boolean logStackTrace = LOG_STACK_TRACE_ON_FAILURE;
+    private boolean startConsumingTasksOnStart = true;
 
     public SchedulerBuilder(DataSource dataSource, List<Task<?>> knownTasks) {
         this.dataSource = dataSource;
@@ -148,6 +149,11 @@ public class SchedulerBuilder {
         return this;
     }
 
+    public SchedulerBuilder disableStartConsumingTasksOnStart(){
+        this.startConsumingTasksOnStart = false;
+        return this;
+    }
+
     public SchedulerBuilder deleteUnresolvedAfter(Duration deleteAfter) {
         this.deleteUnresolvedAfter = deleteAfter;
         return this;
@@ -205,6 +211,6 @@ public class SchedulerBuilder {
             schedulerName.getName());
         return new Scheduler(clock, schedulerTaskRepository, clientTaskRepository, taskResolver, executorThreads, candidateExecutorService,
             schedulerName, waiter, heartbeatInterval, enableImmediateExecution, statsRegistry, pollingLimit,
-            deleteUnresolvedAfter, shutdownMaxWait, logLevel, logStackTrace, startTasks);
+            deleteUnresolvedAfter, shutdownMaxWait, logLevel, logStackTrace, startTasks, startConsumingTasksOnStart);
     }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/ManualScheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/ManualScheduler.java
@@ -31,8 +31,13 @@ public class ManualScheduler extends Scheduler {
     private static final Logger LOG = LoggerFactory.getLogger(ManualScheduler.class);
     private final SettableClock clock;
 
-    ManualScheduler(SettableClock clock, TaskRepository schedulerTaskRepository, TaskRepository clientTaskRepository, TaskResolver taskResolver, int maxThreads, ExecutorService executorService, SchedulerName schedulerName, Waiter waiter, Duration heartbeatInterval, boolean executeImmediately, StatsRegistry statsRegistry, int pollingLimit, Duration deleteUnresolvedAfter, LogLevel logLevel, boolean logStackTrace, List<OnStartup> onStartup) {
-        super(clock, schedulerTaskRepository, clientTaskRepository, taskResolver, maxThreads, executorService, schedulerName, waiter, heartbeatInterval, executeImmediately, statsRegistry, pollingLimit, deleteUnresolvedAfter, Duration.ZERO, logLevel, logStackTrace, onStartup);
+    ManualScheduler(SettableClock clock, TaskRepository schedulerTaskRepository, TaskRepository clientTaskRepository,
+        TaskResolver taskResolver, int maxThreads, ExecutorService executorService, SchedulerName schedulerName, Waiter waiter, Duration heartbeatInterval, boolean executeImmediately, StatsRegistry statsRegistry,
+        int pollingLimit, Duration deleteUnresolvedAfter, LogLevel logLevel, boolean logStackTrace,
+        List<OnStartup> onStartup, boolean startConsumingTasksOnStart) {
+
+        super(clock, schedulerTaskRepository, clientTaskRepository, taskResolver, maxThreads, executorService, schedulerName, waiter, heartbeatInterval, executeImmediately, statsRegistry, pollingLimit, deleteUnresolvedAfter, Duration.ZERO, logLevel, logStackTrace, onStartup,
+            startConsumingTasksOnStart);
         this.clock = clock;
     }
 
@@ -49,7 +54,7 @@ public class ManualScheduler extends Scheduler {
     }
 
     public void runAnyDueExecutions() {
-        super.executeDue();
+        super.executeDueTasks();
     }
 
     public void runDeadExecutionDetection() {
@@ -57,7 +62,7 @@ public class ManualScheduler extends Scheduler {
     }
 
 
-    public void start() {
+    public void startConsumer() {
         LOG.info("Starting manual scheduler. Executing on-startup tasks.");
         executeOnStartup();
     }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
@@ -70,12 +70,12 @@ public class TestHelper {
             final JdbcTaskRepository schedulerTaskRepository = new JdbcTaskRepository(dataSource, true, new DefaultJdbcCustomization(), tableName, taskResolver, new SchedulerName.Fixed("manual"), serializer);
             final JdbcTaskRepository clientTaskRepository = new JdbcTaskRepository(dataSource, commitWhenAutocommitDisabled, new DefaultJdbcCustomization(), tableName, taskResolver, new SchedulerName.Fixed("manual"), serializer);
 
-            return new ManualScheduler(clock, schedulerTaskRepository, clientTaskRepository, taskResolver, executorThreads, new DirectExecutorService(), schedulerName, waiter, heartbeatInterval, enableImmediateExecution, statsRegistry, pollingLimit, deleteUnresolvedAfter, LogLevel.DEBUG, true, startTasks);
+            return new ManualScheduler(clock, schedulerTaskRepository, clientTaskRepository, taskResolver, executorThreads, new DirectExecutorService(), schedulerName, waiter, heartbeatInterval, enableImmediateExecution, statsRegistry, pollingLimit, deleteUnresolvedAfter, LogLevel.DEBUG, true, startTasks, true);
         }
 
         public ManualScheduler start() {
             ManualScheduler scheduler = build();
-            scheduler.start();
+            scheduler.startConsumer();
             return scheduler;
         }
     }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/ClusterTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/ClusterTest.java
@@ -52,8 +52,8 @@ public class ClusterTest {
             final Scheduler scheduler2 = createScheduler("scheduler2", task, stats);
 
             stopScheduler.register(scheduler1, scheduler2);
-            scheduler1.start();
-            scheduler2.start();
+            scheduler1.startConsumer();
+            scheduler2.startConsumer();
 
             ids.forEach(id -> {
                 scheduler1.schedule(task.instance(id), Instant.now());
@@ -88,8 +88,8 @@ public class ClusterTest {
             final Scheduler scheduler2 = createSchedulerRecurring("scheduler2", task1, stats);
 
             stopScheduler.register(scheduler1, scheduler2);
-            scheduler1.start();
-            scheduler2.start();
+            scheduler1.startConsumer();
+            scheduler2.startConsumer();
 
             Thread.sleep(5_000);
             scheduler1.stop();

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
@@ -75,7 +75,8 @@ public class DeadExecutionsTest {
             Duration.ZERO,
             LogLevel.DEBUG,
             true,
-            new ArrayList<>());
+            new ArrayList<>(),
+            true);
 
     }
 
@@ -113,10 +114,10 @@ public class DeadExecutionsTest {
         final Execution execution1 = new Execution(oneHourAgo, taskInstance);
         jdbcTaskRepository.createIfNotExists(execution1);
 
-        scheduler.executeDue();
+        scheduler.executeDueTasks();
         assertThat(nonCompletingExecutionHandler.timesExecuted.get(), is(1));
 
-        scheduler.executeDue();
+        scheduler.executeDueTasks();
         assertThat(nonCompletingExecutionHandler.timesExecuted.get(), is(1));
 
         settableClock.set(Instant.now());
@@ -126,7 +127,7 @@ public class DeadExecutionsTest {
 
         settableClock.set(Instant.now());
 
-        scheduler.executeDue();
+        scheduler.executeDueTasks();
         assertThat(nonCompletingExecutionHandler.timesExecuted.get(), is(2));
     }
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/CompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/CompatibilityTest.java
@@ -20,10 +20,8 @@ import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay;
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
 import java.time.Duration;
@@ -33,7 +31,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.github.kagkarlsson.scheduler.JdbcTaskRepository.DEFAULT_TABLE_NAME;
-import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
@@ -105,7 +102,7 @@ public abstract class CompatibilityTest {
             scheduler.schedule(recurring.instance("id3"), Instant.now());
             scheduler.schedule(recurring.instance("id4"), Instant.now());
 
-            scheduler.start();
+            scheduler.startConsumer();
             completed12Condition.waitFor();
             scheduler.stop();
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/DeadExecutionTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/DeadExecutionTest.java
@@ -1,6 +1,5 @@
 package com.github.kagkarlsson.scheduler.functional;
 
-import com.github.kagkarlsson.scheduler.DbUtils;
 import com.github.kagkarlsson.scheduler.EmbeddedPostgresqlExtension;
 import com.github.kagkarlsson.scheduler.Scheduler;
 import com.github.kagkarlsson.scheduler.SchedulerName;
@@ -52,7 +51,7 @@ public class DeadExecutionTest {
             stopScheduler.register(scheduler);
 
             scheduler.schedule(customTask.instance("1"), Instant.now());
-            scheduler.start();
+            scheduler.startConsumer();
             completedCondition.waitFor();
 
             assertEquals(registry.getCount(SchedulerStatsEvent.DEAD_EXECUTION), 1);

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/ExecutorPoolTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/ExecutorPoolTest.java
@@ -91,7 +91,7 @@ public class ExecutorPoolTest {
         IntStream.range(0, executionsToRun).forEach(i -> scheduler.schedule(task.instance(String.valueOf(i)), clock.now()));
 
         Assertions.assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
-            scheduler.start();
+            scheduler.startConsumer();
             condition.waitFor();
 
             List<ExecutionComplete> completed = registry.getCompleted();

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/ImmediateExecutionTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/ImmediateExecutionTest.java
@@ -1,7 +1,6 @@
 package com.github.kagkarlsson.scheduler.functional;
 
 import co.unruly.matchers.TimeMatchers;
-import com.github.kagkarlsson.scheduler.DbUtils;
 import com.github.kagkarlsson.scheduler.EmbeddedPostgresqlExtension;
 import com.github.kagkarlsson.scheduler.Scheduler;
 import com.github.kagkarlsson.scheduler.SchedulerName;
@@ -14,7 +13,6 @@ import com.github.kagkarlsson.scheduler.testhelper.SettableClock;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.time.Duration;
@@ -59,7 +57,7 @@ public class ImmediateExecutionTest {
                 .build();
             stopScheduler.register(scheduler);
 
-            scheduler.start();
+            scheduler.startConsumer();
             executeDueCondition.waitFor();
 
             scheduler.schedule(task.instance("1"), clock.now());

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/RecurringTaskTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/RecurringTaskTest.java
@@ -51,7 +51,7 @@ public class RecurringTaskTest {
             .execute(TestTasks.DO_NOTHING);
 
         ManualScheduler scheduler = manualSchedulerFor(singletonList(recurringTask));
-        scheduler.start();
+        scheduler.startConsumer();
 
         assertScheduled(scheduler, RECURRING_A, LocalTime.of(23, 59));
     }
@@ -63,7 +63,7 @@ public class RecurringTaskTest {
             .execute(TestTasks.DO_NOTHING);
 
         ManualScheduler scheduler = manualSchedulerFor(singletonList(recurringTask));
-        scheduler.start();
+        scheduler.startConsumer();
 
         assertScheduled(scheduler, RECURRING_A, TIME);
     }
@@ -75,7 +75,7 @@ public class RecurringTaskTest {
 
         ManualScheduler scheduler = manualSchedulerFor(singletonList(recurringTask));
 
-        scheduler.start();
+        scheduler.startConsumer();
         assertScheduled(scheduler, RECURRING_A, LocalTime.of(23, 59));
 
         // Add an additional execution-time to the daily schedule
@@ -88,7 +88,7 @@ public class RecurringTaskTest {
         ManualScheduler schedulerUpdatedTask = manualSchedulerFor(singletonList(recurringTaskNewSchedule));
 
         // Simulate restart with updated schedule for task, execution now already exists
-        schedulerUpdatedTask.start();
+        schedulerUpdatedTask.startConsumer();
 
         assertScheduled(schedulerUpdatedTask, RECURRING_A, LocalTime.of(12, 0));
     }
@@ -100,7 +100,7 @@ public class RecurringTaskTest {
 
         ManualScheduler scheduler = manualSchedulerFor(singletonList(recurringTask));
 
-        scheduler.start();
+        scheduler.startConsumer();
         assertScheduled(scheduler, RECURRING_A, LocalTime.of(12, 0));
 
         RecurringTask<Void> recurringTaskNewSchedule = Tasks.recurring(RECURRING_A,
@@ -110,7 +110,7 @@ public class RecurringTaskTest {
         ManualScheduler schedulerUpdatedTask = manualSchedulerFor(singletonList(recurringTaskNewSchedule));
 
         // Simulate restart with updated schedule for task, execution now already exists
-        schedulerUpdatedTask.start();
+        schedulerUpdatedTask.startConsumer();
 
         // Should have unchanged execution-time
         assertScheduled(schedulerUpdatedTask, RECURRING_A, LocalTime.of(23, 59));
@@ -124,7 +124,7 @@ public class RecurringTaskTest {
 
         ManualScheduler scheduler = manualSchedulerFor(singletonList(recurringTask));
 
-        scheduler.start();
+        scheduler.startConsumer();
         assertScheduled(scheduler, RECURRING_A, LocalTime.of(23, 59), 1);
 
         // Add an additional execution-time to the daily schedule
@@ -138,7 +138,7 @@ public class RecurringTaskTest {
         ManualScheduler schedulerUpdatedTask = manualSchedulerFor(singletonList(recurringTaskNewSchedule));
 
         // Simulate restart with updated schedule for task, execution now already exists
-        schedulerUpdatedTask.start();
+        schedulerUpdatedTask.startConsumer();
 
         assertScheduled(schedulerUpdatedTask, RECURRING_A, LocalTime.of(12, 0), 1); // unchanged data
     }


### PR DESCRIPTION
Motivation: in processing pipelines where tasks can be time-intensive, and multiple queues/tasks are fighting for resources, the lib users can benefit from implementing a more complex pulling strategy and trigger executions manually. Hence we start exposing a public executeDueTasks() method.

Changes:
- Exposing executeDueTasks as public
- renaming Scheduler.start() to Scheduler.startConsumer(), keeping backward compatibility, to reflect that only the "consumer-machines" will have to start this process
- add the ability to disable consuming with SchedulerBuilder.disableStartConsumingTasksOnStart(), in such a way that lifecycle threads can handle heartbeat and dead executions, but not computation heavy threads (of the executions), which can be triggered manually

Additional:
- feature tested
- all methods changes are backward compatible.