### PR TITLE
Adds exponential backoff and max retries failure handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ scheduler.schedule(myAdhocTask.instance("1045", new MyTaskData(1001L)), Instant.
 
 * [EnableImmediateExecutionMain.java](./examples/features/src/main/java/com/github/kagkarlsson/examples/EnableImmediateExecutionMain.java)
 * [MaxRetriesMain.java](./examples/features/src/main/java/com/github/kagkarlsson/examples/MaxRetriesMain.java)
+* [ExponentialBackoffMain.java](./examples/features/src/main/java/com/github/kagkarlsson/examples/ExponentialBackoffMain.java)
+* [ExponentialBackoffWithMaxRetriesMain.java](./examples/features/src/main/java/com/github/kagkarlsson/examples/ExponentialBackoffWithMaxRetriesMain.java)
 * [TrackingProgressRecurringTaskMain.java](./examples/features/src/main/java/com/github/kagkarlsson/examples/TrackingProgressRecurringTaskMain.java)
 * [SpawningOtherTasksMain.java](./examples/features/src/main/java/com/github/kagkarlsson/examples/SpawningOtherTasksMain.java)
 * [SchedulerClientMain.java](./examples/features/src/main/java/com/github/kagkarlsson/examples/SchedulerClientMain.java)

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/FailureHandler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/FailureHandler.java
@@ -75,7 +75,6 @@ public interface FailureHandler<T> {
         }
     }
 
-    // TODO: Failure handler with backoff: if (isFailing(.)) then nextTry = 2* duration_from_first_failure (minimum 1m, max 1d)
     class OnFailureRetryLater<T> implements FailureHandler<T> {
 
         private static final Logger LOG = LoggerFactory.getLogger(CompletionHandler.OnCompleteReschedule.class);

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/FailureHandler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/FailureHandler.java
@@ -67,8 +67,9 @@ public interface FailureHandler<T> {
         @Override
         public void onFailure(final ExecutionComplete executionComplete, final ExecutionOperations<T> executionOperations) {
             int consecutiveFailures = executionComplete.getExecution().consecutiveFailures;
-            if(consecutiveFailures >= maxRetries){
-                LOG.error("Execution has failed {} times for task instance {}. Cancelling execution.", consecutiveFailures, executionComplete.getExecution().taskInstance);
+            int totalNumberOfFailures = consecutiveFailures + 1;
+            if(totalNumberOfFailures > maxRetries){
+                LOG.error("Execution has failed {} times for task instance {}. Cancelling execution.", totalNumberOfFailures, executionComplete.getExecution().taskInstance);
                 executionOperations.stop();
             }else{
                 this.failureHandler.onFailure(executionComplete, executionOperations);

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/FailureHandler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/FailureHandler.java
@@ -66,8 +66,9 @@ public interface FailureHandler<T> {
 
         @Override
         public void onFailure(final ExecutionComplete executionComplete, final ExecutionOperations<T> executionOperations) {
-            if(executionComplete.getExecution().consecutiveFailures >= maxRetries){
-                LOG.error("Max execution attempts exceeded, task instance {} will no longer be handled.", executionComplete.getExecution().taskInstance);
+            int consecutiveFailures = executionComplete.getExecution().consecutiveFailures;
+            if(consecutiveFailures >= maxRetries){
+                LOG.error("Execution has failed {} times for task instance {}. Cancelling execution.", consecutiveFailures, executionComplete.getExecution().taskInstance);
                 executionOperations.stop();
             }else{
                 this.failureHandler.onFailure(executionComplete, executionOperations);

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
@@ -192,7 +192,7 @@ public class SchedulerTest {
 
         //Simulate 15 minutes worth of time to validate we did not process more than we should
         for( int minuteWorthOfTime = 1; minuteWorthOfTime <= 15; minuteWorthOfTime ++) {
-            clock.set(clock.now().plus(ofMinutes(minuteWorthOfTime)));
+            clock.set(clock.now().plus(ofMinutes(1)));
             scheduler.executeDue();
         }
 
@@ -220,9 +220,9 @@ public class SchedulerTest {
         scheduler.schedule(oneTimeTask.instance("1"), firstExecution);
         scheduler.executeDue();
 
-        //Simulate 15 minutes worth of time to validate we did not process more than we should
-        for( int minuteWorthOfTime = 1; minuteWorthOfTime <= 15; minuteWorthOfTime ++) {
-            clock.set(clock.now().plus(ofMinutes(minuteWorthOfTime)));
+        //Simulate 30 minutes worth of time to validate we did not process more than we should
+        for( int minuteWorthOfTime = 1; minuteWorthOfTime <= 30; minuteWorthOfTime ++) {
+            clock.set(clock.now().plus(ofMinutes(1)));
             scheduler.executeDue();
         }
 
@@ -262,7 +262,7 @@ public class SchedulerTest {
 
         //Simulate 15 minutes worth of time to validate we did not process more than we should
         for( int minuteWorthOfTime = 1; minuteWorthOfTime <= 15; minuteWorthOfTime ++) {
-            clock.set(clock.now().plus(ofMinutes(minuteWorthOfTime)));
+            clock.set(clock.now().plus(ofMinutes(1)));
             scheduler.executeDue();
         }
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
@@ -260,8 +260,8 @@ public class SchedulerTest {
         scheduler.schedule(oneTimeTask.instance("1"), firstExecution);
         scheduler.executeDue();
 
-        //Simulate 15 minutes worth of time to validate we did not process more than we should
-        for( int minuteWorthOfTime = 1; minuteWorthOfTime <= 15; minuteWorthOfTime ++) {
+        //Simulate 30 minutes worth of time to validate we did not process more than we should
+        for( int minuteWorthOfTime = 1; minuteWorthOfTime <= 30; minuteWorthOfTime ++) {
             clock.set(clock.now().plus(ofMinutes(1)));
             scheduler.executeDue();
         }

--- a/examples/features/src/main/java/com/github/kagkarlsson/examples/ExponentialBackoffWithMaxRetriesMain.java
+++ b/examples/features/src/main/java/com/github/kagkarlsson/examples/ExponentialBackoffWithMaxRetriesMain.java
@@ -1,40 +1,38 @@
 package com.github.kagkarlsson.examples;
 
+import java.time.Instant;
+
+import javax.sql.DataSource;
+
 import com.github.kagkarlsson.examples.helpers.Example;
 import com.github.kagkarlsson.examples.helpers.ExampleHelpers;
 import com.github.kagkarlsson.scheduler.Scheduler;
-import com.github.kagkarlsson.scheduler.task.ExecutionComplete;
-import com.github.kagkarlsson.scheduler.task.ExecutionOperations;
 import com.github.kagkarlsson.scheduler.task.FailureHandler;
 import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 
-import javax.sql.DataSource;
-import java.time.Duration;
-import java.time.Instant;
+import static java.time.Duration.ofSeconds;
 
-public class MaxRetriesMain extends Example {
+public class ExponentialBackoffWithMaxRetriesMain extends Example {
 
     public static void main(String[] args) {
-        new MaxRetriesMain().runWithDatasource();
+        new ExponentialBackoffWithMaxRetriesMain().runWithDatasource();
     }
 
     @Override
     public void run(DataSource dataSource) {
-
-        OneTimeTask<Void> failingTask = Tasks.oneTime("max_retries_task")
-            .onFailure(new FailureHandler.MaxRetriesFailureHandler<>(3, (executionComplete, executionOperations) -> {
-                    // try again in 1 second
-                    System.out.println("Execution has failed " + executionComplete.getExecution().consecutiveFailures + " times. Trying again in a bit...");
-                    executionOperations.reschedule(executionComplete, Instant.now().plusSeconds(1));
-            }))
+        OneTimeTask<Void> failingTask = Tasks.oneTime("exponential_backoff_with_max_retries_task")
+            .onFailure(new FailureHandler.MaxRetriesFailureHandler<>(
+                6,
+                new FailureHandler.ExponentialBackoffFailureHandler<>(ofSeconds(1), 2))
+            )
             .execute((taskInstance, executionContext) -> {
                 throw new RuntimeException("simulated task exception");
             });
 
         final Scheduler scheduler = Scheduler
             .create(dataSource, failingTask)
-            .pollingInterval(Duration.ofSeconds(2))
+            .pollingInterval(ofSeconds(2))
             .build();
 
         scheduler.schedule(failingTask.instance("1"), Instant.now());
@@ -43,5 +41,4 @@ public class MaxRetriesMain extends Example {
 
         scheduler.start();
     }
-
 }


### PR DESCRIPTION
### MaxRetriesFailureHandler - 
This is a wrapper around any existing failure failure. It simply works as a guard clause that will only delegate to the other failure handler if the number of retries has not be exceeded. 

### ExponentialBackoffFailureHandler - 
Does the following equation to calculate the next execution time to retry the task. 

![image](https://user-images.githubusercontent.com/1099906/114776472-803ed000-9d40-11eb-9dcb-a370da868314.png)

The default rate to use was stolen/borrowed from resilience4j project but is configurable to allow users to configure how much/less the backoff applies to the future executions. https://github.com/resilience4j/resilience4j/blob/03253134ac6f88954c8a65faa6dd7f92ed5e02f1/resilience4j-core/src/main/java/io/github/resilience4j/core/IntervalFunction.java#L20

This site is helpful to figure out what rate will be best for your situation. (not affiliated with this site just thought it was useful)
http://exponentialbackoffcalculator.com/ 

Both new failure handlers are useful to actually use together since if you exponentially backoff forever you could possibly end up with scheduling things days, months, years in the future. 
