### PR TITLE
OnStartup items should always trigger commit.

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ScheduledExecution.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ScheduledExecution.java
@@ -74,6 +74,14 @@ public class ScheduledExecution<DATA_TYPE> {
     public int hashCode() {
         return Objects.hash(execution);
     }
+
+    @Override
+    public String toString() {
+        return "ScheduledExecution{" +
+            "execution=" + execution +
+            '}';
+    }
+
     public static class DataClassMismatchException extends RuntimeException {
     }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -118,9 +118,11 @@ public class Scheduler implements SchedulerClient {
     }
 
     protected void executeOnStartup() {
+        // Client used for OnStartup always commits
+        final StandardSchedulerClient onStartupClient = new StandardSchedulerClient(schedulerTaskRepository);
         onStartup.forEach(os -> {
             try {
-                os.onStartup(this, this.clock);
+                os.onStartup(onStartupClient, this.clock);
             } catch (Exception e) {
                 LOG.error("Unexpected error while executing OnStartup tasks. Continuing.", e);
                 statsRegistry.register(SchedulerStatsEvent.UNEXPECTED_ERROR);

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/OnStartup.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/OnStartup.java
@@ -16,8 +16,8 @@
 package com.github.kagkarlsson.scheduler.task;
 
 import com.github.kagkarlsson.scheduler.Clock;
-import com.github.kagkarlsson.scheduler.Scheduler;
+import com.github.kagkarlsson.scheduler.SchedulerClient;
 
 public interface OnStartup {
-    void onStartup(Scheduler scheduler, Clock clock);
+    void onStartup(SchedulerClient scheduler, Clock clock);
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/CustomTask.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/CustomTask.java
@@ -16,7 +16,7 @@
 package com.github.kagkarlsson.scheduler.task.helper;
 
 import com.github.kagkarlsson.scheduler.Clock;
-import com.github.kagkarlsson.scheduler.Scheduler;
+import com.github.kagkarlsson.scheduler.SchedulerClient;
 import com.github.kagkarlsson.scheduler.task.AbstractTask;
 import com.github.kagkarlsson.scheduler.task.DeadExecutionHandler;
 import com.github.kagkarlsson.scheduler.task.FailureHandler;
@@ -31,7 +31,7 @@ public abstract class CustomTask<T> extends AbstractTask<T> implements OnStartup
     }
 
     @Override
-    public void onStartup(Scheduler scheduler, Clock clock) {
+    public void onStartup(SchedulerClient scheduler, Clock clock) {
         if (scheduleOnStartup != null) {
                 scheduleOnStartup.apply(scheduler, clock, this);
         }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTask.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTask.java
@@ -16,7 +16,7 @@
 package com.github.kagkarlsson.scheduler.task.helper;
 
 import com.github.kagkarlsson.scheduler.Clock;
-import com.github.kagkarlsson.scheduler.Scheduler;
+import com.github.kagkarlsson.scheduler.SchedulerClient;
 import com.github.kagkarlsson.scheduler.task.*;
 import com.github.kagkarlsson.scheduler.task.CompletionHandler.OnCompleteReschedule;
 import com.github.kagkarlsson.scheduler.task.DeadExecutionHandler.ReviveDeadExecution;
@@ -43,7 +43,7 @@ public abstract class RecurringTask<T> extends AbstractTask<T> implements OnStar
     }
 
     @Override
-    public void onStartup(Scheduler scheduler, Clock clock) {
+    public void onStartup(SchedulerClient scheduler, Clock clock) {
         if (scheduleOnStartup != null) {
             scheduleOnStartup.apply(scheduler, clock, this);
         }
@@ -56,6 +56,10 @@ public abstract class RecurringTask<T> extends AbstractTask<T> implements OnStar
     }
 
     public abstract void executeRecurringly(TaskInstance<T> taskInstance, ExecutionContext executionContext);
+
+    public TaskInstanceId getDefaultTaskInstance() {
+        return TaskInstanceId.of(name, INSTANCE);
+    }
 
     @Override
     public String toString() {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleOnStartup.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleOnStartup.java
@@ -17,8 +17,9 @@ package com.github.kagkarlsson.scheduler.task.helper;
 
 import com.github.kagkarlsson.scheduler.Clock;
 import com.github.kagkarlsson.scheduler.Scheduler;
+import com.github.kagkarlsson.scheduler.SchedulerClient;
 import com.github.kagkarlsson.scheduler.task.Task;
 
 public interface ScheduleOnStartup<T> {
-    void apply(Scheduler scheduler, Clock clock, Task<T> task);
+    void apply(SchedulerClient scheduler, Clock clock, Task<T> task);
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleOnceOnStartup.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleOnceOnStartup.java
@@ -16,7 +16,7 @@
 package com.github.kagkarlsson.scheduler.task.helper;
 
 import com.github.kagkarlsson.scheduler.Clock;
-import com.github.kagkarlsson.scheduler.Scheduler;
+import com.github.kagkarlsson.scheduler.SchedulerClient;
 import com.github.kagkarlsson.scheduler.task.Task;
 import com.github.kagkarlsson.scheduler.task.TaskInstance;
 
@@ -42,7 +42,7 @@ class ScheduleOnceOnStartup<T> implements ScheduleOnStartup<T> {
         this.data = data;
     }
 
-    public void apply(Scheduler scheduler, Clock clock, Task<T> task) {
+    public void apply(SchedulerClient scheduler, Clock clock, Task<T> task) {
         scheduler.schedule(getSchedulableInstance(task), firstExecutionTime.apply(clock.now()));
     }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleRecurringOnStartup.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleRecurringOnStartup.java
@@ -17,7 +17,7 @@ package com.github.kagkarlsson.scheduler.task.helper;
 
 import com.github.kagkarlsson.scheduler.Clock;
 import com.github.kagkarlsson.scheduler.ScheduledExecution;
-import com.github.kagkarlsson.scheduler.Scheduler;
+import com.github.kagkarlsson.scheduler.SchedulerClient;
 import com.github.kagkarlsson.scheduler.task.ExecutionComplete;
 import com.github.kagkarlsson.scheduler.task.Task;
 import com.github.kagkarlsson.scheduler.task.TaskInstance;
@@ -42,7 +42,7 @@ class ScheduleRecurringOnStartup<T> implements ScheduleOnStartup<T> {
     }
 
     @Override
-    public void apply(Scheduler scheduler, Clock clock, Task<T> task) {
+    public void apply(SchedulerClient scheduler, Clock clock, Task<T> task) {
         final TaskInstance<T> instanceWithoutData = task.instance(this.instance);
         final Optional<ScheduledExecution<Object>> preexistingExecution = scheduler.getScheduledExecution(instanceWithoutData);
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/EmbeddedPostgresqlExtension.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/EmbeddedPostgresqlExtension.java
@@ -20,6 +20,7 @@ public class EmbeddedPostgresqlExtension implements AfterEachCallback {
     private static DataSource dataSource;
     private final Consumer<DataSource> initializeSchema;
     private final Consumer<DataSource> cleanupAfter;
+    private DataSource nonPooledDatasource;
 
     public EmbeddedPostgresqlExtension() {
         this(DbUtils.runSqlResource("/postgresql_tables.sql"), DbUtils::clearTables);
@@ -35,7 +36,8 @@ public class EmbeddedPostgresqlExtension implements AfterEachCallback {
                     embeddedPostgresql = initPostgres();
 
                     HikariConfig config = new HikariConfig();
-                    config.setDataSource(embeddedPostgresql.getDatabase("test", "test"));
+                    nonPooledDatasource = embeddedPostgresql.getDatabase("test", "test");
+                    config.setDataSource(nonPooledDatasource);
 
                     dataSource = new HikariDataSource(config);
 
@@ -49,6 +51,10 @@ public class EmbeddedPostgresqlExtension implements AfterEachCallback {
 
     public DataSource getDataSource() {
         return dataSource;
+    }
+
+    public DataSource getNonPooledDatasource() {
+        return nonPooledDatasource;
     }
 
     private EmbeddedPostgres initPostgres() throws IOException {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/MysqlCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/MysqlCompatibilityTest.java
@@ -6,6 +6,7 @@ import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.util.DriverDataSource;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -16,6 +17,7 @@ import java.util.Properties;
 
 @Tag("compatibility")
 @Testcontainers
+@Disabled
 public class MysqlCompatibilityTest extends CompatibilityTest {
 
     @Container

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/NoAutocommitTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/NoAutocommitTest.java
@@ -1,6 +1,6 @@
-package com.github.kagkarlsson.scheduler.functional;
+package com.github.kagkarlsson.scheduler.compatibility;
 
-import com.github.kagkarlsson.scheduler.EmbeddedPostgresqlExtension;
+import com.github.kagkarlsson.scheduler.DbUtils;
 import com.github.kagkarlsson.scheduler.ScheduledExecution;
 import com.github.kagkarlsson.scheduler.Scheduler;
 import com.github.kagkarlsson.scheduler.SchedulerName;
@@ -12,24 +12,58 @@ import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 import com.github.kagkarlsson.scheduler.task.schedule.Schedule;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.util.DriverDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.Properties;
 
 import static co.unruly.matchers.OptionalMatchers.empty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
+@Tag("compatibility")
+@Testcontainers
 public class NoAutocommitTest {
 
-    @RegisterExtension
-    public EmbeddedPostgresqlExtension postgres = new EmbeddedPostgresqlExtension();
+    private static HikariDataSource noAutocommitingDatasource;
     @RegisterExtension
     public StopSchedulerExtension stopScheduler = new StopSchedulerExtension();
 
+    @Container
+    private static final PostgreSQLContainer POSTGRES = new PostgreSQLContainer();
+
+    @BeforeAll
+    private static void initSchema() {
+        final DriverDataSource datasource = new DriverDataSource(POSTGRES.getJdbcUrl(), "org.postgresql.Driver",
+            new Properties(), POSTGRES.getUsername(), POSTGRES.getPassword());
+
+        // init schema
+        DbUtils.runSqlResource("/postgresql_tables.sql").accept(datasource);
+
+        // Setup non auto-committing datasource
+        final HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setDataSource(datasource);
+        hikariConfig.setAutoCommit(false);
+        noAutocommitingDatasource = new HikariDataSource(hikariConfig);
+    }
+
+    @AfterEach
+    public void clearTables() {
+        assertTimeoutPreemptively(Duration.ofSeconds(20), () ->
+            DbUtils.clearTables(noAutocommitingDatasource)
+        );
+    }
 
     @Test
     public void onstartup_should_always_commit() {
@@ -38,12 +72,7 @@ public class NoAutocommitTest {
             .execute(counter);
 
         // Setup non auto-committing datasource
-        final HikariConfig hikariConfig = new HikariConfig();
-        hikariConfig.setDataSource(postgres.getNonPooledDatasource());
-        hikariConfig.setAutoCommit(false);
-        HikariDataSource noAutocommitDatasource = new HikariDataSource(hikariConfig);
-
-        Scheduler scheduler = Scheduler.create(noAutocommitDatasource)
+        Scheduler scheduler = Scheduler.create(noAutocommitingDatasource)
             .startTasks(recurring1)
             .schedulerName(new SchedulerName.Fixed("test"))
             .commitWhenAutocommitDisabled(false)

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/NoAutocommitTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/NoAutocommitTest.java
@@ -1,0 +1,75 @@
+package com.github.kagkarlsson.scheduler.functional;
+
+import com.github.kagkarlsson.scheduler.EmbeddedPostgresqlExtension;
+import com.github.kagkarlsson.scheduler.ScheduledExecution;
+import com.github.kagkarlsson.scheduler.Scheduler;
+import com.github.kagkarlsson.scheduler.SchedulerName;
+import com.github.kagkarlsson.scheduler.StopSchedulerExtension;
+import com.github.kagkarlsson.scheduler.TestTasks;
+import com.github.kagkarlsson.scheduler.task.ExecutionComplete;
+import com.github.kagkarlsson.scheduler.task.helper.RecurringTask;
+import com.github.kagkarlsson.scheduler.task.helper.Tasks;
+import com.github.kagkarlsson.scheduler.task.schedule.Schedule;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+import static co.unruly.matchers.OptionalMatchers.empty;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+
+public class NoAutocommitTest {
+
+    @RegisterExtension
+    public EmbeddedPostgresqlExtension postgres = new EmbeddedPostgresqlExtension();
+    @RegisterExtension
+    public StopSchedulerExtension stopScheduler = new StopSchedulerExtension();
+
+
+    @Test
+    public void onstartup_should_always_commit() {
+        final TestTasks.CountingHandler<Void> counter = new TestTasks.CountingHandler<>();
+        final RecurringTask<Void> recurring1 = Tasks.recurring("recurring1", new FutureSchedule())
+            .execute(counter);
+
+        // Setup non auto-committing datasource
+        final HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setDataSource(postgres.getNonPooledDatasource());
+        hikariConfig.setAutoCommit(false);
+        HikariDataSource noAutocommitDatasource = new HikariDataSource(hikariConfig);
+
+        Scheduler scheduler = Scheduler.create(noAutocommitDatasource)
+            .startTasks(recurring1)
+            .schedulerName(new SchedulerName.Fixed("test"))
+            .commitWhenAutocommitDisabled(false)
+            .build();
+        stopScheduler.register(scheduler);
+
+        scheduler.start();
+
+        final Optional<ScheduledExecution<Object>> scheduledExecution = scheduler.getScheduledExecution(recurring1.getDefaultTaskInstance());
+        assertThat(scheduledExecution, not(empty()));
+    }
+
+    private static class FutureSchedule implements Schedule {
+        @Override
+        public Instant getNextExecutionTime(ExecutionComplete executionComplete) {
+            return Instant.now().plusSeconds(60);
+        }
+
+        @Override
+        public Instant getInitialExecutionTime(Instant now) {
+            return now.plus(Duration.ofMinutes(1));
+        }
+
+        @Override
+        public boolean isDeterministic() {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Transactions for `OnStartup` items (for example scheduling the initial `RecurringTask` instance) should be managed by the scheduler, i.e. should always commit. 

Fixes a bug where recurring-tasks were not scheduled on startup when using datasources that sets autocommit=false.