### PR TITLE
Enhance ExecutePicked logs. Fixes kagkarlsson/db-scheduler#223

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ExecutePicked.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ExecutePicked.java
@@ -79,9 +79,12 @@ class ExecutePicked implements Runnable {
 
         Instant executionStarted = clock.now();
         try {
-            LOG.debug("Executing " + execution);
+            String executionString = execution.toString();
+            String decapitalizedExecutionString = Character.toLowerCase(executionString.charAt(0)) + executionString.substring(1);
+            
+            LOG.debug("Starting " + decapitalizedExecutionString);
             CompletionHandler completion = task.get().execute(execution.taskInstance, new ExecutionContext(schedulerState, execution, schedulerClient));
-            LOG.debug("Execution done");
+            LOG.debug("Finished " + decapitalizedExecutionString);
 
             complete(completion, execution, executionStarted);
             statsRegistry.register(StatsRegistry.ExecutionStatsEvent.COMPLETED);


### PR DESCRIPTION
The debug logs of `ExecutePicked` for starting and finishing an execution are enhanced to be more readable and informative.

## Starting an execution:
#### Before:
> com.github.kagkarlsson.scheduler.ExecutePicked - Executing Execution: task=some-test-task, id=1234, ...
#### After:
> com.github.kagkarlsson.scheduler.ExecutePicked - Starting execution: task=some-test-task, id=1234, ...
## Finishing an execution:
#### Before:
> Execution done
#### After:
> Finished execution: task=some-test-task, id=1234, ...