### PR TITLE
Don't require Spring Boot Actuator to work

### DIFF
--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerActuatorAutoConfiguration.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerActuatorAutoConfiguration.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) Gustav Karlsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.kagkarlsson.scheduler.boot.autoconfigure;
+
+import com.github.kagkarlsson.scheduler.Scheduler;
+import com.github.kagkarlsson.scheduler.boot.actuator.DbSchedulerHealthIndicator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
+import org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnClass(HealthContributorAutoConfiguration.class)
+@AutoConfigureAfter({
+    HealthContributorAutoConfiguration.class,
+    DbSchedulerAutoConfiguration.class,
+})
+public class DbSchedulerActuatorAutoConfiguration {
+    private static final Logger log = LoggerFactory.getLogger(DbSchedulerActuatorAutoConfiguration.class);
+
+    @ConditionalOnEnabledHealthIndicator("db-scheduler")
+    @ConditionalOnClass(HealthIndicator.class)
+    @ConditionalOnBean(Scheduler.class)
+    @Bean
+    public HealthIndicator dbScheduler(Scheduler scheduler) {
+        log.debug("Exposing health indicator for db-scheduler");
+        return new DbSchedulerHealthIndicator(scheduler);
+    }
+}

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
@@ -20,18 +20,15 @@ import com.github.kagkarlsson.scheduler.Scheduler;
 import com.github.kagkarlsson.scheduler.SchedulerBuilder;
 import com.github.kagkarlsson.scheduler.SchedulerName;
 import com.github.kagkarlsson.scheduler.Serializer;
-import com.github.kagkarlsson.scheduler.boot.actuator.DbSchedulerHealthIndicator;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerCustomizer;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerProperties;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerStarter;
 import com.github.kagkarlsson.scheduler.boot.config.startup.ContextReadyStart;
 import com.github.kagkarlsson.scheduler.boot.config.startup.ImmediateStart;
 import com.github.kagkarlsson.scheduler.exceptions.SerializationException;
-import com.github.kagkarlsson.scheduler.stats.MicrometerStatsRegistry;
 import com.github.kagkarlsson.scheduler.stats.StatsRegistry;
 import com.github.kagkarlsson.scheduler.task.OnStartup;
 import com.github.kagkarlsson.scheduler.task.Task;
-import io.micrometer.core.instrument.MeterRegistry;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInput;
@@ -42,18 +39,11 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.sql.DataSource;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
-import org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration;
-import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
-import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
-import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
@@ -68,9 +58,6 @@ import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy;
 @AutoConfigurationPackage
 @AutoConfigureAfter({
     DataSourceAutoConfiguration.class,
-    HealthContributorAutoConfiguration.class,
-    MetricsAutoConfiguration.class,
-    CompositeMeterRegistryAutoConfiguration.class,
 })
 @ConditionalOnBean(DataSource.class)
 @ConditionalOnProperty(value = "db-scheduler.enabled", matchIfMissing = true)
@@ -99,15 +86,9 @@ public class DbSchedulerAutoConfiguration {
         };
     }
 
-    @ConditionalOnClass(MeterRegistry.class)
-    @ConditionalOnBean(MeterRegistry.class)
-    @ConditionalOnMissingBean(StatsRegistry.class)
-    @Bean
-    StatsRegistry micrometerStatsRegistry(MeterRegistry registry) {
-        log.debug("Missing StatsRegistry bean in context but Micrometer detected. Will use: {}", registry.getClass().getName());
-        return new MicrometerStatsRegistry(registry, configuredTasks);
-    }
-
+    /**
+     * Will typically be created if Spring Boot Actuator is not on the classpath.
+     */
     @ConditionalOnMissingBean(StatsRegistry.class)
     @Bean
     StatsRegistry noopStatsRegistry() {
@@ -179,15 +160,6 @@ public class DbSchedulerAutoConfiguration {
         builder.failureLogging(config.getFailureLoggerLevel(), config.isFailureLoggerLogStackTrace());
 
         return builder.build();
-    }
-
-    @ConditionalOnEnabledHealthIndicator("db-scheduler")
-    @ConditionalOnClass(HealthIndicator.class)
-    @ConditionalOnBean(Scheduler.class)
-    @Bean
-    public HealthIndicator dbScheduler(Scheduler scheduler) {
-        log.debug("Exposing health indicator for db-scheduler");
-        return new DbSchedulerHealthIndicator(scheduler);
     }
 
     @ConditionalOnBean(Scheduler.class)

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerMetricsAutoConfiguration.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerMetricsAutoConfiguration.java
@@ -1,0 +1,49 @@
+package com.github.kagkarlsson.scheduler.boot.autoconfigure;
+
+import com.github.kagkarlsson.scheduler.stats.MicrometerStatsRegistry;
+import com.github.kagkarlsson.scheduler.stats.StatsRegistry;
+import com.github.kagkarlsson.scheduler.task.Task;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnClass({
+    MetricsAutoConfiguration.class,
+    CompositeMeterRegistryAutoConfiguration.class,
+})
+@AutoConfigureAfter({
+    MetricsAutoConfiguration.class,
+    CompositeMeterRegistryAutoConfiguration.class,
+})
+@AutoConfigureBefore(DbSchedulerAutoConfiguration.class)
+@ConditionalOnProperty(value = "db-scheduler.enabled", matchIfMissing = true)
+public class DbSchedulerMetricsAutoConfiguration {
+    private static final Logger log = LoggerFactory.getLogger(DbSchedulerMetricsAutoConfiguration.class);
+    private final List<Task<?>> configuredTasks;
+
+    public DbSchedulerMetricsAutoConfiguration(List<Task<?>> configuredTasks) {
+        this.configuredTasks = configuredTasks;
+    }
+
+    @ConditionalOnClass(MeterRegistry.class)
+    @ConditionalOnBean(MeterRegistry.class)
+    @ConditionalOnMissingBean(StatsRegistry.class)
+    @Bean
+    StatsRegistry micrometerStatsRegistry(MeterRegistry registry) {
+        log.debug("Spring Boot Actuator and Micrometer detected. Will use: {} for StatsRegistry", registry.getClass().getName());
+        return new MicrometerStatsRegistry(registry, configuredTasks);
+    }
+}
+

--- a/db-scheduler-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/db-scheduler-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,4 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.github.kagkarlsson.scheduler.boot.autoconfigure.DbSchedulerAutoConfiguration
+com.github.kagkarlsson.scheduler.boot.autoconfigure.DbSchedulerAutoConfiguration,\
+com.github.kagkarlsson.scheduler.boot.autoconfigure.DbSchedulerMetricsAutoConfiguration,\
+com.github.kagkarlsson.scheduler.boot.autoconfigure.DbSchedulerActuatorAutoConfiguration


### PR DESCRIPTION
I recently found out that the Spring Boot starter implicitly requires [Actuator](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html) to work. This PR changes the autoconfiguration so it will work both with and without Actuator on the classpath.