### PR TITLE
change transferwise to wise in the readme due to renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ List of organizations known to be running db-scheduler in production:
 |-------------------------------------------|--------------------------------------------------------------|
 | [Digipost](https://digipost.no)           | Provider of digital mailboxes in Norway                      |
 | [Vy Group](https://www.vy.no/en)          | One of the largest transport groups in the Nordic countries. |
-| [TransferWise](https://transferwise.com/) | A cheap, fast way to send money abroad.                      |
+| [Wise](https://wise.com/)                 | A cheap, fast way to send money abroad.                      |
 | Becker Professional Education             |                                                              |
 | [Monitoria](https://monitoria.ca)         | Website monitoring service.                                  |
 | [Loadster](https://loadster.app)          | Load testing for web applications.                           |


### PR DESCRIPTION
Hey 
we have renamed from TransferWise to Wise some time ago 🙂 
so changing the readme to reflect  this