### PR TITLE
Update: 'Who uses db-scheduler?'

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ List of organizations known to be running db-scheduler in production:
 | [Monitoria](https://monitoria.ca)         | Website monitoring service.                                  |
 | [Loadster](https://loadster.app)          | Load testing for web applications.                           |
 | [Statens vegvesen](https://www.vegvesen.no/)| The Norwegian Public Roads Administration                  |
-| [Lightyear](https://golightyear.com/) |  A simple and approachable way to invest your money globally.    |
+| [Lightyear](https://golightyear.com/)     |  A simple and approachable way to invest your money globally.|
+| [NAV](https://www.nav.no/)                |  The Norwegian Labour and Welfare Administration             |
 
 Feel free to open a PR to add your organization to the list.
 


### PR DESCRIPTION
In production (2022.03.01): https://github.com/navikt/veilarbportefolje/pull/733 