### PR TITLE
Support for disabled schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ The library contains a number of Schedule-implementations for recurring tasks. S
 | ------------- | ------------- |
 | `.daily(LocalTime ...)`  | Runs every day at specified times. Optionally a time zone can be specified. |
 | `.fixedDelay(Duration)`  | Next execution-time is `Duration` after last completed execution. **Note:** This `Schedule` schedules the initial execution to `Instant.now()` when used in `startTasks(...)`|
-| `.cron(String)`  | Spring-style cron-expression. |
+| `.cron(String)`  | Spring-style cron-expression. The pattern `-` is interpreted as a [disabled schedule](#disabled-schedules).  |
 
 Another option to configure schedules is reading string patterns with `Schedules.parse(String)`.
 
@@ -283,8 +283,14 @@ The currently available patterns are:
 | ------------- | ------------- |
 | `FIXED_DELAY\|Ns`  | Same as `.fixedDelay(Duration)` with duration set to N seconds. |
 | `DAILY\|12:30,15:30...(\|time_zone)`  | Same as `.daily(LocalTime)` with optional time zone (e.g. Europe/Rome, UTC)|
+| `-`  | [Disabled schedule](#disabled-schedules) |
 
 More details on the time zone formats can be found [here](https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html#of-java.lang.String-).
+
+### Disabled schedules
+
+A `Schedule` can be marked as disabled. The scheduler will not schedule the initial executions for tasks with a disabled schedule,
+and it will remove any existing executions for that task.
 
 ### Serializers
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/DisabledSchedule.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/DisabledSchedule.java
@@ -19,21 +19,29 @@ import com.github.kagkarlsson.scheduler.task.ExecutionComplete;
 
 import java.time.Instant;
 
-public interface Schedule {
+public class DisabledSchedule implements Schedule{
 
-    Instant getNextExecutionTime(ExecutionComplete executionComplete);
-
-    /**
-     * Used to get the first execution-time for a schedule. Simulates an ExecutionComplete event.
-     */
-    default Instant getInitialExecutionTime(Instant now) {
-        return getNextExecutionTime(ExecutionComplete.simulatedSuccess(now));
+    @Override
+    public Instant getNextExecutionTime(ExecutionComplete executionComplete) {
+        throw unsupportedException();
     }
 
-    boolean isDeterministic();
-
-    default boolean isDisabled() {
-        return false;
+    @Override
+    public boolean isDeterministic() {
+        throw unsupportedException();
     }
 
+    @Override
+    public Instant getInitialExecutionTime(Instant now) {
+        throw unsupportedException();
+    }
+
+    @Override
+    public boolean isDisabled() {
+        return true;
+    }
+
+    private UnsupportedOperationException unsupportedException() {
+        return new UnsupportedOperationException("DisabledSchedule does not support any other operations than 'isDisabled()'. This appears to be a bug.");
+    }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/DisabledScheduleParser.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/DisabledScheduleParser.java
@@ -15,25 +15,21 @@
  */
 package com.github.kagkarlsson.scheduler.task.schedule;
 
-import com.github.kagkarlsson.scheduler.task.ExecutionComplete;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.MatchResult;
+import java.util.regex.Pattern;
 
-import java.time.Instant;
+final class DisabledScheduleParser extends RegexBasedParser {
+    private static final Pattern DISABLED_PATTERN = Pattern.compile("^-$");
+    private static final List<String> EXAMPLES = Collections.singletonList("-");
 
-public interface Schedule {
-
-    Instant getNextExecutionTime(ExecutionComplete executionComplete);
-
-    /**
-     * Used to get the first execution-time for a schedule. Simulates an ExecutionComplete event.
-     */
-    default Instant getInitialExecutionTime(Instant now) {
-        return getNextExecutionTime(ExecutionComplete.simulatedSuccess(now));
+    DisabledScheduleParser() {
+        super(DISABLED_PATTERN, EXAMPLES);
     }
 
-    boolean isDeterministic();
-
-    default boolean isDisabled() {
-        return false;
+    @Override
+    protected Schedule matchedSchedule(MatchResult matchResult) {
+        return new DisabledSchedule();
     }
-
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/Schedules.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/Schedules.java
@@ -21,7 +21,7 @@ import java.time.ZoneId;
 import java.util.List;
 
 public class Schedules {
-    private static final Parser SCHEDULE_PARSER = CompositeParser.of(new FixedDelayParser(), new DailyParser());
+    private static final Parser SCHEDULE_PARSER = CompositeParser.of(new FixedDelayParser(), new DailyParser(), new DisabledScheduleParser());
 
     public static Daily daily(LocalTime... times) {
         return new Daily(times);

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/DisabledCronTaskTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/DisabledCronTaskTest.java
@@ -1,0 +1,74 @@
+package com.github.kagkarlsson.scheduler.functional;
+
+import com.github.kagkarlsson.scheduler.EmbeddedPostgresqlExtension;
+import com.github.kagkarlsson.scheduler.TestTasks;
+import com.github.kagkarlsson.scheduler.task.TaskInstanceId;
+import com.github.kagkarlsson.scheduler.task.helper.RecurringTask;
+import com.github.kagkarlsson.scheduler.task.helper.Tasks;
+import com.github.kagkarlsson.scheduler.task.schedule.Schedules;
+import com.github.kagkarlsson.scheduler.testhelper.ManualScheduler;
+import com.github.kagkarlsson.scheduler.testhelper.SettableClock;
+import com.github.kagkarlsson.scheduler.testhelper.TestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DisabledCronTaskTest {
+
+    public static final String RECURRING_A = "recurring-a";
+    private SettableClock clock;
+
+    @RegisterExtension
+    public EmbeddedPostgresqlExtension postgres = new EmbeddedPostgresqlExtension();
+
+    @BeforeEach
+    public void setUp() {
+        clock = new SettableClock();
+        clock.set(
+            ZonedDateTime.of(
+                LocalDate.of(2018, 3, 1),
+                LocalTime.of(8, 0),
+                ZoneId.systemDefault()).toInstant());
+    }
+
+    @Test
+    public void should_remove_existing_executions_for_tasks_with_disabled_schedule() {
+        RecurringTask<Void> recurringTask = Tasks.recurring(RECURRING_A, Schedules.cron("0 0 12 * * ?"))
+            .execute(TestTasks.DO_NOTHING);
+
+        ManualScheduler scheduler = manualSchedulerFor(recurringTask);
+        scheduler.start();
+        scheduler.stop();
+
+        assertTrue(scheduler.getScheduledExecution(TaskInstanceId.of(RECURRING_A, RecurringTask.INSTANCE)).isPresent());
+
+        RecurringTask<Void> disabledRecurringTask = Tasks.recurring(RECURRING_A, Schedules.cron("-"))
+            .execute(TestTasks.DO_NOTHING);
+
+        ManualScheduler restartedScheduler = manualSchedulerFor(disabledRecurringTask);
+        restartedScheduler.start();
+        restartedScheduler.stop();
+
+        assertFalse(scheduler.getScheduledExecution(TaskInstanceId.of(RECURRING_A, RecurringTask.INSTANCE)).isPresent());
+
+        restartedScheduler.start();
+
+        assertFalse(scheduler.getScheduledExecution(TaskInstanceId.of(RECURRING_A, RecurringTask.INSTANCE)).isPresent());
+    }
+
+    private ManualScheduler manualSchedulerFor(RecurringTask<?> recurringTasks) {
+        return TestHelper.createManualScheduler(postgres.getDataSource())
+            .clock(clock)
+            .startTasks(singletonList(recurringTasks))
+            .build();
+    }
+}

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/CronTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/CronTest.java
@@ -12,6 +12,8 @@ import java.time.ZonedDateTime;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class CronTest {
@@ -68,6 +70,12 @@ public class CronTest {
         //Every day: 13:05 and 20:05 New York time
         ZonedDateTime firstJanuaryMiddayUTC = ZonedDateTime.of(2000, 1, 1, 12, 0, 0, 0, utc);   //midday UTC = 07:00 New York time
         assertNextExecutionTime(firstJanuaryMiddayUTC, "0 05 13,20 * * ?", newYork, ZonedDateTime.of(2000, 1, 1, 13, 5, 0, 0, newYork));  //next fire time should be 13:05 New York time
+    }
+
+    @Test
+    public void should_mark_schedule_as_disabled() {
+        assertTrue(Schedules.cron("-").isDisabled());
+        assertFalse(Schedules.cron("0 * * * * ?").isDisabled());
     }
 
     private void assertNextExecutionTime(ZonedDateTime timeDone, String cronPattern, ZonedDateTime expectedTime) {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/SchedulesTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/SchedulesTest.java
@@ -1,6 +1,7 @@
 package com.github.kagkarlsson.scheduler.task;
 
 import com.github.kagkarlsson.scheduler.task.schedule.Daily;
+import com.github.kagkarlsson.scheduler.task.schedule.DisabledSchedule;
 import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay;
 import com.github.kagkarlsson.scheduler.task.schedule.Schedule;
 import com.github.kagkarlsson.scheduler.task.schedule.Schedules;
@@ -50,6 +51,8 @@ public class SchedulesTest {
 
         Schedule fixedDelaySchedule = assertParsable("FIXED_DELAY|10s", FixedDelay.class);
         assertThat(fixedDelaySchedule.getNextExecutionTime(complete(NOON_TODAY)), is(NOON_TODAY.plusSeconds(10)));
+
+        assertParsable("-", DisabledSchedule.class);
     }
 
     private ExecutionComplete complete(Instant timeDone) {

--- a/examples/features/src/main/java/com/github/kagkarlsson/examples/JobChainingPocMain.java
+++ b/examples/features/src/main/java/com/github/kagkarlsson/examples/JobChainingPocMain.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) Gustav Karlsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.kagkarlsson.examples;
 
 import com.github.kagkarlsson.examples.helpers.Example;


### PR DESCRIPTION
A Schedule for a RecurringTask can be marked as disabled. Will remove existing executions and not schedule new ones.