### PR TITLE
Upgrade to Spring Boot 2.7.0

### DIFF
--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
@@ -48,6 +48,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.sql.init.dependency.DependsOnDatabaseInitialization;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.ConfigurableObjectInputStream;
@@ -63,7 +64,7 @@ import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy;
 @ConditionalOnProperty(value = "db-scheduler.enabled", matchIfMissing = true)
 public class DbSchedulerAutoConfiguration {
     private static final Logger log = LoggerFactory.getLogger(DbSchedulerAutoConfiguration.class);
-    private static Predicate<Task<?>> shouldBeStarted = task -> task instanceof OnStartup;
+    private static final Predicate<Task<?>> shouldBeStarted = task -> task instanceof OnStartup;
 
     private final DbSchedulerProperties config;
     private final DataSource existingDataSource;
@@ -98,6 +99,7 @@ public class DbSchedulerAutoConfiguration {
 
     @ConditionalOnBean(DataSource.class)
     @ConditionalOnMissingBean
+    @DependsOnDatabaseInitialization
     @Bean(destroyMethod = "stop")
     public Scheduler scheduler(DbSchedulerCustomizer customizer, StatsRegistry registry) {
         log.info("Creating db-scheduler using tasks from Spring context: {}", configuredTasks);

--- a/db-scheduler-boot-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
+++ b/db-scheduler-boot-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
@@ -34,6 +34,7 @@ import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegi
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.sql.init.SqlInitializationAutoConfiguration;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -52,6 +53,7 @@ public class DbSchedulerAutoConfigurationTest {
                 "spring.profiles.active=integration-test"
             ).withConfiguration(AutoConfigurations.of(
                 DataSourceAutoConfiguration.class,
+                SqlInitializationAutoConfiguration.class,
                 MetricsAutoConfiguration.class,
                 CompositeMeterRegistryAutoConfiguration.class,
                 HealthContributorAutoConfiguration.class,

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<dependency-plugin.failOnWarning>true</dependency-plugin.failOnWarning>
 
 		<!-- Dependency versions -->
-		<spring-boot.version>2.3.4.RELEASE</spring-boot.version>
+		<spring-boot.version>2.7.0</spring-boot.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
In preparation for [Spring Boot 3.0.0](https://spring.io/blog/2022/05/24/preparing-for-spring-boot-3-0) it is recommended to build against 2.7.0. This PR does just that.