### PR TITLE
CI: Remove deprecated GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
         java: [ '8', '11', '17' ]
     name: Temurin ${{ matrix.java }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Java ${{ matrix.java }}
       uses: actions/setup-java@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,25 +5,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '15' ]
-    name: AdoptOpenJDK ${{ matrix.java }}
+        java: [ '8', '11', '17' ]
+    name: Temurin ${{ matrix.java }}
     steps:
     - uses: actions/checkout@v2
 
     - name: Set up Java ${{ matrix.java }}
-      uses: joschi/setup-jdk@v2
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.java }}
-
-    - name: Configure Maven cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
+        distribution: 'temurin'
+        cache: 'maven'
 
     - name: Run all tests
-      run: mvn -Pcompatibility clean test --file pom.xml
+      run: mvn -B -Pcompatibility clean test --file pom.xml
       env:
         TZ: UTC

--- a/db-scheduler/pom.xml
+++ b/db-scheduler/pom.xml
@@ -18,7 +18,8 @@
         <hikaricp.version>4.0.3</hikaricp.version>
         <hsqldb.version>2.6.1</hsqldb.version>
         <java8-matchers.version>1.6</java8-matchers.version>
-        <equals-verifier.version>3.9</equals-verifier.version>
+        <equals-verifier.version>3.10</equals-verifier.version>
+        <bytebuddy.version>1.12.8</bytebuddy.version>
         <micro-jdbc.version>0.3</micro-jdbc.version>
         <otj-pg-embedded.version>0.11.4</otj-pg-embedded.version>
         <postgresql.version>42.3.3</postgresql.version>
@@ -125,6 +126,12 @@
             <artifactId>equalsverifier</artifactId>
             <version>${equals-verifier.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>byte-buddy</artifactId>
+                    <groupId>net.bytebuddy</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -205,12 +212,34 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.3.3</version>
+            <version>3.12.4</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>byte-buddy</artifactId>
+                    <groupId>net.bytebuddy</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>byte-buddy-agent</artifactId>
+                    <groupId>net.bytebuddy</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>${bytebuddy.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-agent</artifactId>
+            <version>${bytebuddy.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Reduces number of deprecation warnings. Also adds support for Java 17 (and possibly new versions in the future).