### PR TITLE
Add indices to default schema

### DIFF
--- a/db-scheduler/src/test/resources/mssql_tables.sql
+++ b/db-scheduler/src/test/resources/mssql_tables.sql
@@ -10,5 +10,7 @@ create table scheduled_tasks (
   consecutive_failures INT,
   last_heartbeat datetimeoffset ,
   [version] BIGINT not null,
-  PRIMARY KEY (task_name, task_instance)
+  PRIMARY KEY (task_name, task_instance),
+  INDEX execution_time_idx (execution_time),
+  INDEX last_heartbeat_idx (last_heartbeat)
 )

--- a/db-scheduler/src/test/resources/mysql_tables.sql
+++ b/db-scheduler/src/test/resources/mysql_tables.sql
@@ -10,5 +10,7 @@ create table test.scheduled_tasks (
   consecutive_failures INT,
   last_heartbeat timestamp(6) null,
   version BIGINT not null,
-  PRIMARY KEY (task_name, task_instance)
+  PRIMARY KEY (task_name, task_instance),
+  INDEX execution_time_idx (execution_time),
+  INDEX last_heartbeat_idx (last_heartbeat)
 )

--- a/db-scheduler/src/test/resources/oracle_tables.sql
+++ b/db-scheduler/src/test/resources/oracle_tables.sql
@@ -12,4 +12,7 @@ create table scheduled_tasks
     last_heartbeat       TIMESTAMP(6),
     version              NUMBER(19, 0),
     PRIMARY KEY (task_name, task_instance)
-)
+);
+
+CREATE INDEX execution_time_idx ON scheduled_tasks (execution_time);
+CREATE INDEX last_heartbeat_idx ON scheduled_tasks (last_heartbeat);

--- a/db-scheduler/src/test/resources/postgresql_tables.sql
+++ b/db-scheduler/src/test/resources/postgresql_tables.sql
@@ -11,4 +11,7 @@ create table scheduled_tasks (
   last_heartbeat timestamp with time zone,
   version BIGINT not null,
   PRIMARY KEY (task_name, task_instance)
-)
+);
+
+CREATE INDEX execution_time_idx ON scheduled_tasks (execution_time);
+CREATE INDEX last_heartbeat_idx ON scheduled_tasks (last_heartbeat);


### PR DESCRIPTION
Follow up on this issue #127 .

First of all, thanks for the great library.

We've faced this slow log issue when the number of rows reached around 3.5 million on MySQL (on db.t3.medium AWS RDS). Adding the two indices helped.

So it would be more scalable for others too if these indices were in the default schema.