### PR TITLE
Changing ExecutionComplete constructor visibility to public

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/ExecutionComplete.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/ExecutionComplete.java
@@ -26,7 +26,7 @@ public class ExecutionComplete {
     private final Result result;
     private final Throwable cause;
 
-    ExecutionComplete(Execution execution, Instant timeStarted, Instant timeDone, Result result, Throwable cause) {
+    public ExecutionComplete(Execution execution, Instant timeStarted, Instant timeDone, Result result, Throwable cause) {
         this.timeStarted = timeStarted;
         this.cause = cause;
         if (result == Result.OK && cause != null) {


### PR DESCRIPTION
I don't know exactly if it was intended, but I didn't find a way to reschedule a task from its dead execution handler.
I tried creating a new handler and passing it to ```onDeadExecution```, but its parameters are ```Execution``` and ```ExecutionOperation<Void>```.
Reading the code from ```DeadExecutionHandler.java``` I noticed that it creates a new ```ExecutionComplete```, passing ```execution``` as a parameter. I expected to be able to do the same thing, but ```ExecutionComplete``` has a constructor with default visibility (package only).
![image](https://user-images.githubusercontent.com/17167472/177388768-6d0ed798-a994-4334-b137-a7a455d49b7c.png)

I don't know if ```ExecutionComplete```'s constructor was supposed to be only visibile from its package. If not, this PR should fix it. If the behavior is intented, how should I reschedule my task from its dead execution handler?
