### PR TITLE
Enhance db-scheduler to support asynchronous task execution

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Executor.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Executor.java
@@ -99,4 +99,8 @@ public class Executor {
             LOG.warn("Released execution was not found in collection of executions currently being processed. Should never happen. Execution-id: " + executionId);
         }
     }
+
+    public ExecutorService getExecutorService() {
+        return executorService;
+    }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/ExecutionHandler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/ExecutionHandler.java
@@ -15,6 +15,8 @@
  */
 package com.github.kagkarlsson.scheduler.task;
 
+import java.util.concurrent.CompletableFuture;
+
 public interface ExecutionHandler<T> {
-    CompletionHandler<T> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext);
+    CompletableFuture<CompletionHandler<T>> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext);
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/StateReturningExecutionHandler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/StateReturningExecutionHandler.java
@@ -15,6 +15,8 @@
  */
 package com.github.kagkarlsson.scheduler.task;
 
+import java.util.concurrent.CompletableFuture;
+
 public interface StateReturningExecutionHandler<T> {
 
     /**
@@ -24,5 +26,5 @@ public interface StateReturningExecutionHandler<T> {
      * @param executionContext
      * @return
      */
-    T execute(TaskInstance<T> taskInstance, ExecutionContext executionContext);
+    CompletableFuture<T> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext);
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/VoidExecutionHandler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/VoidExecutionHandler.java
@@ -15,6 +15,8 @@
  */
 package com.github.kagkarlsson.scheduler.task;
 
+import java.util.concurrent.CompletableFuture;
+
 public interface VoidExecutionHandler<T> {
-    void execute(TaskInstance<T> taskInstance, ExecutionContext executionContext);
+    CompletableFuture<Void> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext);
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/OneTimeTask.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/OneTimeTask.java
@@ -22,6 +22,7 @@ import com.github.kagkarlsson.scheduler.task.FailureHandler.OnFailureRetryLater;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
 
 public abstract class OneTimeTask<T> extends AbstractTask<T> {
 
@@ -44,12 +45,14 @@ public abstract class OneTimeTask<T> extends AbstractTask<T> {
     }
 
     @Override
-    public CompletionHandler<T> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
-        executeOnce(taskInstance, executionContext);
-        return new OnCompleteRemove<>();
+    public CompletableFuture<CompletionHandler<T>> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+        CompletableFuture<Void> voidFuture = executeOnce(taskInstance, executionContext);
+        return voidFuture.thenApply((nextData) -> {
+            return new OnCompleteRemove<>();
+        });
     }
 
-    public abstract void executeOnce(TaskInstance<T> taskInstance, ExecutionContext executionContext);
+    public abstract CompletableFuture<Void> executeOnce(TaskInstance<T> taskInstance, ExecutionContext executionContext);
 
     @Override
     public String toString() {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTask.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTask.java
@@ -24,6 +24,7 @@ import com.github.kagkarlsson.scheduler.task.schedule.Schedule;
 
 import java.time.Instant;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 public abstract class RecurringTask<T> extends AbstractTask<T> implements OnStartup {
 
@@ -65,12 +66,15 @@ public abstract class RecurringTask<T> extends AbstractTask<T> implements OnStar
     }
 
     @Override
-    public CompletionHandler<T> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
-        executeRecurringly(taskInstance, executionContext);
-        return onComplete;
+    public CompletableFuture<CompletionHandler<T>> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+        CompletableFuture<Void> voidFuture = executeRecurringly(taskInstance, executionContext);
+        return voidFuture.thenApply((v) -> {
+            return onComplete;
+        });
+
     }
 
-    public abstract void executeRecurringly(TaskInstance<T> taskInstance, ExecutionContext executionContext);
+    public abstract CompletableFuture<Void> executeRecurringly(TaskInstance<T> taskInstance, ExecutionContext executionContext);
 
     public TaskInstanceId getDefaultTaskInstance() {
         return TaskInstanceId.of(name, INSTANCE);

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/ClusterTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/ClusterTest.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -112,6 +113,7 @@ public class ClusterTest {
                     .execute((taskInstance, executionContext) -> {
                         // do nothing
                         // System.out.println(counter.incrementAndGet() + " " + Thread.currentThread().getName());
+                        return CompletableFuture.completedFuture(null);
                     });
 
             final TestTasks.SimpleStatsRegistry stats = new TestTasks.SimpleStatsRegistry();

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import static com.github.kagkarlsson.scheduler.jdbc.JdbcTaskRepository.DEFAULT_TABLE_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -140,9 +141,11 @@ public class DeadExecutionsTest {
         }
 
         @Override
-        public void executeOnce(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
-            handler.execute(taskInstance, executionContext);
-            throw new RuntimeException("simulated unexpected exception");
+        public CompletableFuture<Void> executeOnce(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+            return handler.execute(taskInstance, executionContext)
+                .thenApply((v) -> {
+                    throw new RuntimeException("simulated unexpected exception");
+                });
         }
     }
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/ExecutionTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/ExecutionTest.java
@@ -7,6 +7,7 @@ import com.github.kagkarlsson.scheduler.task.helper.RecurringTask;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -23,7 +24,7 @@ public class ExecutionTest {
     @Test
     public void test_equals() {
         Instant now = Instant.now();
-        OneTimeTask<Void> task = TestTasks.oneTime("OneTime", Void.class, (instance, executionContext) -> {});
+        OneTimeTask<Void> task = TestTasks.oneTime("OneTime", Void.class, (instance, executionContext) -> CompletableFuture.completedFuture(null));
         RecurringTask<Void> task2 = TestTasks.recurring("Recurring", FixedDelay.of(Duration.ofHours(1)), TestTasks.DO_NOTHING);
 
         assertEquals(new Execution(now, task.instance("id1")), new Execution(now, task.instance("id1")));

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/ScheduledExecutionTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/ScheduledExecutionTest.java
@@ -6,6 +6,7 @@ import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -23,14 +24,14 @@ public class ScheduledExecutionTest {
     }
 
     private ScheduledExecution<Void> createExecution(String taskname, String id, Instant executionTime) {
-        OneTimeTask<Integer> task = TestTasks.oneTime(taskname, Integer.class, (instance, executionContext) -> {});
+        OneTimeTask<Integer> task = TestTasks.oneTime(taskname, Integer.class, (instance, executionContext) -> CompletableFuture.completedFuture(null));
         return new ScheduledExecution<Void>(Void.class, new Execution(executionTime, task.instance(id)));
     }
 
     @Test
     public void test_data_class_type_equals() {
         Instant now = Instant.now();
-        OneTimeTask<Integer> task = TestTasks.oneTime("OneTime", Integer.class, (instance, executionContext) -> {});
+        OneTimeTask<Integer> task = TestTasks.oneTime("OneTime", Integer.class, (instance, executionContext) -> CompletableFuture.completedFuture(null));
         Execution execution = new Execution(now, task.instance("id1", new Integer(1)));
 
         ScheduledExecution<Integer> scheduledExecution = new ScheduledExecution<>(Integer.class, execution);
@@ -42,8 +43,7 @@ public class ScheduledExecutionTest {
         DataClassMismatchException dataClassMismatchException = assertThrows(DataClassMismatchException.class, () -> {
 
             Instant now = Instant.now();
-            OneTimeTask<Integer> task = TestTasks.oneTime("OneTime", Integer.class, (instance, executionContext) -> {
-            });
+            OneTimeTask<Integer> task = TestTasks.oneTime("OneTime", Integer.class, (instance, executionContext) -> CompletableFuture.completedFuture(null));
             Execution execution = new Execution(now, task.instance("id1", new Integer(1))); // Data class is an integer
 
             new ScheduledExecution<>(String.class, execution).getData(); // Instantiate with incorrect type

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.time.Duration.ofSeconds;
@@ -65,16 +66,18 @@ public class SchedulerClientTest {
     }
 
     @Test
-    public void client_should_be_able_to_schedule_executions() {
+    public void client_should_be_able_to_schedule_executions() throws InterruptedException {
         SchedulerClient client = SchedulerClient.Builder.create(DB.getDataSource()).build();
         client.schedule(oneTimeTaskA.instance("1"), settableClock.now());
 
         scheduler.runAnyDueExecutions();
+        // Since execution is executed in an async way, we need to wait for a while to let the execution finish before asserting
+        Thread.sleep(1000);
         assertThat(onetimeTaskHandlerA.timesExecuted.get(), CoreMatchers.is(1));
     }
 
     @Test
-    public void should_be_able_to_schedule_other_executions_from_an_executionhandler() {
+    public void should_be_able_to_schedule_other_executions_from_an_executionhandler() throws InterruptedException {
         scheduler.schedule(scheduleAnotherTask.instance("1"), settableClock.now());
         scheduler.runAnyDueExecutions();
         assertThat(scheduleAnother.timesExecuted, CoreMatchers.is(1));
@@ -82,6 +85,8 @@ public class SchedulerClientTest {
 
         scheduler.tick(ofSeconds(1));
         scheduler.runAnyDueExecutions();
+        // Since execution is executed in an async way, we need to wait for a while to let the execution finish before asserting
+        Thread.sleep(1000);
         assertThat(onetimeTaskHandlerA.timesExecuted.get(), CoreMatchers.is(1));
     }
 
@@ -155,9 +160,10 @@ public class SchedulerClientTest {
         }
 
         @Override
-        public void execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+        public CompletableFuture<Void> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
             executionContext.getSchedulerClient().schedule(secondTask, instant);
             this.timesExecuted++;
+            return CompletableFuture.completedFuture(null);
         }
     }
 }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/TestTasks.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/TestTasks.java
@@ -13,6 +13,7 @@ import com.github.kagkarlsson.scheduler.task.helper.RecurringTask;
 import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.LoggerFactory;
@@ -20,13 +21,15 @@ import org.slf4j.LoggerFactory;
 public class TestTasks {
 
     public static final CompletionHandler<Void> REMOVE_ON_COMPLETE = new CompletionHandler.OnCompleteRemove<>();
-    public static final VoidExecutionHandler<Void> DO_NOTHING = (taskInstance, executionContext) -> {};
+    public static final VoidExecutionHandler<Void> DO_NOTHING = (taskInstance, executionContext) -> {
+        return CompletableFuture.completedFuture(null);
+    };
 
     public static <T> OneTimeTask<T> oneTime(String name, Class<T> dataClass, VoidExecutionHandler<T> handler) {
         return new OneTimeTask<T>(name, dataClass) {
             @Override
-            public void executeOnce(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
-                handler.execute(taskInstance, executionContext);
+            public CompletableFuture<Void> executeOnce(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+                return handler.execute(taskInstance, executionContext);
             }
         };
     }
@@ -34,8 +37,8 @@ public class TestTasks {
     public static <T> OneTimeTask<T> oneTimeWithType(String name, Class<T> dataClass, VoidExecutionHandler<T> handler) {
         return new OneTimeTask<T>(name, dataClass) {
             @Override
-            public void executeOnce(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
-                handler.execute(taskInstance, executionContext);
+            public CompletableFuture<Void> executeOnce(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+                return handler.execute(taskInstance, executionContext);
             }
         };
     }
@@ -43,8 +46,8 @@ public class TestTasks {
     public static RecurringTask<Void> recurring(String name, FixedDelay schedule, VoidExecutionHandler<Void> handler) {
         return new RecurringTask<Void>(name, schedule, Void.class) {
             @Override
-            public void executeRecurringly(TaskInstance<Void> taskInstance, ExecutionContext executionContext) {
-                handler.execute(taskInstance, executionContext);
+            public CompletableFuture<Void> executeRecurringly(TaskInstance<Void> taskInstance, ExecutionContext executionContext) {
+                return handler.execute(taskInstance, executionContext);
             }
         };
     }
@@ -52,8 +55,8 @@ public class TestTasks {
     public static <T> RecurringTask<T> recurringWithData(String name, Class<T> dataClass, T initialData, FixedDelay schedule, VoidExecutionHandler<T> handler) {
         return new RecurringTask<T>(name, schedule, dataClass, initialData) {
             @Override
-            public void executeRecurringly(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
-                handler.execute(taskInstance, executionContext);
+            public CompletableFuture<Void> executeRecurringly(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+                return handler.execute(taskInstance, executionContext);
             }
         };
     }
@@ -98,13 +101,15 @@ public class TestTasks {
         }
 
         @Override
-        public void execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
-            this.timesExecuted.incrementAndGet();
-            try {
-                Thread.sleep(wait.toMillis());
-            } catch (InterruptedException e) {
-                LoggerFactory.getLogger(CountingHandler.class).info("Interrupted.");
-            }
+        public CompletableFuture<Void> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+            return CompletableFuture.runAsync(() -> {
+                this.timesExecuted.incrementAndGet();
+                try {
+                    Thread.sleep(wait.toMillis());
+                } catch (InterruptedException e) {
+                    LoggerFactory.getLogger(CountingHandler.class).info("Interrupted.");
+                }
+            });
         }
     }
 
@@ -117,12 +122,14 @@ public class TestTasks {
         }
 
         @Override
-        public void execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
-            try {
-                waitForNotify.await();
-            } catch (InterruptedException e) {
-                LoggerFactory.getLogger(WaitingHandler.class).info("Interrupted.");
-            }
+        public CompletableFuture<Void> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+            return CompletableFuture.runAsync(() -> {
+                try {
+                    waitForNotify.await();
+                } catch (InterruptedException e) {
+                    LoggerFactory.getLogger(WaitingHandler.class).info("Interrupted.");
+                }
+            });
         }
     }
 
@@ -137,13 +144,15 @@ public class TestTasks {
         }
 
         @Override
-        public void execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
-            try {
-                waitForExecute.countDown();
-                waitInExecuteUntil.await();
-            } catch (InterruptedException e) {
-                LoggerFactory.getLogger(WaitingHandler.class).info("Interrupted.");
-            }
+        public CompletableFuture<Void> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+            return CompletableFuture.runAsync(() -> {
+                try {
+                    waitForExecute.countDown();
+                    waitInExecuteUntil.await();
+                } catch (InterruptedException e) {
+                    LoggerFactory.getLogger(WaitingHandler.class).info("Interrupted.");
+                }
+            });
         }
     }
 
@@ -156,19 +165,22 @@ public class TestTasks {
         }
 
         @Override
-        public void execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
-            try {
-                Thread.sleep(millis);
-            } catch (InterruptedException e) {
-                LoggerFactory.getLogger(WaitingHandler.class).info("Interrupted.");
-            }
+        public CompletableFuture<Void> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+            return CompletableFuture.runAsync(() -> {
+                try {
+                    Thread.sleep(millis);
+                } catch (InterruptedException e) {
+                    LoggerFactory.getLogger(WaitingHandler.class).info("Interrupted.");
+                }
+            });
         }
     }
 
     public static class DoNothingHandler<T> implements VoidExecutionHandler<T> {
 
         @Override
-        public void execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+        public CompletableFuture<Void> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+            return CompletableFuture.completedFuture(null);
         }
     }
 
@@ -176,8 +188,9 @@ public class TestTasks {
         public T savedData;
 
         @Override
-        public void execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+        public CompletableFuture<Void> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
             savedData = taskInstance.getData();
+            return CompletableFuture.completedFuture(null);
         }
     }
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/DeadExecutionTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/DeadExecutionTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
 
 import static com.github.kagkarlsson.scheduler.stats.StatsRegistry.SchedulerStatsEvent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,12 +33,12 @@ public class DeadExecutionTest {
     public void test_dead_execution() {
         Assertions.assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
             CustomTask<Void> customTask = Tasks.custom("custom-a", Void.class)
-                .execute((taskInstance, executionContext) -> new CompletionHandler<Void>() {
+                .execute((taskInstance, executionContext) -> CompletableFuture.supplyAsync(() -> new CompletionHandler<Void>() {
                     @Override
                     public void complete(ExecutionComplete executionComplete, ExecutionOperations<Void> executionOperations) {
                         //do nothing on complete, row will be left as-is in database
                     }
-                });
+                }));
 
             TestableRegistry.Condition completedCondition = TestableRegistry.Conditions.completed(2);
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/RecurringTaskTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/RecurringTaskTest.java
@@ -21,6 +21,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import static co.unruly.matchers.OptionalMatchers.contains;
 import static java.util.Collections.singletonList;
@@ -120,7 +121,7 @@ public class RecurringTaskTest {
     public void should_not_update_data_of_preexisting_exeutions_even_if_rescheduling_because_of_updated_schedule() {
         RecurringTask<Integer> recurringTask = Tasks.recurring(RECURRING_A, Schedules.daily(LocalTime.of(23, 59)), Integer.class)
             .initialData(1)
-            .execute((taskInstance, executionContext) -> {});
+            .execute((taskInstance, executionContext) -> CompletableFuture.completedFuture(null));
 
         ManualScheduler scheduler = manualSchedulerFor(singletonList(recurringTask));
 
@@ -133,7 +134,7 @@ public class RecurringTaskTest {
                 LocalTime.of(12, 0),
                 LocalTime.of(23, 59)), Integer.class)
             .initialData(2)
-            .execute((taskInstance, executionContext) -> {});
+            .execute((taskInstance, executionContext) -> CompletableFuture.completedFuture(null));
 
         ManualScheduler schedulerUpdatedTask = manualSchedulerFor(singletonList(recurringTaskNewSchedule));
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/helper/ComposableTask.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/helper/ComposableTask.java
@@ -20,6 +20,7 @@ import com.github.kagkarlsson.scheduler.task.schedule.Schedule;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
 
 @Deprecated
 public class ComposableTask {
@@ -27,8 +28,8 @@ public class ComposableTask {
     public static <T> OneTimeTask<T> onetimeTask(String name, Class<T> dataClass, VoidExecutionHandler<T> executionHandler) {
         return new OneTimeTask<T>(name, dataClass) {
             @Override
-            public void executeOnce(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
-                executionHandler.execute(taskInstance, executionContext);
+            public CompletableFuture<Void> executeOnce(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+                return executionHandler.execute(taskInstance, executionContext);
             }
         };
     }
@@ -46,9 +47,9 @@ public class ComposableTask {
             }
 
             @Override
-            public CompletionHandler<T> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
-                executionHandler.execute(taskInstance, executionContext);
-                return completionHandler;
+            public CompletableFuture<CompletionHandler<T>> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+                return executionHandler.execute(taskInstance, executionContext)
+                    .thenApply((v) -> completionHandler);
             }
         };
     }
@@ -66,9 +67,9 @@ public class ComposableTask {
             }
 
             @Override
-            public CompletionHandler<T> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
-                executionHandler.execute(taskInstance, executionContext);
-                return completionHandler;
+            public CompletableFuture<CompletionHandler<T>> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+                return executionHandler.execute(taskInstance, executionContext)
+                    .thenApply((v) -> completionHandler);
             }
         };
     }


### PR DESCRIPTION
Thank you for maintaining db-scheduler.

# What
This PR enhances db-scheduler to support task execution asynchronously. It addresses [this issue](https://github.com/kagkarlsson/db-scheduler/issues/114)

# Why
db-scheduler has an executorservice of threadpool. Threadpools are used to schedule db-scheduler tasks.
Tasks were executed in a synchronous way. If tasks do something (http call eg) asynchronously, the threadpool will remain blocked.
This might not be an issue where tasks are tiny or the task throughput is tiny. But, it can become an issue for some scenarios.

# Current status
* Few TCs are flaky due to asychronous implementation. To look into fixing it.
* Create PR upstream to the original repo, get it merged possibly