### PR TITLE
Add support for ExecutionOperations.replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ scheduler.schedule(myAdhocTask.instance("1045", new MyTaskData(1001L)), Instant.
 * [RecurringTaskWithPersistentScheduleMain.java](./examples/features/src/main/java/com/github/kagkarlsson/examples/RecurringTaskWithPersistentScheduleMain.java)
 * [StatefulRecurringTaskWithPersistentScheduleMain.java](./examples/features/src/main/java/com/github/kagkarlsson/examples/StatefulRecurringTaskWithPersistentScheduleMain.java)
 * [JsonSerializerMain.java](./examples/features/src/main/java/com/github/kagkarlsson/examples/JsonSerializerMain.java)
+* [JobChainingUsingTaskDataMain.java](./examples/features/src/main/java/com/github/kagkarlsson/examples/JobChainingUsingTaskDataMain.java)
+* [JobChainingUsingSeparateTasksMain.java](./examples/features/src/main/java/com/github/kagkarlsson/examples/JobChainingUsingSeparateTasksMain.java)
 
 
 ## Configuration

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
@@ -28,6 +28,9 @@ public interface TaskRepository {
 
     boolean createIfNotExists(SchedulableInstance execution);
     List<Execution> getDue(Instant now, int limit);
+
+    Instant replace(Execution toBeReplaced, SchedulableInstance newInstance);
+
     void getScheduledExecutions(ScheduledExecutionsFilter filter, Consumer<Execution> consumer);
     void getScheduledExecutions(ScheduledExecutionsFilter filter, String taskName, Consumer<Execution> consumer);
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TriggerCheckForDueExecutions.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TriggerCheckForDueExecutions.java
@@ -47,7 +47,7 @@ class TriggerCheckForDueExecutions implements SchedulerClientEventListener {
 
             Instant scheduledToExecutionTime = ctx.getExecutionTime();
             if (scheduledToExecutionTime.toEpochMilli() <= clock.now().toEpochMilli()) {
-                LOG.info("Task-instance scheduled to run directly, triggering check for due exections (unless it is already running). Task: {}, instance: {}",
+                LOG.debug("Task-instance scheduled to run directly, triggering check for due executions (unless it is already running). Task: {}, instance: {}",
                         ctx.getTaskInstanceId().getTaskName(), ctx.getTaskInstanceId().getId());
                 executeDueWaiter.wakeOrSkipNextWait();
             }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
@@ -5,10 +5,7 @@ import com.github.kagkarlsson.scheduler.helper.TestableRegistry;
 import com.github.kagkarlsson.scheduler.helper.TimeHelper;
 import com.github.kagkarlsson.scheduler.jdbc.JdbcTaskRepository;
 import com.github.kagkarlsson.scheduler.stats.StatsRegistry.SchedulerStatsEvent;
-import com.github.kagkarlsson.scheduler.task.Execution;
-import com.github.kagkarlsson.scheduler.task.SchedulableTaskInstance;
-import com.github.kagkarlsson.scheduler.task.Task;
-import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import com.github.kagkarlsson.scheduler.task.*;
 import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -78,6 +75,23 @@ public class JdbcTaskRepositoryTest {
         assertFalse(taskRepository.createIfNotExists(new SchedulableTaskInstance<>(instance1, now)));
 
         assertTrue(taskRepository.createIfNotExists(new SchedulableTaskInstance<>(instance2, now)));
+    }
+
+    @Test
+    public void test_replace() {
+        Instant now = TimeHelper.truncatedInstantNow();
+
+        TaskInstance<Integer> instance1 = oneTimeTaskWithData.instance("id1", 1);
+        SchedulableInstance<Integer> instance2 = oneTimeTaskWithData.schedulableInstance("id2", 2);
+
+        assertTrue(taskRepository.createIfNotExists(new SchedulableTaskInstance<>(instance1, now)));
+        Execution scheduled = taskRepository.getExecution(instance1).get();
+        assertEquals(1, scheduled.taskInstance.getData());
+
+        taskRepository.replace(scheduled, instance2);
+        Execution replaced = taskRepository.getExecution(instance2.getTaskInstance()).get();
+        assertEquals(2, replaced.taskInstance.getData());
+        assertEquals("id2", replaced.taskInstance.getId());
     }
 
     @Test

--- a/examples/features/src/main/java/com/github/kagkarlsson/examples/JobChainingUsingSeparateTasksMain.java
+++ b/examples/features/src/main/java/com/github/kagkarlsson/examples/JobChainingUsingSeparateTasksMain.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (C) Gustav Karlsson
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.kagkarlsson.examples;
+
+import com.github.kagkarlsson.examples.helpers.Example;
+import com.github.kagkarlsson.scheduler.Scheduler;
+import com.github.kagkarlsson.scheduler.task.*;
+import com.github.kagkarlsson.scheduler.task.helper.CustomTask;
+import com.github.kagkarlsson.scheduler.task.helper.Tasks;
+
+import javax.sql.DataSource;
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.Instant;
+
+public class JobChainingUsingSeparateTasksMain extends Example {
+
+    public static void main(String[] args) {
+        new JobChainingUsingSeparateTasksMain().runWithDatasource();
+    }
+
+    @Override
+    public void run(DataSource dataSource) {
+
+        final CustomTask<JobId> jobStep1 = Tasks.custom("job-step-1", JobId.class)
+            .execute((taskInstance, executionContext) -> {
+                System.out.println("Step1 ran. Job: " + taskInstance.getData());
+                return new OnCompleteRemoveAndCreateNextStep("job-step-2");
+            });
+
+        final CustomTask<JobId> jobStep2 = Tasks.custom("job-step-2", JobId.class)
+            .execute((taskInstance, executionContext) -> {
+                System.out.println("Step2 ran. Removing multistep-job. Job: " + taskInstance.getData());
+                return new CompletionHandler.OnCompleteRemove<>();
+            });
+
+        final Scheduler scheduler = Scheduler
+            .create(dataSource, jobStep1, jobStep2)
+            .enableImmediateExecution()  // will cause job scheduled to now() to run directly
+            .pollingInterval(Duration.ofSeconds(10))
+            .build();
+
+        scheduler.start();
+
+        sleep(1_000);
+
+        // Schedule a multistep job. Simulate some instance-specific data, id=507
+        scheduler.schedule(jobStep1.instance("job-507", new JobId(507)), Instant.now()); // both steps will run directly
+    }
+
+    public static class JobId implements Serializable {
+        private static long serialVersionUID = 1L;
+        public int id;
+
+        public JobId(int id) {
+            this.id = id;
+        }
+
+        @Override
+        public String toString() {
+            return "JobId{" +
+                "id=" + id +
+                '}';
+        }
+    }
+
+    class OnCompleteRemoveAndCreateNextStep implements CompletionHandler<JobId> {
+        private final String newTaskName;
+
+        public OnCompleteRemoveAndCreateNextStep(String newTaskName) {
+            this.newTaskName = newTaskName;
+        }
+
+        @Override
+        public void complete(ExecutionComplete executionComplete, ExecutionOperations<JobId> executionOperations) {
+            TaskInstance taskInstance = executionComplete.getExecution().taskInstance;
+            TaskInstance<JobId> nextInstance = new TaskInstance<>(newTaskName, taskInstance.getId(), (JobId) taskInstance.getData());
+            executionOperations.removeAndScheduleNew(SchedulableInstance.of(nextInstance, Instant.now()));
+        }
+    }
+
+}

--- a/examples/features/src/main/java/com/github/kagkarlsson/examples/JobChainingUsingTaskDataMain.java
+++ b/examples/features/src/main/java/com/github/kagkarlsson/examples/JobChainingUsingTaskDataMain.java
@@ -17,10 +17,7 @@ package com.github.kagkarlsson.examples;
 
 import com.github.kagkarlsson.examples.helpers.Example;
 import com.github.kagkarlsson.scheduler.Scheduler;
-import com.github.kagkarlsson.scheduler.logging.LogLevel;
 import com.github.kagkarlsson.scheduler.task.CompletionHandler;
-import com.github.kagkarlsson.scheduler.task.ExecutionComplete;
-import com.github.kagkarlsson.scheduler.task.ExecutionOperations;
 import com.github.kagkarlsson.scheduler.task.helper.CustomTask;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 
@@ -29,10 +26,10 @@ import java.io.Serializable;
 import java.time.Duration;
 import java.time.Instant;
 
-public class JobChainingPocMain extends Example {
+public class JobChainingUsingTaskDataMain extends Example {
 
     public static void main(String[] args) {
-        new JobChainingPocMain().runWithDatasource();
+        new JobChainingUsingTaskDataMain().runWithDatasource();
     }
 
     @Override


### PR DESCRIPTION
Enables JobChaining by replacing the old execution with the next step in the CompletionHandler.