### PR TITLE
feat: Add commitWhenAutocommitDisabled to spring-boot config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ db-scheduler.table-name=scheduled_tasks
 db-scheduler.immediate-execution-enabled=false
 db-scheduler.scheduler-name=
 db-scheduler.threads=10
+db-scheduler.commitWhenAutocommitDisabled=false
 
 # Ignored if a custom DbSchedulerStarter bean is defined
 db-scheduler.delay-startup-until-context-ready=false

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
@@ -112,6 +112,8 @@ public class DbSchedulerAutoConfiguration {
 
         builder.threads(config.getThreads());
 
+        builder.commitWhenAutocommitDisabled(config.isCommitWhenAutocommitDisabled());
+
         // Polling
         builder.pollingInterval(config.getPollingInterval());
 

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
@@ -110,6 +110,11 @@ public class DbSchedulerProperties {
     private Duration shutdownMaxWait = SchedulerBuilder.SHUTDOWN_MAX_WAIT;
 
     /**
+     * If this is enabled, the scheduler will attempt to commit changes.
+     */
+    private boolean commitWhenAutocommitDisabled = false;
+
+    /**
      * <p>Which log level to use when logging task failures. Defaults to {@link LogLevel#DEBUG}.</p>
      */
     private LogLevel failureLoggerLevel = SchedulerBuilder.DEFAULT_FAILURE_LOG_LEVEL;
@@ -237,5 +242,13 @@ public class DbSchedulerProperties {
 
     public void setPollingStrategyUpperLimitFractionOfThreads(double pollingStrategyUpperLimitFractionOfThreads) {
         this.pollingStrategyUpperLimitFractionOfThreads = pollingStrategyUpperLimitFractionOfThreads;
+    }
+
+    public boolean isCommitWhenAutocommitDisabled() {
+        return commitWhenAutocommitDisabled;
+    }
+
+    public void setCommitWhenAutocommitDisabled(boolean commitWhenAutocommitDisabled) {
+        this.commitWhenAutocommitDisabled = commitWhenAutocommitDisabled;
     }
 }

--- a/db-scheduler-boot-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
+++ b/db-scheduler-boot-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
@@ -85,6 +85,7 @@ public class DbSchedulerAutoConfigurationTest {
             assertThat(props.getPollingInterval()).isEqualTo(DEFAULT_POLLING_INTERVAL);
             assertThat(props.getHeartbeatInterval()).isEqualTo(DEFAULT_HEARTBEAT_INTERVAL);
             assertThat(props.getDeleteUnresolvedAfter()).isEqualTo(DEFAULT_DELETION_OF_UNRESOLVED_TASKS_DURATION);
+            assertThat(props.isCommitWhenAutocommitDisabled()).isFalse();
         });
     }
 


### PR DESCRIPTION
## Add commitWhenAutocommitDisabled to spring-boot config.


## Fixes
In spring-boot application when datasource auto-commit is set to false, i had no issue running recurring tasks, but one time tasks were not saved into db. I check documentation and there is option to change this by  prop commitWhenAutocommitDisabled, unfortunately i could change it by creating bean from scratch, which may change with future enhancements, this way it can be configured with 1 prop. But if i am missing something, please let me know how to handle that better. Thank you

## Reminders
- [x] Added/ran automated tests
- [x] Update README and/or examples

---
cc @kagkarlsson
