### PR TITLE
fixes #354 MSSQL task_data datatype

### DIFF
--- a/db-scheduler/src/test/resources/mssql_tables.sql
+++ b/db-scheduler/src/test/resources/mssql_tables.sql
@@ -1,7 +1,7 @@
 create table scheduled_tasks (
   task_name varchar(250) not null,
   task_instance varchar(250) not null,
-  task_data  nvarchar(max),
+  task_data varbinary(max),
   execution_time datetimeoffset  not null,
   picked bit,
   picked_by text,


### PR DESCRIPTION
Column task_data uses correct data type (for binary data) in MSSQL according to MS documentation


## Fixes
 #354


## Reminders
- [ ] Added/ran automated tests
- [ ] Update README and/or examples

---
cc @kagkarlsson
