### PR TITLE
Increasing sleep time to reduce the chance of test failure

### DIFF
--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/RunUntilShutdownTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/RunUntilShutdownTest.java
@@ -28,7 +28,7 @@ public class RunUntilShutdownTest {
 
     @Test
     public void should_wait_on_ok_execution() {
-        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
+        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(2), () -> {
 
             runUntilShutdown.run();
             assertThat(countingWaiter.counter, is(2));


### PR DESCRIPTION
**Description:**
This test is flakily fails. I run this test many times and it makes assertion fails. The failure message is as follows.

<!--- Which issue # does this fix? --->

**Failure:**
[INFO] Running com.github.kagkarlsson.scheduler.RunUntilShutdownTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.086 s <<< FAILURE! - in com.github.kagkarlsson.scheduler.RunUntilShutdownTest
[ERROR] should_wait_on_ok_execution  Time elapsed: 1.083 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: execution timed out after 1000 ms
	at com.github.kagkarlsson.scheduler.RunUntilShutdownTest.should_wait_on_ok_execution(RunUntilShutdownTest.java:31)
Caused by: org.junit.jupiter.api.AssertTimeout$ExecutionTimeoutException: Execution timed out in thread junit-timeout-thread-1
	at com.github.kagkarlsson.scheduler.RunUntilShutdownTest.lambda$should_wait_on_ok_execution$0(RunUntilShutdownTest.java:34)

[ERROR]   RunUntilShutdownTest.should_wait_on_ok_execution:31 execution timed out after 1000 ms
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
