### PR TITLE
Shutdown heartbeating last

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -157,11 +157,12 @@ public class Scheduler implements SchedulerClient {
             }
         }
 
+        executor.stop(shutdownMaxWait);
+
+        // Shutdown heartbeating thread last
         if (!ExecutorUtils.shutdownAndAwaitTermination(housekeeperExecutor, utilExecutorsWaitBeforeInterrupt, utilExecutorsWaitAfterInterrupt)) {
             LOG.warn("Failed to shutdown housekeeper-executor properly.");
         }
-
-        executor.stop(shutdownMaxWait);
     }
 
     public void pause() {


### PR DESCRIPTION
Shutdown heartbeating last to prevent execution classified as dead when stopping the execution is slow (since heartbeating already have stopped)