### PR TITLE
fix: Use Spring v5.3+ cron-style

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,10 +192,10 @@ Number of threads. Default `10`.
 How often the scheduler checks the database for due executions. Default `10s`.<br/>
 
 :gear: `.enableImmediateExecution()`<br/>
-If this is enabled, the scheduler will attempt to hint to the local `Scheduler` that there are executions to be executed after they are scheduled to 
-run `now()`, or a time in the past. **NB:** If the call to `schedule(..)`/`reschedule(..)` occur from within a transaction, the scheduler might attempt to run 
-it before the update is visible (transaction has not committed). It is still persisted though, so even if it is a miss, it will run before the 
-next `polling-interval`. You may also programmatically trigger an early check for due executions using the 
+If this is enabled, the scheduler will attempt to hint to the local `Scheduler` that there are executions to be executed after they are scheduled to
+run `now()`, or a time in the past. **NB:** If the call to `schedule(..)`/`reschedule(..)` occur from within a transaction, the scheduler might attempt to run
+it before the update is visible (transaction has not committed). It is still persisted though, so even if it is a miss, it will run before the
+next `polling-interval`. You may also programmatically trigger an early check for due executions using the
 Scheduler-method `scheduler.triggerCheckForDueExecutions()`). Default `false`.
 
 :gear: `.registerShutdownHook()`<br/>
@@ -290,11 +290,11 @@ Tasks are created using one of the builder-classes in `Tasks`. The builders have
 
 The library contains a number of Schedule-implementations for recurring tasks. See class `Schedules`.
 
-| Schedule  | Description |
-| ------------- | ------------- |
-| `.daily(LocalTime ...)`  | Runs every day at specified times. Optionally a time zone can be specified. |
-| `.fixedDelay(Duration)`  | Next execution-time is `Duration` after last completed execution. **Note:** This `Schedule` schedules the initial execution to `Instant.now()` when used in `startTasks(...)`|
-| `.cron(String)`  | Spring-style cron-expression. The pattern `-` is interpreted as a [disabled schedule](#disabled-schedules).  |
+| Schedule  | Description                                                                                                                                                                   |
+| ------------- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `.daily(LocalTime ...)`  | Runs every day at specified times. Optionally a time zone can be specified.                                                                                                   |
+| `.fixedDelay(Duration)`  | Next execution-time is `Duration` after last completed execution. **Note:** This `Schedule` schedules the initial execution to `Instant.now()` when used in `startTasks(...)` |
+| `.cron(String)`  | Spring-style cron-expression (v5.3+). The pattern `-` is interpreted as a [disabled schedule](#disabled-schedules).                                                           |
 
 Another option to configure schedules is reading string patterns with `Schedules.parse(String)`.
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/CronSchedule.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/CronSchedule.java
@@ -89,7 +89,7 @@ public class CronSchedule implements Schedule, Serializable {
           cronExecutionTime = new CronSchedule.DisabledScheduleExecutionTime();
         } else {
           CronParser parser =
-              new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.SPRING));
+              new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.SPRING53));
           Cron cron = parser.parse(pattern);
           cronExecutionTime = ExecutionTime.forCron(cron);
         }


### PR DESCRIPTION
## Brief, plain english overview of your changes here

Change supported Cron-expressions to Spring 5.3

## Fixes
#352


## Reminders
- [x] Added/ran automated tests
- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`

---
cc @kagkarlsson
