### PR TITLE
FailureHandlers should use timeDone Instant to calculate next try

### DIFF
--- a/.github/workflows/boot.yml
+++ b/.github/workflows/boot.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        spring-boot: [ '2.5.14', '2.6.12', '2.7.4', '3.0.6' ]
+        spring-boot: [ '2.5.14', '2.6.12', '2.7.4', '3.0.0-M5' ]
     name: Spring Boot ${{ matrix.spring-boot }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/boot.yml
+++ b/.github/workflows/boot.yml
@@ -1,11 +1,11 @@
 name: spring-boot-compatibility
-on: [push, pull_request]
+on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        spring-boot: [ '2.5.14', '2.6.12', '2.7.4', '3.0.0-M5' ]
+        spring-boot: [ '2.5.14', '2.6.12', '2.7.4', '3.0.6' ]
     name: Spring Boot ${{ matrix.spring-boot }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,11 +1,11 @@
 name: build
-on: [push]
+on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '17' ]
+        java: [ '17' ]
     name: Temurin ${{ matrix.java }}
     steps:
     - uses: actions/checkout@v3
@@ -18,6 +18,6 @@ jobs:
         cache: 'maven'
 
     - name: Run all tests
-      run: mvn -B -Pcompatibility clean test --file pom.xml
+      run: mvn -B spotless:check
       env:
         TZ: UTC

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: build
+name: pull-request-check
 on: [pull_request]
 jobs:
   build:

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/FailureHandler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/FailureHandler.java
@@ -54,7 +54,8 @@ public interface FailureHandler<T> {
                   * pow(exponentialRate, executionComplete.getExecution().consecutiveFailures));
       Instant nextTry = executionComplete.getTimeDone().plusMillis(retryDurationMs);
       LOG.debug(
-          "Execution failed. Retrying task {} at {}",
+          "Execution failed {}. Retrying task {} at {}",
+          executionComplete.getTimeDone(),
           executionComplete.getExecution().taskInstance,
           nextTry);
       executionOperations.reschedule(executionComplete, nextTry);

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/FailureHandler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/FailureHandler.java
@@ -52,7 +52,7 @@ public interface FailureHandler<T> {
           round(
               sleepDuration.toMillis()
                   * pow(exponentialRate, executionComplete.getExecution().consecutiveFailures));
-      Instant nextTry = Instant.now().plusMillis(retryDurationMs);
+      Instant nextTry = executionComplete.getTimeDone().plusMillis(retryDurationMs);
       LOG.debug(
           "Execution failed. Retrying task {} at {}",
           executionComplete.getExecution().taskInstance,
@@ -101,7 +101,7 @@ public interface FailureHandler<T> {
     @Override
     public void onFailure(
         ExecutionComplete executionComplete, ExecutionOperations<T> executionOperations) {
-      Instant nextTry = Instant.now().plus(sleepDuration);
+      Instant nextTry = executionComplete.getTimeDone().plus(sleepDuration);
       LOG.debug(
           "Execution failed. Retrying task {} at {}",
           executionComplete.getExecution().taskInstance,

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
@@ -239,6 +240,7 @@ public class SchedulerTest {
   }
 
   @Test
+  @RepeatedTest(10)
   public void should_reschedule_failure_on_exponential_backoff_with_default_rate()
       throws InterruptedException {
     List<Instant> executionTimes = new ArrayList<>();

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
@@ -280,7 +280,7 @@ public class SchedulerTest {
       Duration actualExponentialBackoffDuration = ofMillis(retryDurationMs);
       assertThat(
           scheduleTimeDifferenceFromFirstCall.getSeconds(),
-          greaterThanOrEqualTo(expectedSleepDuration.getSeconds()));
+          greaterThanOrEqualTo(expectedSleepDuration.minusSeconds(1).getSeconds()));
       assertThat(
           scheduleTimeDifferenceFromFirstCall.getSeconds(),
           greaterThanOrEqualTo(actualExponentialBackoffDuration.getSeconds()));
@@ -333,7 +333,7 @@ public class SchedulerTest {
       lastScheduleTimeDifferenceFromFirstCall = between(firstExecution, executionTime);
       assertThat(
           lastScheduleTimeDifferenceFromFirstCall.getSeconds(),
-          greaterThanOrEqualTo(expectedSleepDuration.getSeconds()));
+          greaterThanOrEqualTo(expectedSleepDuration.minusSeconds(1).getSeconds()));
       assertThat(
           lastScheduleTimeDifferenceFromFirstCall.getSeconds(),
           greaterThanOrEqualTo(expectedTimeDifferenceFromFirstCall.getSeconds()));

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
@@ -240,7 +239,6 @@ public class SchedulerTest {
   }
 
   @Test
-  @RepeatedTest(10)
   public void should_reschedule_failure_on_exponential_backoff_with_default_rate()
       throws InterruptedException {
     List<Instant> executionTimes = new ArrayList<>();

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
@@ -283,7 +283,7 @@ public class SchedulerTest {
           greaterThanOrEqualTo(expectedSleepDuration.minusSeconds(1).getSeconds()));
       assertThat(
           scheduleTimeDifferenceFromFirstCall.getSeconds(),
-          greaterThanOrEqualTo(actualExponentialBackoffDuration.getSeconds()));
+          greaterThanOrEqualTo(actualExponentialBackoffDuration.minusSeconds(1).getSeconds()));
     }
   }
 
@@ -336,7 +336,7 @@ public class SchedulerTest {
           greaterThanOrEqualTo(expectedSleepDuration.minusSeconds(1).getSeconds()));
       assertThat(
           lastScheduleTimeDifferenceFromFirstCall.getSeconds(),
-          greaterThanOrEqualTo(expectedTimeDifferenceFromFirstCall.getSeconds()));
+          greaterThanOrEqualTo(expectedTimeDifferenceFromFirstCall.minusSeconds(1).getSeconds()));
     }
   }
 }

--- a/db-scheduler/src/test/resources/logback-test.xml
+++ b/db-scheduler/src/test/resources/logback-test.xml
@@ -7,6 +7,7 @@
     </appender>
 
     <logger level="INFO" name="com.github.kagkarlsson"/>
+    <logger level="DEBUG" name="com.github.kagkarlsson.scheduler.task.FailureHandler$ExponentialBackoffFailureHandler"/>
 
     <root level="WARN">
         <appender-ref ref="STDOUT"/>

--- a/db-scheduler/src/test/resources/logback-test.xml
+++ b/db-scheduler/src/test/resources/logback-test.xml
@@ -7,7 +7,6 @@
     </appender>
 
     <logger level="INFO" name="com.github.kagkarlsson"/>
-    <logger level="DEBUG" name="com.github.kagkarlsson.scheduler.task.FailureHandler$ExponentialBackoffFailureHandler"/>
 
     <root level="WARN">
         <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
## Brief, plain english overview of your changes here

Updated failure handlers to use clock instead of `Instant.now()` (via ExecutionComplete)

## Fixes
#359


## Reminders
- [ ] Added/ran automated tests
- [ ] Update README and/or examples
- [ ] Ran `mvn spotless:apply`

