### PR TITLE
refactor: replace opentable embedded postgres with zonky

### DIFF
--- a/db-scheduler/pom.xml
+++ b/db-scheduler/pom.xml
@@ -23,7 +23,7 @@
         <equals-verifier.version>3.14.1</equals-verifier.version>
         <bytebuddy.version>1.12.16</bytebuddy.version>
         <micro-jdbc.version>0.3</micro-jdbc.version>
-        <otj-pg-embedded.version>1.0.1</otj-pg-embedded.version>
+        <zonky-pg-embedded.version>2.0.3</zonky-pg-embedded.version>
         <postgresql.version>42.5.1</postgresql.version>
         <slf4j.version>1.7.36</slf4j.version>
         <test.excludedTags>compatibility</test.excludedTags>
@@ -161,9 +161,9 @@
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.microsoft.sqlserver/mssql-jdbc -->
         <dependency>
-            <groupId>com.opentable.components</groupId>
-            <artifactId>otj-pg-embedded</artifactId>
-            <version>${otj-pg-embedded.version}</version>
+            <groupId>io.zonky.test</groupId>
+            <artifactId>embedded-postgres</artifactId>
+            <version>${zonky-pg-embedded.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/EmbeddedPostgresqlExtension.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/EmbeddedPostgresqlExtension.java
@@ -4,9 +4,9 @@ import static com.github.kagkarlsson.jdbc.PreparedStatementSetter.NOOP;
 
 import com.github.kagkarlsson.jdbc.JdbcRunner;
 import com.github.kagkarlsson.jdbc.Mappers;
-import com.opentable.db.postgres.embedded.EmbeddedPostgres;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
 import java.io.IOException;
 import java.util.function.Consumer;
 import javax.sql.DataSource;


### PR DESCRIPTION
Replace opentable embedded postgres as they are moving to Docker.

## Reminders
- [x] Added/ran automated tests
- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`
