### PR TITLE
feat: Candidate provided due and housekeeper executors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: build
-on: [push]
+on: [push,pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
@@ -158,6 +158,12 @@ public class DbSchedulerAutoConfiguration {
     // Use custom executor service if provided
     customizer.executorService().ifPresent(builder::executorService);
 
+    // Use custom due executor if provided
+    customizer.dueExecutor().ifPresent(builder::dueExecutor);
+
+    // Use housekeeper executor service if provided
+    customizer.housekeeperExecutor().ifPresent(builder::housekeeperExecutor);
+
     builder.deleteUnresolvedAfter(config.getDeleteUnresolvedAfter());
 
     // Add recurring jobs and jobs that implements OnStartup

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerCustomizer.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerCustomizer.java
@@ -16,8 +16,10 @@ package com.github.kagkarlsson.scheduler.boot.config;
 import com.github.kagkarlsson.scheduler.SchedulerName;
 import com.github.kagkarlsson.scheduler.jdbc.JdbcCustomization;
 import com.github.kagkarlsson.scheduler.serializer.Serializer;
+
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Provides functionality for customizing various aspects of the db-scheduler configuration that is
@@ -34,8 +36,20 @@ public interface DbSchedulerCustomizer {
     return Optional.empty();
   }
 
-  /** Provide an existing {@link ExecutorService} instance. */
+  /** Provide an existing {@link ExecutorService} instance. Used for processing tasks. */
   default Optional<ExecutorService> executorService() {
+    return Optional.empty();
+  }
+
+
+  /** Provide an existing {@link ExecutorService} instance. Used for handling due executions. */
+  default Optional<ExecutorService> dueExecutor() {
+    return Optional.empty();
+  }
+
+
+  /** Provide an existing {@link ScheduledExecutorService} instance. Used for housekeeping tasks. */
+  default Optional<ScheduledExecutorService> housekeeperExecutor() {
     return Optional.empty();
   }
 

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerCustomizer.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerCustomizer.java
@@ -16,7 +16,6 @@ package com.github.kagkarlsson.scheduler.boot.config;
 import com.github.kagkarlsson.scheduler.SchedulerName;
 import com.github.kagkarlsson.scheduler.jdbc.JdbcCustomization;
 import com.github.kagkarlsson.scheduler.serializer.Serializer;
-
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -41,12 +40,10 @@ public interface DbSchedulerCustomizer {
     return Optional.empty();
   }
 
-
   /** Provide an existing {@link ExecutorService} instance. Used for handling due executions. */
   default Optional<ExecutorService> dueExecutor() {
     return Optional.empty();
   }
-
 
   /** Provide an existing {@link ScheduledExecutorService} instance. Used for housekeeping tasks. */
   default Optional<ScheduledExecutorService> housekeeperExecutor() {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
@@ -117,8 +117,8 @@ public class SchedulerBuilder {
   }
 
   public SchedulerBuilder housekeeperExecutor(ScheduledExecutorService housekeeperExecutor) {
-      this.housekeeperExecutor = housekeeperExecutor;
-      return this;
+    this.housekeeperExecutor = housekeeperExecutor;
+    return this;
   }
 
   public SchedulerBuilder statsRegistry(StatsRegistry statsRegistry) {
@@ -246,10 +246,10 @@ public class SchedulerBuilder {
 
     ScheduledExecutorService candidateHousekeeperExecutor = housekeeperExecutor;
     if (candidateHousekeeperExecutor == null) {
-        candidateHousekeeperExecutor =
+      candidateHousekeeperExecutor =
           Executors.newScheduledThreadPool(
               3, defaultThreadFactoryWithPrefix(THREAD_PREFIX + "-housekeeper-"));
-      }
+    }
 
     LOG.info(
         "Creating scheduler with configuration: threads={}, pollInterval={}s, heartbeat={}s enable-immediate-execution={}, table-name={}, name={}",
@@ -280,8 +280,7 @@ public class SchedulerBuilder {
             logStackTrace,
             startTasks,
             candidateDueExecutor,
-            candidateHousekeeperExecutor
-            );
+            candidateHousekeeperExecutor);
 
     if (registerShutdownHook) {
       Runtime.getRuntime()

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,6 +64,8 @@ public class SchedulerBuilder {
   protected String tableName = JdbcTaskRepository.DEFAULT_TABLE_NAME;
   protected boolean enableImmediateExecution = false;
   protected ExecutorService executorService;
+  protected ExecutorService dueExecutor;
+  protected ScheduledExecutorService housekeeperExecutor;
   protected Duration deleteUnresolvedAfter = DEFAULT_DELETION_OF_UNRESOLVED_TASKS_DURATION;
   protected JdbcCustomization jdbcCustomization = null;
   protected Duration shutdownMaxWait = SHUTDOWN_MAX_WAIT;
@@ -106,6 +109,16 @@ public class SchedulerBuilder {
   public SchedulerBuilder executorService(ExecutorService executorService) {
     this.executorService = executorService;
     return this;
+  }
+
+  public SchedulerBuilder dueExecutor(ExecutorService dueExecutor) {
+    this.dueExecutor = dueExecutor;
+    return this;
+  }
+
+  public SchedulerBuilder housekeeperExecutor(ScheduledExecutorService housekeeperExecutor) {
+      this.housekeeperExecutor = housekeeperExecutor;
+      return this;
   }
 
   public SchedulerBuilder statsRegistry(StatsRegistry statsRegistry) {
@@ -224,6 +237,20 @@ public class SchedulerBuilder {
               executorThreads, defaultThreadFactoryWithPrefix(THREAD_PREFIX + "-"));
     }
 
+    ExecutorService candidateDueExecutor = dueExecutor;
+    if (candidateDueExecutor == null) {
+      candidateDueExecutor =
+          Executors.newSingleThreadExecutor(
+              defaultThreadFactoryWithPrefix(THREAD_PREFIX + "-execute-due-"));
+    }
+
+    ScheduledExecutorService candidateHousekeeperExecutor = housekeeperExecutor;
+    if (candidateHousekeeperExecutor == null) {
+        candidateHousekeeperExecutor =
+          Executors.newScheduledThreadPool(
+              3, defaultThreadFactoryWithPrefix(THREAD_PREFIX + "-housekeeper-"));
+      }
+
     LOG.info(
         "Creating scheduler with configuration: threads={}, pollInterval={}s, heartbeat={}s enable-immediate-execution={}, table-name={}, name={}",
         executorThreads,
@@ -251,7 +278,10 @@ public class SchedulerBuilder {
             shutdownMaxWait,
             logLevel,
             logStackTrace,
-            startTasks);
+            startTasks,
+            candidateDueExecutor,
+            candidateHousekeeperExecutor
+            );
 
     if (registerShutdownHook) {
       Runtime.getRuntime()

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/ManualScheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/ManualScheduler.java
@@ -21,8 +21,12 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static com.github.kagkarlsson.scheduler.ExecutorUtils.defaultThreadFactoryWithPrefix;
 
 public class ManualScheduler extends Scheduler {
   private static final Logger LOG = LoggerFactory.getLogger(ManualScheduler.class);
@@ -44,7 +48,9 @@ public class ManualScheduler extends Scheduler {
       Duration deleteUnresolvedAfter,
       LogLevel logLevel,
       boolean logStackTrace,
-      List<OnStartup> onStartup) {
+      List<OnStartup> onStartup,
+      ExecutorService dueExecutor,
+      ScheduledExecutorService houseKeeperExecutor) {
     super(
         clock,
         schedulerTaskRepository,
@@ -62,7 +68,9 @@ public class ManualScheduler extends Scheduler {
         Duration.ZERO,
         logLevel,
         logStackTrace,
-        onStartup);
+        onStartup,
+        dueExecutor,
+        houseKeeperExecutor);
     this.clock = clock;
   }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/ManualScheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/ManualScheduler.java
@@ -22,11 +22,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static com.github.kagkarlsson.scheduler.ExecutorUtils.defaultThreadFactoryWithPrefix;
 
 public class ManualScheduler extends Scheduler {
   private static final Logger LOG = LoggerFactory.getLogger(ManualScheduler.class);

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
@@ -13,6 +13,8 @@
  */
 package com.github.kagkarlsson.scheduler.testhelper;
 
+import static com.github.kagkarlsson.scheduler.ExecutorUtils.defaultThreadFactoryWithPrefix;
+
 import com.github.kagkarlsson.scheduler.PollingStrategyConfig;
 import com.github.kagkarlsson.scheduler.SchedulerBuilder;
 import com.github.kagkarlsson.scheduler.SchedulerName;
@@ -29,8 +31,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.*;
 import javax.sql.DataSource;
-
-import static com.github.kagkarlsson.scheduler.ExecutorUtils.defaultThreadFactoryWithPrefix;
 
 public class TestHelper {
 
@@ -94,17 +94,17 @@ public class TestHelper {
               serializer,
               clock);
 
-
       ExecutorService testDueExecutor = dueExecutor;
       if (testDueExecutor == null) {
-        testDueExecutor = Executors.newSingleThreadExecutor(
-            defaultThreadFactoryWithPrefix("test-execute-due-"));
+        testDueExecutor =
+            Executors.newSingleThreadExecutor(defaultThreadFactoryWithPrefix("test-execute-due-"));
       }
 
       ScheduledExecutorService testHousekeeperExecutor = housekeeperExecutor;
       if (testHousekeeperExecutor == null) {
-        testHousekeeperExecutor = Executors.newScheduledThreadPool(
-            3, defaultThreadFactoryWithPrefix("test-housekeeper-"));
+        testHousekeeperExecutor =
+            Executors.newScheduledThreadPool(
+                3, defaultThreadFactoryWithPrefix("test-housekeeper-"));
       }
 
       return new ManualScheduler(

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
@@ -27,9 +27,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.AbstractExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import javax.sql.DataSource;
+
+import static com.github.kagkarlsson.scheduler.ExecutorUtils.defaultThreadFactoryWithPrefix;
 
 public class TestHelper {
 
@@ -93,6 +94,19 @@ public class TestHelper {
               serializer,
               clock);
 
+
+      ExecutorService testDueExecutor = dueExecutor;
+      if (testDueExecutor == null) {
+        testDueExecutor = Executors.newSingleThreadExecutor(
+            defaultThreadFactoryWithPrefix("test-execute-due-"));
+      }
+
+      ScheduledExecutorService testHousekeeperExecutor = housekeeperExecutor;
+      if (testHousekeeperExecutor == null) {
+        testHousekeeperExecutor = Executors.newScheduledThreadPool(
+            3, defaultThreadFactoryWithPrefix("test-housekeeper-"));
+      }
+
       return new ManualScheduler(
           clock,
           schedulerTaskRepository,
@@ -109,7 +123,9 @@ public class TestHelper {
           deleteUnresolvedAfter,
           LogLevel.DEBUG,
           true,
-          startTasks);
+          startTasks,
+          testDueExecutor,
+          testHousekeeperExecutor);
     }
 
     public ManualScheduler start() {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
@@ -1,5 +1,6 @@
 package com.github.kagkarlsson.scheduler;
 
+import static com.github.kagkarlsson.scheduler.ExecutorUtils.defaultThreadFactoryWithPrefix;
 import static com.github.kagkarlsson.scheduler.jdbc.JdbcTaskRepository.DEFAULT_TABLE_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -19,6 +20,8 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Executors;
+
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -77,7 +80,11 @@ public class DeadExecutionsTest {
             Duration.ZERO,
             LogLevel.DEBUG,
             true,
-            new ArrayList<>());
+            new ArrayList<>(),
+            Executors.newSingleThreadExecutor(
+                defaultThreadFactoryWithPrefix("test-execute-due-")),
+            Executors.newScheduledThreadPool(
+                3, defaultThreadFactoryWithPrefix("test-housekeeper-")));
   }
 
   @Test

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
@@ -13,7 +13,9 @@ import com.github.kagkarlsson.scheduler.logging.LogLevel;
 import com.github.kagkarlsson.scheduler.stats.StatsRegistry;
 import com.github.kagkarlsson.scheduler.task.*;
 import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
+import com.github.kagkarlsson.scheduler.testhelper.ManualScheduler;
 import com.github.kagkarlsson.scheduler.testhelper.SettableClock;
+import com.github.kagkarlsson.scheduler.testhelper.TestHelper;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.time.Duration;
 import java.time.Instant;
@@ -32,7 +34,7 @@ public class DeadExecutionsTest {
 
   @RegisterExtension public EmbeddedPostgresqlExtension DB = new EmbeddedPostgresqlExtension();
 
-  private Scheduler scheduler;
+  private ManualScheduler scheduler;
   private SettableClock settableClock;
   private OneTimeTask<Void> oneTimeTask;
   private JdbcTaskRepository jdbcTaskRepository;
@@ -61,28 +63,9 @@ public class DeadExecutionsTest {
             new SchedulerName.Fixed("scheduler1"),
             settableClock);
 
-    scheduler =
-        new Scheduler(
-            settableClock,
-            jdbcTaskRepository,
-            jdbcTaskRepository,
-            taskResolver,
-            1,
-            MoreExecutors.newDirectExecutorService(),
-            new SchedulerName.Fixed("test-scheduler"),
-            new Waiter(Duration.ZERO),
-            Duration.ofMinutes(1),
-            false,
-            StatsRegistry.NOOP,
-            PollingStrategyConfig.DEFAULT_FETCH,
-            Duration.ofDays(14),
-            Duration.ZERO,
-            LogLevel.DEBUG,
-            true,
-            new ArrayList<>(),
-            Executors.newSingleThreadExecutor(defaultThreadFactoryWithPrefix("test-execute-due-")),
-            Executors.newScheduledThreadPool(
-                3, defaultThreadFactoryWithPrefix("test-housekeeper-")));
+    scheduler = TestHelper.createManualScheduler(DB.getDataSource(), oneTimeTask, nonCompleting)
+        .clock(settableClock)
+        .start();
   }
 
   @Test

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
@@ -1,6 +1,5 @@
 package com.github.kagkarlsson.scheduler;
 
-import static com.github.kagkarlsson.scheduler.ExecutorUtils.defaultThreadFactoryWithPrefix;
 import static com.github.kagkarlsson.scheduler.jdbc.JdbcTaskRepository.DEFAULT_TABLE_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -9,20 +8,16 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.kagkarlsson.scheduler.jdbc.JdbcTaskRepository;
-import com.github.kagkarlsson.scheduler.logging.LogLevel;
 import com.github.kagkarlsson.scheduler.stats.StatsRegistry;
 import com.github.kagkarlsson.scheduler.task.*;
 import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
 import com.github.kagkarlsson.scheduler.testhelper.ManualScheduler;
 import com.github.kagkarlsson.scheduler.testhelper.SettableClock;
 import com.github.kagkarlsson.scheduler.testhelper.TestHelper;
-import com.google.common.util.concurrent.MoreExecutors;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.Executors;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,9 +58,10 @@ public class DeadExecutionsTest {
             new SchedulerName.Fixed("scheduler1"),
             settableClock);
 
-    scheduler = TestHelper.createManualScheduler(DB.getDataSource(), oneTimeTask, nonCompleting)
-        .clock(settableClock)
-        .start();
+    scheduler =
+        TestHelper.createManualScheduler(DB.getDataSource(), oneTimeTask, nonCompleting)
+            .clock(settableClock)
+            .start();
   }
 
   @Test

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executors;
-
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -81,8 +80,7 @@ public class DeadExecutionsTest {
             LogLevel.DEBUG,
             true,
             new ArrayList<>(),
-            Executors.newSingleThreadExecutor(
-                defaultThreadFactoryWithPrefix("test-execute-due-")),
+            Executors.newSingleThreadExecutor(defaultThreadFactoryWithPrefix("test-execute-due-")),
             Executors.newScheduledThreadPool(
                 3, defaultThreadFactoryWithPrefix("test-housekeeper-")));
   }


### PR DESCRIPTION
## Brief, plain english overview of your changes here

Candidate provided dueExecutor and houseKeeperExecutor. 

Issue: https://github.com/kagkarlsson/db-scheduler/issues/392

This helps db-scheduler work when applications use ThreadLocals or MDC. These applications have to implement custom thread pool or decorator patterns to manage state across threads. For just one example see `decorateTask` in ScheduledThreadPoolExecutor.

## Reminders
- [X] Added/ran automated tests
- N/A Update README and/or examples
- [X] Ran `mvn spotless:apply`

---
cc @kagkarlsson
