### PR TITLE
fix: getScheduledExecutions(...) should be able to return executions with unresolved tasks

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ScheduledExecution.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ScheduledExecution.java
@@ -14,8 +14,10 @@
 package com.github.kagkarlsson.scheduler;
 
 import com.github.kagkarlsson.scheduler.exceptions.DataClassMismatchException;
+import com.github.kagkarlsson.scheduler.exceptions.MissingRawDataException;
 import com.github.kagkarlsson.scheduler.task.Execution;
 import com.github.kagkarlsson.scheduler.task.TaskInstanceId;
+
 import java.time.Instant;
 import java.util.Objects;
 
@@ -45,6 +47,19 @@ public class ScheduledExecution<DATA_TYPE> {
       return (DATA_TYPE) data;
     }
     throw new DataClassMismatchException(dataClass, data.getClass());
+  }
+
+  public boolean hasRawData() {
+    Object data = this.execution.taskInstance.getData();
+    return data == null || data.getClass().equals(byte[].class);
+  }
+
+  public byte[] getRawData() {
+    if (!hasRawData()) {
+      throw new MissingRawDataException(dataClass);
+    }
+
+    return (byte[]) this.execution.taskInstance.getData();
   }
 
   public Instant getLastSuccess() {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ScheduledExecution.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ScheduledExecution.java
@@ -17,7 +17,6 @@ import com.github.kagkarlsson.scheduler.exceptions.DataClassMismatchException;
 import com.github.kagkarlsson.scheduler.exceptions.MissingRawDataException;
 import com.github.kagkarlsson.scheduler.task.Execution;
 import com.github.kagkarlsson.scheduler.task.TaskInstanceId;
-
 import java.time.Instant;
 import java.util.Objects;
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ScheduledExecutionsFilter.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ScheduledExecutionsFilter.java
@@ -18,10 +18,15 @@ import java.util.Optional;
 public class ScheduledExecutionsFilter {
 
   private Boolean pickedValue;
+  private boolean includeUnresolved = false;
 
   private ScheduledExecutionsFilter() {}
 
   public static ScheduledExecutionsFilter all() {
+    return new ScheduledExecutionsFilter().withIncludeUnresolved(true);
+  }
+
+  public static ScheduledExecutionsFilter onlyResolved() {
     return new ScheduledExecutionsFilter();
   }
 
@@ -30,7 +35,16 @@ public class ScheduledExecutionsFilter {
     return this;
   }
 
+  public ScheduledExecutionsFilter withIncludeUnresolved(boolean includeUnresolved) {
+    this.includeUnresolved = includeUnresolved;
+    return this;
+  }
+
   public Optional<Boolean> getPickedValue() {
     return Optional.ofNullable(pickedValue);
+  }
+
+  public boolean getIncludeUnresolved() {
+    return includeUnresolved;
   }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ScheduledExecutionsFilter.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ScheduledExecutionsFilter.java
@@ -27,7 +27,7 @@ public class ScheduledExecutionsFilter {
   }
 
   public static ScheduledExecutionsFilter onlyResolved() {
-    return new ScheduledExecutionsFilter();
+    return new ScheduledExecutionsFilter().withIncludeUnresolved(false);
   }
 
   public ScheduledExecutionsFilter withPicked(boolean pickedValue) {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
@@ -142,6 +142,17 @@ public interface SchedulerClient {
   /**
    * @see #fetchScheduledExecutionsForTask(String, Class, Consumer)
    */
+  default <T> List<ScheduledExecution<Object>> getScheduledExecutionsForTask(
+    String taskName) {
+    List<ScheduledExecution<Object>> executions = new ArrayList<>();
+    fetchScheduledExecutionsForTask(taskName, Object.class, executions::add);
+    return executions;
+  }
+
+
+  /**
+   * @see #fetchScheduledExecutionsForTask(String, Class, Consumer)
+   */
   default <T> List<ScheduledExecution<T>> getScheduledExecutionsForTask(
       String taskName, Class<T> dataClass) {
     List<ScheduledExecution<T>> executions = new ArrayList<>();

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
@@ -142,13 +142,11 @@ public interface SchedulerClient {
   /**
    * @see #fetchScheduledExecutionsForTask(String, Class, Consumer)
    */
-  default <T> List<ScheduledExecution<Object>> getScheduledExecutionsForTask(
-    String taskName) {
+  default <T> List<ScheduledExecution<Object>> getScheduledExecutionsForTask(String taskName) {
     List<ScheduledExecution<Object>> executions = new ArrayList<>();
     fetchScheduledExecutionsForTask(taskName, Object.class, executions::add);
     return executions;
   }
-
 
   /**
    * @see #fetchScheduledExecutionsForTask(String, Class, Consumer)

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskResolver.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskResolver.java
@@ -52,8 +52,12 @@ public class TaskResolver {
   }
 
   public Optional<Task> resolve(String taskName) {
+    return resolve(taskName, true);
+  }
+
+  public Optional<Task> resolve(String taskName, boolean addUnresolvedToExclusionFilter) {
     Task task = taskMap.get(taskName);
-    if (task == null) {
+    if (task == null && addUnresolvedToExclusionFilter) {
       addUnresolved(taskName);
       statsRegistry.register(StatsRegistry.SchedulerStatsEvent.UNRESOLVED_TASK);
       LOG.info(

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/exceptions/DataClassMismatchException.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/exceptions/DataClassMismatchException.java
@@ -19,9 +19,10 @@ public class DataClassMismatchException extends DbSchedulerException {
   public DataClassMismatchException(Class expectedClass, Class actualClass) {
     super(
         String.format(
-            "Task data mismatch. If actual data-class is byte[], it might have been fetched without" +
-              " knowledge of task-data types, and is thus not deserialized." +
-              " Use getRawData() to get non-deserialized data in that case." +
-              " Expected class : %s, actual : %s", expectedClass, actualClass));
+            "Task data mismatch. If actual data-class is byte[], it might have been fetched without"
+                + " knowledge of task-data types, and is thus not deserialized."
+                + " Use getRawData() to get non-deserialized data in that case."
+                + " Expected class : %s, actual : %s",
+            expectedClass, actualClass));
   }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/exceptions/MissingRawDataException.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/exceptions/MissingRawDataException.java
@@ -13,15 +13,13 @@
  */
 package com.github.kagkarlsson.scheduler.exceptions;
 
-public class DataClassMismatchException extends DbSchedulerException {
-  private static final long serialVersionUID = 6333316294241471977L;
+public class MissingRawDataException extends DbSchedulerException {
+  private static final long serialVersionUID = 1L;
 
-  public DataClassMismatchException(Class expectedClass, Class actualClass) {
+  public MissingRawDataException(Class<?> dataClass) {
     super(
         String.format(
-            "Task data mismatch. If actual data-class is byte[], it might have been fetched without" +
-              " knowledge of task-data types, and is thus not deserialized." +
-              " Use getRawData() to get non-deserialized data in that case." +
-              " Expected class : %s, actual : %s", expectedClass, actualClass));
+            "Scheduled execution has typed data, use getData() to read the deserialized object. Data-class : %s",
+            dataClass));
   }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
@@ -13,6 +13,11 @@
  */
 package com.github.kagkarlsson.scheduler.jdbc;
 
+import static com.github.kagkarlsson.scheduler.StringUtils.truncate;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
 import com.github.kagkarlsson.jdbc.JdbcRunner;
 import com.github.kagkarlsson.jdbc.ResultSetMapper;
 import com.github.kagkarlsson.jdbc.SQLRuntimeException;
@@ -25,10 +30,6 @@ import com.github.kagkarlsson.scheduler.task.Execution;
 import com.github.kagkarlsson.scheduler.task.SchedulableInstance;
 import com.github.kagkarlsson.scheduler.task.Task;
 import com.github.kagkarlsson.scheduler.task.TaskInstance;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.sql.DataSource;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -39,11 +40,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-
-import static com.github.kagkarlsson.scheduler.StringUtils.truncate;
-import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("rawtypes")
 public class JdbcTaskRepository implements TaskRepository {
@@ -579,11 +578,11 @@ public class JdbcTaskRepository implements TaskRepository {
     private final ExecutionResultSetConsumer delegate;
 
     private ExecutionResultSetMapper(
-      boolean includeUnresolved, boolean addUnresolvedToExclusionFilter) {
+        boolean includeUnresolved, boolean addUnresolvedToExclusionFilter) {
       this.executions = new ArrayList<>();
       this.delegate =
-        new ExecutionResultSetConsumer(
-          executions::add, includeUnresolved, addUnresolvedToExclusionFilter);
+          new ExecutionResultSetConsumer(
+              executions::add, includeUnresolved, addUnresolvedToExclusionFilter);
     }
 
     @Override
@@ -605,9 +604,9 @@ public class JdbcTaskRepository implements TaskRepository {
     }
 
     private ExecutionResultSetConsumer(
-      Consumer<Execution> consumer,
-      boolean includeUnresolved,
-      boolean addUnresolvedToExclusionFilter) {
+        Consumer<Execution> consumer,
+        boolean includeUnresolved,
+        boolean addUnresolvedToExclusionFilter) {
       this.consumer = consumer;
       this.includeUnresolved = includeUnresolved;
       this.addUnresolvedToExclusionFilter = addUnresolvedToExclusionFilter;
@@ -623,11 +622,11 @@ public class JdbcTaskRepository implements TaskRepository {
         if (!task.isPresent() && !includeUnresolved) {
           if (addUnresolvedToExclusionFilter) {
             LOG.warn(
-              "Failed to find implementation for task with name '{}'. Execution will be excluded from due. "
-                + "Either delete the execution from the database, or add an implementation for it. "
-                + "The scheduler may be configured to automatically delete unresolved tasks "
-                + "after a certain period of time.",
-              taskName);
+                "Failed to find implementation for task with name '{}'. Execution will be excluded from due. "
+                    + "Either delete the execution from the database, or add an implementation for it. "
+                    + "The scheduler may be configured to automatically delete unresolved tasks "
+                    + "after a certain period of time.",
+                taskName);
           }
           continue;
         }
@@ -642,32 +641,32 @@ public class JdbcTaskRepository implements TaskRepository {
         Instant lastSuccess = jdbcCustomization.getInstant(rs, "last_success");
         Instant lastFailure = jdbcCustomization.getInstant(rs, "last_failure");
         int consecutiveFailures =
-          rs.getInt("consecutive_failures"); // null-value is returned as 0 which is the preferred
+            rs.getInt("consecutive_failures"); // null-value is returned as 0 which is the preferred
         // default
         Instant lastHeartbeat = jdbcCustomization.getInstant(rs, "last_heartbeat");
         long version = rs.getLong("version");
 
         Supplier dataSupplier =
-          memoize(
-            () -> {
-              if (!task.isPresent()) {
-                // return the data raw if the type is not known
-                //  a case for standalone clients, with no "known tasks"
-                return data;
-              }
-              return serializer.deserialize(task.get().getDataClass(), data);
-            });
+            memoize(
+                () -> {
+                  if (!task.isPresent()) {
+                    // return the data raw if the type is not known
+                    //  a case for standalone clients, with no "known tasks"
+                    return data;
+                  }
+                  return serializer.deserialize(task.get().getDataClass(), data);
+                });
         this.consumer.accept(
-          new Execution(
-            executionTime,
-            new TaskInstance(taskName, instanceId, dataSupplier),
-            picked,
-            pickedBy,
-            lastSuccess,
-            lastFailure,
-            consecutiveFailures,
-            lastHeartbeat,
-            version));
+            new Execution(
+                executionTime,
+                new TaskInstance(taskName, instanceId, dataSupplier),
+                picked,
+                pickedBy,
+                lastSuccess,
+                lastFailure,
+                consecutiveFailures,
+                lastHeartbeat,
+                version));
       }
 
       return null;
@@ -680,7 +679,9 @@ public class JdbcTaskRepository implements TaskRepository {
 
       public T get() {
         return delegate.get();
-      }      Supplier<T> delegate = this::firstTime;
+      }
+
+      Supplier<T> delegate = this::firstTime;
 
       private synchronized T firstTime() {
         if (!initialized) {
@@ -690,8 +691,6 @@ public class JdbcTaskRepository implements TaskRepository {
         }
         return delegate.get();
       }
-
-
     };
   }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
@@ -623,9 +623,8 @@ public class JdbcTaskRepository implements TaskRepository {
           if (addUnresolvedToExclusionFilter) {
             LOG.warn(
                 "Failed to find implementation for task with name '{}'. Execution will be excluded from due. "
-                    + "Either delete the execution from the database, or add an implementation for it. "
-                    + "The scheduler may be configured to automatically delete unresolved tasks "
-                    + "after a certain period of time.",
+                    + "The scheduler normally delete unresolved tasks after 14d. To handle manually, "
+                    + "either delete the execution from the database, or add an implementation for it. ",
                 taskName);
           }
           continue;
@@ -681,8 +680,6 @@ public class JdbcTaskRepository implements TaskRepository {
         return delegate.get();
       }
 
-      Supplier<T> delegate = this::firstTime;
-
       private synchronized T firstTime() {
         if (!initialized) {
           T value = original.get();
@@ -691,6 +688,8 @@ public class JdbcTaskRepository implements TaskRepository {
         }
         return delegate.get();
       }
+
+      Supplier<T> delegate = this::firstTime;
     };
   }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
@@ -13,19 +13,10 @@
  */
 package com.github.kagkarlsson.scheduler.jdbc;
 
-import static com.github.kagkarlsson.scheduler.StringUtils.truncate;
-import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
-
 import com.github.kagkarlsson.jdbc.JdbcRunner;
 import com.github.kagkarlsson.jdbc.ResultSetMapper;
 import com.github.kagkarlsson.jdbc.SQLRuntimeException;
-import com.github.kagkarlsson.scheduler.Clock;
-import com.github.kagkarlsson.scheduler.ScheduledExecutionsFilter;
-import com.github.kagkarlsson.scheduler.SchedulerName;
-import com.github.kagkarlsson.scheduler.TaskRepository;
-import com.github.kagkarlsson.scheduler.TaskResolver;
+import com.github.kagkarlsson.scheduler.*;
 import com.github.kagkarlsson.scheduler.TaskResolver.UnresolvedTask;
 import com.github.kagkarlsson.scheduler.exceptions.ExecutionException;
 import com.github.kagkarlsson.scheduler.exceptions.TaskInstanceException;
@@ -34,6 +25,10 @@ import com.github.kagkarlsson.scheduler.task.Execution;
 import com.github.kagkarlsson.scheduler.task.SchedulableInstance;
 import com.github.kagkarlsson.scheduler.task.Task;
 import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -44,9 +39,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import javax.sql.DataSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import static com.github.kagkarlsson.scheduler.StringUtils.truncate;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
 
 @SuppressWarnings("rawtypes")
 public class JdbcTaskRepository implements TaskRepository {
@@ -244,22 +241,31 @@ public class JdbcTaskRepository implements TaskRepository {
     UnresolvedFilter unresolvedFilter = new UnresolvedFilter(taskResolver.getUnresolved());
 
     QueryBuilder q = queryForFilter(filter);
-    if (unresolvedFilter.isActive()) {
+    if (unresolvedFilter.isActive() && !filter.getIncludeUnresolved()) {
       q.andCondition(unresolvedFilter);
     }
 
     jdbcRunner.query(
-        q.getQuery(), q.getPreparedStatementSetter(), new ExecutionResultSetConsumer(consumer));
+        q.getQuery(),
+        q.getPreparedStatementSetter(),
+        new ExecutionResultSetConsumer(consumer, filter.getIncludeUnresolved(), false));
   }
 
   @Override
   public void getScheduledExecutions(
       ScheduledExecutionsFilter filter, String taskName, Consumer<Execution> consumer) {
+    UnresolvedFilter unresolvedFilter = new UnresolvedFilter(taskResolver.getUnresolved());
+
     QueryBuilder q = queryForFilter(filter);
+    if (unresolvedFilter.isActive() && !filter.getIncludeUnresolved()) {
+      q.andCondition(unresolvedFilter);
+    }
     q.andCondition(new TaskCondition(taskName));
 
     jdbcRunner.query(
-        q.getQuery(), q.getPreparedStatementSetter(), new ExecutionResultSetConsumer(consumer));
+        q.getQuery(),
+        q.getPreparedStatementSetter(),
+        new ExecutionResultSetConsumer(consumer, filter.getIncludeUnresolved(), false));
   }
 
   @Override
@@ -285,7 +291,7 @@ public class JdbcTaskRepository implements TaskRepository {
             p.setMaxRows(limit);
           }
         },
-        new ExecutionResultSetMapper());
+        new ExecutionResultSetMapper(false, true));
   }
 
   @Override
@@ -377,6 +383,7 @@ public class JdbcTaskRepository implements TaskRepository {
               jdbcCustomization.setInstant(ps, index++, nextExecutionTime);
               if (newData != null) {
                 // may cause datbase-specific problems, might have to use setNull instead
+                // FIXLATER: optionally support bypassing serializer if byte[] already
                 ps.setObject(index++, serializer.serialize(newData.data));
               }
               ps.setString(index++, execution.taskInstance.getTaskName());
@@ -449,7 +456,7 @@ public class JdbcTaskRepository implements TaskRepository {
           jdbcCustomization.setInstant(p, index++, olderThan);
           unresolvedFilter.setParameters(p, index);
         },
-        new ExecutionResultSetMapper());
+        new ExecutionResultSetMapper(false, true));
   }
 
   @Override
@@ -497,7 +504,7 @@ public class JdbcTaskRepository implements TaskRepository {
           jdbcCustomization.setInstant(p, index++, Instant.now().minus(interval));
           unresolvedFilter.setParameters(p, index);
         },
-        new ExecutionResultSetMapper());
+        new ExecutionResultSetMapper(false, false));
   }
 
   public Optional<Execution> getExecution(TaskInstance taskInstance) {
@@ -512,7 +519,7 @@ public class JdbcTaskRepository implements TaskRepository {
               p.setString(1, taskName);
               p.setString(2, taskInstanceId);
             },
-            new ExecutionResultSetMapper());
+            new ExecutionResultSetMapper(true, false));
     if (executions.size() > 1) {
       throw new TaskInstanceException(
           "Found more than one matching execution for task name/id combination.",
@@ -544,7 +551,11 @@ public class JdbcTaskRepository implements TaskRepository {
 
   private JdbcTaskRepositoryContext getTaskRespositoryContext() {
     return new JdbcTaskRepositoryContext(
-        taskResolver, tableName, schedulerSchedulerName, jdbcRunner, ExecutionResultSetMapper::new);
+        taskResolver,
+        tableName,
+        schedulerSchedulerName,
+        jdbcRunner,
+        () -> new ExecutionResultSetMapper(false, true));
   }
 
   private QueryBuilder queryForFilter(ScheduledExecutionsFilter filter) {
@@ -567,9 +578,12 @@ public class JdbcTaskRepository implements TaskRepository {
 
     private final ExecutionResultSetConsumer delegate;
 
-    private ExecutionResultSetMapper() {
+    private ExecutionResultSetMapper(
+      boolean includeUnresolved, boolean addUnresolvedToExclusionFilter) {
       this.executions = new ArrayList<>();
-      this.delegate = new ExecutionResultSetConsumer(executions::add);
+      this.delegate =
+        new ExecutionResultSetConsumer(
+          executions::add, includeUnresolved, addUnresolvedToExclusionFilter);
     }
 
     @Override
@@ -583,9 +597,20 @@ public class JdbcTaskRepository implements TaskRepository {
   private class ExecutionResultSetConsumer implements ResultSetMapper<Void> {
 
     private final Consumer<Execution> consumer;
+    private final boolean includeUnresolved;
+    private boolean addUnresolvedToExclusionFilter;
 
     private ExecutionResultSetConsumer(Consumer<Execution> consumer) {
+      this(consumer, false, true);
+    }
+
+    private ExecutionResultSetConsumer(
+      Consumer<Execution> consumer,
+      boolean includeUnresolved,
+      boolean addUnresolvedToExclusionFilter) {
       this.consumer = consumer;
+      this.includeUnresolved = includeUnresolved;
+      this.addUnresolvedToExclusionFilter = addUnresolvedToExclusionFilter;
     }
 
     @Override
@@ -593,12 +618,17 @@ public class JdbcTaskRepository implements TaskRepository {
 
       while (rs.next()) {
         String taskName = rs.getString("task_name");
-        Optional<Task> task = taskResolver.resolve(taskName);
+        Optional<Task> task = taskResolver.resolve(taskName, addUnresolvedToExclusionFilter);
 
-        if (!task.isPresent()) {
-          LOG.warn(
-              "Failed to find implementation for task with name '{}'. Execution will be excluded from due. Either delete the execution from the database, or add an implementation for it. The scheduler may be configured to automatically delete unresolved tasks after a certain period of time.",
+        if (!task.isPresent() && !includeUnresolved) {
+          if (addUnresolvedToExclusionFilter) {
+            LOG.warn(
+              "Failed to find implementation for task with name '{}'. Execution will be excluded from due. "
+                + "Either delete the execution from the database, or add an implementation for it. "
+                + "The scheduler may be configured to automatically delete unresolved tasks "
+                + "after a certain period of time.",
               taskName);
+          }
           continue;
         }
 
@@ -612,24 +642,32 @@ public class JdbcTaskRepository implements TaskRepository {
         Instant lastSuccess = jdbcCustomization.getInstant(rs, "last_success");
         Instant lastFailure = jdbcCustomization.getInstant(rs, "last_failure");
         int consecutiveFailures =
-            rs.getInt("consecutive_failures"); // null-value is returned as 0 which is the preferred
+          rs.getInt("consecutive_failures"); // null-value is returned as 0 which is the preferred
         // default
         Instant lastHeartbeat = jdbcCustomization.getInstant(rs, "last_heartbeat");
         long version = rs.getLong("version");
 
         Supplier dataSupplier =
-            memoize(() -> serializer.deserialize(task.get().getDataClass(), data));
+          memoize(
+            () -> {
+              if (!task.isPresent()) {
+                // return the data raw if the type is not known
+                //  a case for standalone clients, with no "known tasks"
+                return data;
+              }
+              return serializer.deserialize(task.get().getDataClass(), data);
+            });
         this.consumer.accept(
-            new Execution(
-                executionTime,
-                new TaskInstance(taskName, instanceId, dataSupplier),
-                picked,
-                pickedBy,
-                lastSuccess,
-                lastFailure,
-                consecutiveFailures,
-                lastHeartbeat,
-                version));
+          new Execution(
+            executionTime,
+            new TaskInstance(taskName, instanceId, dataSupplier),
+            picked,
+            pickedBy,
+            lastSuccess,
+            lastFailure,
+            consecutiveFailures,
+            lastHeartbeat,
+            version));
       }
 
       return null;
@@ -638,12 +676,11 @@ public class JdbcTaskRepository implements TaskRepository {
 
   private static <T> Supplier<T> memoize(Supplier<T> original) {
     return new Supplier<T>() {
-      Supplier<T> delegate = this::firstTime;
       boolean initialized;
 
       public T get() {
         return delegate.get();
-      }
+      }      Supplier<T> delegate = this::firstTime;
 
       private synchronized T firstTime() {
         if (!initialized) {
@@ -653,6 +690,8 @@ public class JdbcTaskRepository implements TaskRepository {
         }
         return delegate.get();
       }
+
+
     };
   }
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.stream.IntStream;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -413,7 +412,8 @@ public class JdbcTaskRepositoryTest {
     assertThat(taskResolver.getUnresolved(), hasSize(1));
 
     assertThat(getScheduledExecutions(ScheduledExecutionsFilter.onlyResolved()), hasSize(0));
-    assertThat(getScheduledExecutions(ScheduledExecutionsFilter.onlyResolved(), taskName), hasSize(0));
+    assertThat(
+        getScheduledExecutions(ScheduledExecutionsFilter.onlyResolved(), taskName), hasSize(0));
     assertThat(getScheduledExecutions(all()), hasSize(1));
     assertThat(getScheduledExecutions(all(), taskName), hasSize(1));
   }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.github.kagkarlsson.scheduler;
 
 import static com.github.kagkarlsson.scheduler.ScheduledExecutionsFilter.all;
+import static com.github.kagkarlsson.scheduler.ScheduledExecutionsFilter.onlyResolved;
 import static com.github.kagkarlsson.scheduler.jdbc.JdbcTaskRepository.DEFAULT_TABLE_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
@@ -29,6 +30,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.stream.IntStream;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -402,15 +404,18 @@ public class JdbcTaskRepositoryTest {
   @Test
   public void get_scheduled_executions_should_work_with_unresolved() {
     Instant now = TimeHelper.truncatedInstantNow();
+    String taskName = "unresolved1";
     final OneTimeTask<Void> unresolved1 =
-        TestTasks.oneTime("unresolved1", Void.class, TestTasks.DO_NOTHING);
+        TestTasks.oneTime(taskName, Void.class, TestTasks.DO_NOTHING);
     taskRepository.createIfNotExists(
         new SchedulableTaskInstance<>(unresolved1.instance("id"), now));
     assertThat(taskRepository.getDue(now, POLLING_LIMIT), hasSize(0));
     assertThat(taskResolver.getUnresolved(), hasSize(1));
 
-    taskRepository.getScheduledExecutions(ScheduledExecutionsFilter.all(), e -> {});
-    taskRepository.getScheduledExecutions(ScheduledExecutionsFilter.all(), "sometask", e -> {});
+    assertThat(getScheduledExecutions(ScheduledExecutionsFilter.onlyResolved()), hasSize(0));
+    assertThat(getScheduledExecutions(ScheduledExecutionsFilter.onlyResolved(), taskName), hasSize(0));
+    assertThat(getScheduledExecutions(all()), hasSize(1));
+    assertThat(getScheduledExecutions(all(), taskName), hasSize(1));
   }
 
   @Test
@@ -459,7 +464,7 @@ public class JdbcTaskRepositoryTest {
 
   private Execution getSingleExecution() {
     List<Execution> executions = new ArrayList<>();
-    taskRepository.getScheduledExecutions(all().withPicked(false), executions::add);
+    taskRepository.getScheduledExecutions(onlyResolved().withPicked(false), executions::add);
     return executions.get(0);
   }
 }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/ScheduledExecutionTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/ScheduledExecutionTest.java
@@ -1,5 +1,6 @@
 package com.github.kagkarlsson.scheduler;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -8,6 +9,8 @@ import com.github.kagkarlsson.scheduler.exceptions.DataClassMismatchException;
 import com.github.kagkarlsson.scheduler.task.Execution;
 import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
 import java.time.Instant;
+
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 
 public class ScheduledExecutionTest {
@@ -59,8 +62,8 @@ public class ScheduledExecutionTest {
                   .getData(); // Instantiate with incorrect type
             });
 
-    assertEquals(
-        "Task data mismatch. Expected class : class java.lang.String, actual : class java.lang.Integer",
-        dataClassMismatchException.getMessage());
+    assertThat(
+      dataClassMismatchException.getMessage(),
+        CoreMatchers.containsString("Task data mismatch"));
   }
 }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/ScheduledExecutionTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/ScheduledExecutionTest.java
@@ -9,7 +9,6 @@ import com.github.kagkarlsson.scheduler.exceptions.DataClassMismatchException;
 import com.github.kagkarlsson.scheduler.task.Execution;
 import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
 import java.time.Instant;
-
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 
@@ -63,7 +62,6 @@ public class ScheduledExecutionTest {
             });
 
     assertThat(
-      dataClassMismatchException.getMessage(),
-        CoreMatchers.containsString("Task data mismatch"));
+        dataClassMismatchException.getMessage(), CoreMatchers.containsString("Task data mismatch"));
   }
 }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
@@ -1,12 +1,8 @@
 package com.github.kagkarlsson.scheduler;
 
-import static java.time.Duration.ofSeconds;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-
 import co.unruly.matchers.OptionalMatchers;
 import com.github.kagkarlsson.scheduler.TestTasks.SavingHandler;
+import com.github.kagkarlsson.scheduler.serializer.JavaSerializer;
 import com.github.kagkarlsson.scheduler.task.ExecutionContext;
 import com.github.kagkarlsson.scheduler.task.TaskInstance;
 import com.github.kagkarlsson.scheduler.task.TaskInstanceId;
@@ -15,12 +11,22 @@ import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
 import com.github.kagkarlsson.scheduler.testhelper.ManualScheduler;
 import com.github.kagkarlsson.scheduler.testhelper.SettableClock;
 import com.github.kagkarlsson.scheduler.testhelper.TestHelper;
-import java.time.Instant;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.github.kagkarlsson.scheduler.SchedulerClient.Builder.create;
+import static java.time.Duration.ofSeconds;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SchedulerClientTest {
 
@@ -40,6 +46,8 @@ public class SchedulerClientTest {
 
   private SavingHandler<String> savingHandler;
   private OneTimeTask<String> savingTask;
+  private OneTimeTask<Integer> oneTimeTaskC;
+  private VoidExecutionHandler<Integer> onetimeTaskHandlerC;
 
   @BeforeEach
   public void setUp() {
@@ -50,6 +58,9 @@ public class SchedulerClientTest {
 
     oneTimeTaskB = TestTasks.oneTime("OneTimeB", Void.class, onetimeTaskHandlerB);
     onetimeTaskHandlerB = new TestTasks.CountingHandler<>();
+
+    oneTimeTaskC = TestTasks.oneTime("OneTimeC", Integer.class, onetimeTaskHandlerC);
+    onetimeTaskHandlerC = new TestTasks.CountingHandler<>();
 
     scheduleAnother =
         new ScheduleAnotherTaskHandler<>(
@@ -68,7 +79,7 @@ public class SchedulerClientTest {
 
   @Test
   public void client_should_be_able_to_schedule_executions() {
-    SchedulerClient client = SchedulerClient.Builder.create(DB.getDataSource()).build();
+    SchedulerClient client = create(DB.getDataSource()).build();
     client.schedule(oneTimeTaskA.instance("1"), settableClock.now());
 
     scheduler.runAnyDueExecutions();
@@ -89,8 +100,7 @@ public class SchedulerClientTest {
 
   @Test
   public void client_should_be_able_to_fetch_executions_for_task() {
-    SchedulerClient client =
-        SchedulerClient.Builder.create(DB.getDataSource(), oneTimeTaskA, oneTimeTaskB).build();
+    SchedulerClient client = create(DB.getDataSource(), oneTimeTaskA, oneTimeTaskB).build();
     client.schedule(oneTimeTaskA.instance("1"), settableClock.now());
     client.schedule(oneTimeTaskA.instance("2"), settableClock.now());
     client.schedule(oneTimeTaskB.instance("10"), settableClock.now());
@@ -107,8 +117,7 @@ public class SchedulerClientTest {
 
   @Test
   public void client_should_be_able_to_fetch_single_scheduled_execution() {
-    SchedulerClient client =
-        SchedulerClient.Builder.create(DB.getDataSource(), oneTimeTaskA).build();
+    SchedulerClient client = create(DB.getDataSource(), oneTimeTaskA).build();
     client.schedule(oneTimeTaskA.instance("1"), settableClock.now());
 
     assertThat(
@@ -142,6 +151,35 @@ public class SchedulerClientTest {
     assertThat(savingHandler.savedData, CoreMatchers.is(data2));
   }
 
+  @SuppressWarnings("OptionalGetWithoutIsPresent")
+  @Test
+  public void raw_client_should_be_able_to_fetch_executions() {
+    TaskInstance<Integer> instance = oneTimeTaskC.instance("1", 5);
+
+    SchedulerClient clientWithTypes = create(DB.getDataSource(), oneTimeTaskC).build();
+    clientWithTypes.schedule(instance, settableClock.now());
+
+    SchedulerClient clientWithoutTypes = create(DB.getDataSource()).build();
+
+    Optional<ScheduledExecution<Object>> e1 = clientWithoutTypes.getScheduledExecution(instance);
+    assertThat(e1, not(OptionalMatchers.empty()));
+    assertRawData(e1.get(), 5);
+
+    List<ScheduledExecution<Object>> allScheduled = clientWithoutTypes.getScheduledExecutions();
+    assertThat(allScheduled, hasSize(1));
+    assertRawData(allScheduled.get(0), 5);
+
+    List<ScheduledExecution<Object>> scheduledForTask =
+        clientWithoutTypes.getScheduledExecutionsForTask(instance.getTaskName());
+    assertThat(scheduledForTask, hasSize(1));
+    assertRawData(scheduledForTask.get(0), 5);
+  }
+
+  private void assertRawData(ScheduledExecution<Object> se, Integer expectedValue) {
+    assertTrue(se.hasRawData());
+    assertEquals(expectedValue, new JavaSerializer().deserialize(Integer.class, se.getRawData()));
+  }
+
   private int countAllExecutions(SchedulerClient client) {
     AtomicInteger counter = new AtomicInteger(0);
     client.fetchScheduledExecutions(
@@ -164,9 +202,9 @@ public class SchedulerClientTest {
   }
 
   public static class ScheduleAnotherTaskHandler<T> implements VoidExecutionHandler<T> {
-    public int timesExecuted = 0;
     private final TaskInstance<Void> secondTask;
     private final Instant instant;
+    public int timesExecuted = 0;
 
     public ScheduleAnotherTaskHandler(TaskInstance<Void> secondTask, Instant instant) {
       this.secondTask = secondTask;

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
@@ -1,5 +1,12 @@
 package com.github.kagkarlsson.scheduler;
 
+import static com.github.kagkarlsson.scheduler.SchedulerClient.Builder.create;
+import static java.time.Duration.ofSeconds;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import co.unruly.matchers.OptionalMatchers;
 import com.github.kagkarlsson.scheduler.TestTasks.SavingHandler;
 import com.github.kagkarlsson.scheduler.serializer.JavaSerializer;
@@ -11,22 +18,14 @@ import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
 import com.github.kagkarlsson.scheduler.testhelper.ManualScheduler;
 import com.github.kagkarlsson.scheduler.testhelper.SettableClock;
 import com.github.kagkarlsson.scheduler.testhelper.TestHelper;
-import org.hamcrest.CoreMatchers;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import static com.github.kagkarlsson.scheduler.SchedulerClient.Builder.create;
-import static java.time.Duration.ofSeconds;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class SchedulerClientTest {
 

--- a/examples/features/pom.xml
+++ b/examples/features/pom.xml
@@ -42,6 +42,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>${postgresql.version}</version>

--- a/examples/features/src/main/java/com/github/kagkarlsson/examples/SchedulerClientMain.java
+++ b/examples/features/src/main/java/com/github/kagkarlsson/examples/SchedulerClientMain.java
@@ -38,10 +38,10 @@ public class SchedulerClientMain extends Example {
                   System.out.println("Task a executed");
                 });
 
-    final SchedulerClient clientWithTypeInformation = SchedulerClient.Builder
-      .create(dataSource, task)
-      .serializer(new JacksonSerializer())
-      .build();
+    final SchedulerClient clientWithTypeInformation =
+        SchedulerClient.Builder.create(dataSource, task)
+            .serializer(new JacksonSerializer())
+            .build();
 
     final Instant now = Instant.now();
     for (int i = 0; i < 5; i++) {
@@ -58,23 +58,22 @@ public class SchedulerClientMain extends Example {
                   execution.getTaskInstance().getTaskName(),
                   execution.getTaskInstance().getId(),
                   execution.getExecutionTime(),
-                  execution.getData()
-                );
+                  execution.getData());
             });
 
     final SchedulerClient rawClient = SchedulerClient.Builder.create(dataSource).build();
-    System.out.println("Listing scheduled executions for client with no known tasks (data-classes and implementations)");
+    System.out.println(
+        "Listing scheduled executions for client with no known tasks (data-classes and implementations)");
     rawClient
-      .getScheduledExecutions(ScheduledExecutionsFilter.all())
-      .forEach(
-        execution -> {
-          System.out.printf(
-            "Scheduled execution: taskName=%s, instance=%s, executionTime=%s, data=%s%n",
-            execution.getTaskInstance().getTaskName(),
-            execution.getTaskInstance().getId(),
-            execution.getExecutionTime(),
-            new String((byte[]) execution.getData())
-          );
-        });
+        .getScheduledExecutions(ScheduledExecutionsFilter.all())
+        .forEach(
+            execution -> {
+              System.out.printf(
+                  "Scheduled execution: taskName=%s, instance=%s, executionTime=%s, data=%s%n",
+                  execution.getTaskInstance().getTaskName(),
+                  execution.getTaskInstance().getId(),
+                  execution.getExecutionTime(),
+                  new String((byte[]) execution.getData()));
+            });
   }
 }


### PR DESCRIPTION
If the `SchedulerClient` is instantiated with no _known tasks_, it currently does not find any executions since the client will not be able to resolve the task and will therefore filter them out. 

This PR **changes the behavior** of `getScheduledExecution()`, `getScheduledExecutions()` to also return unresolved executions, and additionally adds options in `ScheduledExecutionsFilter` to enable controlling whether or not to include them. 
