### PR TITLE
docs: Update README with new Lightyear link

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ List of organizations known to be running db-scheduler in production:
 | [Monitoria](https://monitoria.ca)         | Website monitoring service.                                  |
 | [Loadster](https://loadster.app)          | Load testing for web applications.                           |
 | [Statens vegvesen](https://www.vegvesen.no/)| The Norwegian Public Roads Administration                  |
-| [Lightyear](https://golightyear.com/)     |  A simple and approachable way to invest your money globally.|
+| [Lightyear](https://lightyear.com/)       |  A simple and approachable way to invest your money globally.|
 | [NAV](https://www.nav.no/)                |  The Norwegian Labour and Welfare Administration             |
 | [ModernLoop](https://modernloop.io/)      |  Scale with your company’s hiring needs by using ModernLoop to increase efficiency in interview scheduling, communication, and coordination.             |
 | [Diffia](https://www.diffia.com/)         |  Norwegian eHealth company                                   |


### PR DESCRIPTION
Hello @kagkarlsson!

Nearly three years on from when we first started using db-scheduler, the library has scaled beautifully along with us, never causing a headache!

Now, we're a big-boy startup with the root domain lightyear.com. As a result, the old link will soon be obsolete.

Thank you once again for creating this library. We're planning to launch in Norway soon—just to get you onboard as a VIP customer! 😄 

<img width="423" alt="Screenshot 2023-09-14 at 16 48 16" src="https://github.com/kagkarlsson/db-scheduler/assets/4641756/667d5be3-0b26-4478-8ce3-1becb8be42d0">

Old PR for reference: https://github.com/kagkarlsson/db-scheduler/pull/268
