### PR TITLE
docs: Add Swan to the list of users

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ List of organizations known to be running db-scheduler in production:
 | [NAV](https://www.nav.no/)                |  The Norwegian Labour and Welfare Administration             |
 | [ModernLoop](https://modernloop.io/)      |  Scale with your company’s hiring needs by using ModernLoop to increase efficiency in interview scheduling, communication, and coordination.             |
 | [Diffia](https://www.diffia.com/)         |  Norwegian eHealth company                                   |
+| [Swan](https://www.swan.io/)              | Swan helps developers to embed banking services easily into their product. |
 
 Feel free to open a PR to add your organization to the list.
 


### PR DESCRIPTION
## Brief, plain english overview of your changes here
As happy users of db-scheduler we would like to add [Swan](https://www.swan.io/) in the list of users.

---
cc @kagkarlsson
