### PR TITLE
feat: spring-boot: introduce DbSchedulerStopper

### DIFF
--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
@@ -20,6 +20,8 @@ import com.github.kagkarlsson.scheduler.SchedulerName;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerCustomizer;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerProperties;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerStarter;
+import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerStopper;
+import com.github.kagkarlsson.scheduler.boot.config.shutdown.ContextClosedStopper;
 import com.github.kagkarlsson.scheduler.boot.config.startup.ContextReadyStart;
 import com.github.kagkarlsson.scheduler.boot.config.startup.ImmediateStart;
 import com.github.kagkarlsson.scheduler.exceptions.SerializationException;
@@ -100,7 +102,7 @@ public class DbSchedulerAutoConfiguration {
   @ConditionalOnBean(DataSource.class)
   @ConditionalOnMissingBean
   @DependsOnDatabaseInitialization
-  @Bean(destroyMethod = "stop")
+  @Bean
   public Scheduler scheduler(DbSchedulerCustomizer customizer, StatsRegistry registry) {
     log.info("Creating db-scheduler using tasks from Spring context: {}", configuredTasks);
 
@@ -190,6 +192,13 @@ public class DbSchedulerAutoConfiguration {
     }
 
     return new ImmediateStart(scheduler);
+  }
+
+  @ConditionalOnBean(Scheduler.class)
+  @ConditionalOnMissingBean
+  @Bean
+  public DbSchedulerStopper dbSchedulerStopper(Scheduler scheduler) {
+    return new ContextClosedStopper(scheduler);
   }
 
   private static DataSource configureDataSource(DataSource existingDataSource) {

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
@@ -68,11 +68,13 @@ public class DbSchedulerProperties {
   /** What polling-strategy to use. Valid values are: FETCH,LOCK_AND_FETCH */
   private PollingStrategyConfig.Type pollingStrategy =
       SchedulerBuilder.DEFAULT_POLLING_STRATEGY.type;
+
   /**
    * The limit at which more executions are fetched from the database after fetching a full batch.
    */
   private double pollingStrategyLowerLimitFractionOfThreads =
       SchedulerBuilder.DEFAULT_POLLING_STRATEGY.lowerLimitFractionOfThreads;
+
   /**
    * For Type=FETCH, the number of due executions fetched from the database in each batch.
    *

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerStopper.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerStopper.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) Gustav Karlsson
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.kagkarlsson.scheduler.boot.config;
+
+public interface DbSchedulerStopper {
+  void doStop();
+}

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/shutdown/AbstractSchedulerStopper.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/shutdown/AbstractSchedulerStopper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) Gustav Karlsson
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.kagkarlsson.scheduler.boot.config.shutdown;
+
+import com.github.kagkarlsson.scheduler.Scheduler;
+import com.github.kagkarlsson.scheduler.SchedulerState;
+import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerStopper;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractSchedulerStopper implements DbSchedulerStopper {
+  private final Logger log = LoggerFactory.getLogger(this.getClass());
+  private final Scheduler scheduler;
+
+  protected AbstractSchedulerStopper(Scheduler scheduler) {
+    this.scheduler = Objects.requireNonNull(scheduler, "A scheduler must be provided");
+  }
+
+  @Override
+  public void doStop() {
+    SchedulerState state = scheduler.getSchedulerState();
+
+    if (state.isShuttingDown()) {
+      log.warn("Scheduler is already shutting down - will not attempt to stop");
+      return;
+    }
+
+    if (!state.isStarted()) {
+      log.warn("Scheduler not started - will not attempt to stop");
+      return;
+    }
+
+    log.info("Triggering scheduler stop");
+    scheduler.stop();
+  }
+}

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/shutdown/ContextClosedStopper.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/shutdown/ContextClosedStopper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) Gustav Karlsson
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.kagkarlsson.scheduler.boot.config.shutdown;
+
+import com.github.kagkarlsson.scheduler.Scheduler;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.EventListener;
+
+public class ContextClosedStopper extends AbstractSchedulerStopper {
+  public ContextClosedStopper(Scheduler scheduler) {
+    super(scheduler);
+  }
+
+  @EventListener(ContextClosedEvent.class)
+  public void whenContextIsStopped() {
+    doStop();
+  }
+}

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
@@ -39,6 +39,7 @@ public class SchedulerTest {
 
   @RegisterExtension
   public EmbeddedPostgresqlExtension postgres = new EmbeddedPostgresqlExtension();
+
   //    @RegisterExtension
   //        public ChangeLogLevelsExtension changeLogLevels = new ChangeLogLevelsExtension(
   //        new ChangeLogLevelsExtension.LogLevelOverride("com.github.kagkarlsson.scheduler",

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/PostgresqlCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/PostgresqlCompatibilityTest.java
@@ -8,6 +8,7 @@ public class PostgresqlCompatibilityTest extends CompatibilityTest {
 
   @RegisterExtension
   public EmbeddedPostgresqlExtension postgres = new EmbeddedPostgresqlExtension();
+
   //    Enable if test gets flaky!
   //    @RegisterExtension
   //    public ChangeLogLevelsExtension changeLogLevels = new ChangeLogLevelsExtension(

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/ExecutorPoolTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/ExecutorPoolTest.java
@@ -35,6 +35,7 @@ public class ExecutorPoolTest {
   public EmbeddedPostgresqlExtension postgres = new EmbeddedPostgresqlExtension();
 
   @RegisterExtension public StopSchedulerExtension stopScheduler = new StopSchedulerExtension();
+
   //    Enable if test gets flaky!
   //    @RegisterExtension
   //    public ChangeLogLevelsExtension changeLogLevels = new ChangeLogLevelsExtension(

--- a/examples/spring-boot-example/src/test/java/com/github/kagkarlsson/examples/boot/SmokeTest.java
+++ b/examples/spring-boot-example/src/test/java/com/github/kagkarlsson/examples/boot/SmokeTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.kagkarlsson.scheduler.Scheduler;
 import com.github.kagkarlsson.scheduler.boot.actuator.DbSchedulerHealthIndicator;
+import com.github.kagkarlsson.scheduler.boot.config.shutdown.ContextClosedStopper;
 import com.github.kagkarlsson.scheduler.task.Task;
 import com.github.kagkarlsson.scheduler.task.TaskInstance;
 import java.time.Instant;
@@ -48,6 +49,11 @@ public class SmokeTest {
   @Test
   public void it_should_have_a_scheduler_bean() {
     assertThat(ctx).hasSingleBean(Scheduler.class);
+  }
+
+  @Test
+  public void it_should_have_a_stopper_bean() {
+    assertThat(ctx).hasSingleBean(ContextClosedStopper.class);
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
 			<plugin>
 				<groupId>com.diffplug.spotless</groupId>
 				<artifactId>spotless-maven-plugin</artifactId>
-				<version>2.36.0</version>
+				<version>2.40.0</version>
 				<configuration>
 					<java>
 						<includes>
@@ -276,7 +276,7 @@
 							<include>src/test/java/**/*.java</include> <!-- Check application tests code -->
 						</includes>
 						<googleJavaFormat>
-							<version>1.16.0</version>
+							<version>1.18.1</version>
 							<style>GOOGLE</style>
 						</googleJavaFormat>
 						<importOrder />


### PR DESCRIPTION
This lets the user control when the scheduler should be stopped. By default it stops the scheduler when Spring issues the ContextClosedEvent.

## Fixes
#423 


## Reminders
- [x] Added/ran automated tests
- [ ] Update README and/or examples
- [x] Ran `mvn spotless:apply`

---
cc @kagkarlsson
