### PR TITLE
Fix bug that causes cronpatterns with no next execution-time to fail.

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/Schedule.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/Schedule.java
@@ -18,6 +18,8 @@ import java.time.Instant;
 
 public interface Schedule {
 
+  Instant NEVER = Instant.parse("2500-01-01T12:00:00.00Z");
+
   Instant getNextExecutionTime(ExecutionComplete executionComplete);
 
   /** Used to get the first execution-time for a schedule. Simulates an ExecutionComplete event. */

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/CronTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/CronTest.java
@@ -121,6 +121,13 @@ public class CronTest {
     assertFalse(Schedules.cron("0 * * * * ?").isDisabled());
   }
 
+  @Test
+  public void should_not_fail_on_cronschedule_without_next_execution_time() {
+    CronSchedule cron =
+        new CronSchedule("0 0 0 29 2 MON#1", ZoneId.systemDefault(), CronStyle.SPRING53);
+    Assertions.assertEquals(Schedule.NEVER, cron.getNextExecutionTime(complete(Instant.now())));
+  }
+
   private void assertNextExecutionTime(
       ZonedDateTime timeDone, String cronPattern, ZonedDateTime expectedTime) {
     assertNextExecutionTime(timeDone, expectedTime, new CronSchedule(cronPattern));


### PR DESCRIPTION
Introduce an `Instant.NEVER` that represents future execution-time that will nevery run, and use this for cron-patterns with no next execution-time.

## Fixes
* #361 


## Reminders
- [ ] Added/ran automated tests
- [ ] Update README and/or examples
- [ ] Ran `mvn spotless:apply`
