### PR TITLE
fix: use varchar instead of (deprecated) text column type for MSSQL schema

### DIFF
--- a/db-scheduler/src/test/resources/mssql_tables.sql
+++ b/db-scheduler/src/test/resources/mssql_tables.sql
@@ -1,16 +1,17 @@
-create table scheduled_tasks (
-  task_name varchar(250) not null,
-  task_instance varchar(250) not null,
-  task_data  nvarchar(max),
-  execution_time datetimeoffset  not null,
-  picked bit,
-  picked_by text,
-  last_success datetimeoffset ,
-  last_failure datetimeoffset ,
-  consecutive_failures INT,
-  last_heartbeat datetimeoffset ,
-  [version] BIGINT not null,
-  PRIMARY KEY (task_name, task_instance),
-  INDEX execution_time_idx (execution_time),
-  INDEX last_heartbeat_idx (last_heartbeat)
+create table scheduled_tasks
+(
+  task_name            varchar(250)   not null,
+  task_instance        varchar(250)   not null,
+  task_data            nvarchar(max),
+  execution_time       datetimeoffset not null,
+  picked               bit,
+  picked_by            varchar(50),
+  last_success         datetimeoffset,
+  last_failure         datetimeoffset,
+  consecutive_failures int,
+  last_heartbeat       datetimeoffset,
+  [version]            bigint         not null,
+  primary key (task_name, task_instance),
+  index execution_time_idx (execution_time),
+  index last_heartbeat_idx (last_heartbeat)
 )


### PR DESCRIPTION
* Updated the MSSQL schema to not use the (deprecated) `text` data type.
* Use `varchar(5)` since, the max length is 50 according to https://github.com/kagkarlsson/db-scheduler/discussions/453
* Some alignment in casing and spacing

## Fixes
#454

## Reminders
- [ ] Added/ran automated tests
- [ ] Update README and/or examples
- [x] Ran `mvn spotless:apply`

---
cc @kagkarlsson
