### PR TITLE
fix: Update Oracle schema to use timezone-aware type

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
@@ -35,7 +35,11 @@ public class AutodetectJdbcCustomization implements JdbcCustomization {
   private final JdbcCustomization jdbcCustomization;
 
   public AutodetectJdbcCustomization(DataSource dataSource) {
-    JdbcCustomization detectedCustomization = new DefaultJdbcCustomization();
+    this(dataSource, false);
+  }
+
+  public AutodetectJdbcCustomization(DataSource dataSource, boolean persistTimestampInUTC) {
+    JdbcCustomization detectedCustomization = new DefaultJdbcCustomization(persistTimestampInUTC);
 
     LOG.debug("Detecting database...");
     try (Connection c = dataSource.getConnection()) {
@@ -44,25 +48,25 @@ public class AutodetectJdbcCustomization implements JdbcCustomization {
 
       if (databaseProductName.equals(MICROSOFT_SQL_SERVER)) {
         LOG.info("Using MSSQL jdbc-overrides.");
-        detectedCustomization = new MssqlJdbcCustomization();
+        detectedCustomization = new MssqlJdbcCustomization(persistTimestampInUTC);
       } else if (databaseProductName.equals(POSTGRESQL)) {
         LOG.info("Using PostgreSQL jdbc-overrides.");
-        detectedCustomization = new PostgreSqlJdbcCustomization();
+        detectedCustomization = new PostgreSqlJdbcCustomization(false, persistTimestampInUTC);
       } else if (databaseProductName.contains(ORACLE)) {
         LOG.info("Using Oracle jdbc-overrides.");
-        detectedCustomization = new OracleJdbcCustomization();
+        detectedCustomization = new OracleJdbcCustomization(persistTimestampInUTC);
       } else if (databaseProductName.contains(MARIADB)) {
         LOG.info("Using MariaDB jdbc-overrides.");
-        detectedCustomization = new MariaDBJdbcCustomization();
+        detectedCustomization = new MariaDBJdbcCustomization(persistTimestampInUTC);
       } else if (databaseProductName.contains(MYSQL)) {
         int databaseMajorVersion = c.getMetaData().getDatabaseMajorVersion();
         String dbVersion = c.getMetaData().getDatabaseProductVersion();
         if (databaseMajorVersion >= 8) {
           LOG.info("Using MySQL jdbc-overrides version 8 and later. (v {})", dbVersion);
-          detectedCustomization = new MySQL8JdbcCustomization();
+          detectedCustomization = new MySQL8JdbcCustomization(persistTimestampInUTC);
         } else {
           LOG.info("Using MySQL jdbc-overrides for version older than 8. (v {})", dbVersion);
-          detectedCustomization = new MySQLJdbcCustomization();
+          detectedCustomization = new MySQLJdbcCustomization(persistTimestampInUTC);
         }
       }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/DefaultJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/DefaultJdbcCustomization.java
@@ -19,19 +19,38 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Optional;
+import java.util.TimeZone;
 
 public class DefaultJdbcCustomization implements JdbcCustomization {
+  private static final Calendar UTC = GregorianCalendar.getInstance(TimeZone.getTimeZone("CET"));
+  private final boolean persistTimestampInUTC;
+
+  public DefaultJdbcCustomization(boolean persistTimestampInUTC) {
+
+    this.persistTimestampInUTC = persistTimestampInUTC;
+  }
 
   @Override
   public void setInstant(PreparedStatement p, int index, Instant value) throws SQLException {
-    p.setTimestamp(index, value != null ? Timestamp.from(value) : null);
+    if (persistTimestampInUTC) {
+      p.setTimestamp(index, value != null ? Timestamp.from(value) : null, UTC);
+    } else {
+      p.setTimestamp(index, value != null ? Timestamp.from(value) : null);
+    }
   }
 
   @Override
   public Instant getInstant(ResultSet rs, String columnName) throws SQLException {
-    return Optional.ofNullable(rs.getTimestamp(columnName)).map(Timestamp::toInstant).orElse(null);
+    if (persistTimestampInUTC) {
+      return Optional.ofNullable(rs.getTimestamp(columnName, UTC)).map(Timestamp::toInstant).orElse(null);
+    } else {
+      return Optional.ofNullable(rs.getTimestamp(columnName)).map(Timestamp::toInstant).orElse(null);
+    }
   }
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/DefaultJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/DefaultJdbcCustomization.java
@@ -19,7 +19,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
@@ -47,9 +46,13 @@ public class DefaultJdbcCustomization implements JdbcCustomization {
   @Override
   public Instant getInstant(ResultSet rs, String columnName) throws SQLException {
     if (persistTimestampInUTC) {
-      return Optional.ofNullable(rs.getTimestamp(columnName, UTC)).map(Timestamp::toInstant).orElse(null);
+      return Optional.ofNullable(rs.getTimestamp(columnName, UTC))
+          .map(Timestamp::toInstant)
+          .orElse(null);
     } else {
-      return Optional.ofNullable(rs.getTimestamp(columnName)).map(Timestamp::toInstant).orElse(null);
+      return Optional.ofNullable(rs.getTimestamp(columnName))
+          .map(Timestamp::toInstant)
+          .orElse(null);
     }
   }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepositoryContext.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepositoryContext.java
@@ -21,12 +21,12 @@ import com.github.kagkarlsson.scheduler.task.Execution;
 import java.util.List;
 import java.util.function.Supplier;
 
-class JdbcTaskRepositoryContext {
-  final TaskResolver taskResolver;
-  final String tableName;
-  final SchedulerName schedulerName;
-  final JdbcRunner jdbcRunner;
-  final Supplier<ResultSetMapper<List<Execution>>> resultSetMapper;
+public class JdbcTaskRepositoryContext {
+  public final TaskResolver taskResolver;
+  public final String tableName;
+  public final SchedulerName schedulerName;
+  public final JdbcRunner jdbcRunner;
+  public final Supplier<ResultSetMapper<List<Execution>>> resultSetMapper;
 
   JdbcTaskRepositoryContext(
       TaskResolver taskResolver,

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MariaDBJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MariaDBJdbcCustomization.java
@@ -17,6 +17,10 @@ import static com.github.kagkarlsson.scheduler.jdbc.Queries.selectForUpdate;
 
 public class MariaDBJdbcCustomization extends DefaultJdbcCustomization {
 
+  public MariaDBJdbcCustomization(boolean persistTimestampInUTC) {
+    super(persistTimestampInUTC);
+  }
+
   @Override
   public String getName() {
     return "MariaDB";

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MssqlJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MssqlJdbcCustomization.java
@@ -24,6 +24,14 @@ import java.util.TimeZone;
 
 public class MssqlJdbcCustomization extends DefaultJdbcCustomization {
 
+  public MssqlJdbcCustomization() {
+    super(false);
+  }
+
+  public MssqlJdbcCustomization(boolean persistTimestampInUTC) {
+    super(persistTimestampInUTC);
+  }
+
   @Override
   public String getName() {
     return "MSSQL";

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MySQL8JdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MySQL8JdbcCustomization.java
@@ -17,6 +17,10 @@ import static com.github.kagkarlsson.scheduler.jdbc.Queries.selectForUpdate;
 
 public class MySQL8JdbcCustomization extends DefaultJdbcCustomization {
 
+  public MySQL8JdbcCustomization(boolean persistTimestampInUTC) {
+    super(persistTimestampInUTC);
+  }
+
   @Override
   public String getName() {
     return "MySQL => v8";

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MySQLJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MySQLJdbcCustomization.java
@@ -15,6 +15,10 @@ package com.github.kagkarlsson.scheduler.jdbc;
 
 public class MySQLJdbcCustomization extends DefaultJdbcCustomization {
 
+  public MySQLJdbcCustomization(boolean persistTimestampInUTC) {
+    super(persistTimestampInUTC);
+  }
+
   @Override
   public String getName() {
     return "MySQL < v8";

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/OracleJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/OracleJdbcCustomization.java
@@ -17,6 +17,10 @@ import static com.github.kagkarlsson.scheduler.jdbc.Queries.selectForUpdate;
 
 public class OracleJdbcCustomization extends DefaultJdbcCustomization {
 
+  public OracleJdbcCustomization(boolean persistTimestampInUTC) {
+    super(persistTimestampInUTC);
+  }
+
   @Override
   public String getName() {
     return "Oracle";

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/PostgreSqlJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/PostgreSqlJdbcCustomization.java
@@ -24,10 +24,11 @@ public class PostgreSqlJdbcCustomization extends DefaultJdbcCustomization {
   private final boolean useGenericLockAndFetch;
 
   public PostgreSqlJdbcCustomization() {
-    this(false);
+    this(false, false);
   }
 
-  public PostgreSqlJdbcCustomization(boolean useGenericLockAndFetch) {
+  public PostgreSqlJdbcCustomization(boolean useGenericLockAndFetch, boolean persistTimestampInUTC) {
+    super(persistTimestampInUTC);
     this.useGenericLockAndFetch = useGenericLockAndFetch;
   }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/PostgreSqlJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/PostgreSqlJdbcCustomization.java
@@ -27,7 +27,8 @@ public class PostgreSqlJdbcCustomization extends DefaultJdbcCustomization {
     this(false, false);
   }
 
-  public PostgreSqlJdbcCustomization(boolean useGenericLockAndFetch, boolean persistTimestampInUTC) {
+  public PostgreSqlJdbcCustomization(
+      boolean useGenericLockAndFetch, boolean persistTimestampInUTC) {
     super(persistTimestampInUTC);
     this.useGenericLockAndFetch = useGenericLockAndFetch;
   }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
@@ -75,7 +75,7 @@ public class TestHelper {
           new JdbcTaskRepository(
               dataSource,
               true,
-              new DefaultJdbcCustomization(),
+              new DefaultJdbcCustomization(false),
               tableName,
               taskResolver,
               new SchedulerName.Fixed("manual"),
@@ -85,7 +85,7 @@ public class TestHelper {
           new JdbcTaskRepository(
               dataSource,
               commitWhenAutocommitDisabled,
-              new DefaultJdbcCustomization(),
+              new DefaultJdbcCustomization(false),
               tableName,
               taskResolver,
               new SchedulerName.Fixed("manual"),

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/CompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/CompatibilityTest.java
@@ -37,7 +37,6 @@ import com.github.kagkarlsson.scheduler.task.TaskInstance;
 import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
 import com.github.kagkarlsson.scheduler.task.helper.RecurringTask;
 import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay;
-import com.github.kagkarlsson.scheduler.testhelper.SettableClock;
 import com.google.common.collect.Lists;
 import java.time.Duration;
 import java.time.Instant;
@@ -230,36 +229,37 @@ public abstract class CompatibilityTest {
     defaultTaskResolver.addTask(oneTime);
 
     JdbcTaskRepository winterTaskRepo =
-      new JdbcTaskRepository(
-        getDataSource(),
-        commitWhenAutocommitDisabled(),
-        new ZoneSpecificJdbcCustomization(getJdbcCustomization().orElse(new AutodetectJdbcCustomization(getDataSource())),
-          GregorianCalendar.getInstance(TimeZone.getTimeZone("CET"))
-        ),
-        DEFAULT_TABLE_NAME,
-        defaultTaskResolver,
-        new SchedulerName.Fixed("scheduler1"),
-        new SystemClock());
+        new JdbcTaskRepository(
+            getDataSource(),
+            commitWhenAutocommitDisabled(),
+            new ZoneSpecificJdbcCustomization(
+                getJdbcCustomization().orElse(new AutodetectJdbcCustomization(getDataSource())),
+                GregorianCalendar.getInstance(TimeZone.getTimeZone("CET"))),
+            DEFAULT_TABLE_NAME,
+            defaultTaskResolver,
+            new SchedulerName.Fixed("scheduler1"),
+            new SystemClock());
 
     JdbcTaskRepository summerTaskRepo =
-      new JdbcTaskRepository(
-        getDataSource(),
-        commitWhenAutocommitDisabled(),
-        new ZoneSpecificJdbcCustomization(getJdbcCustomization().orElse(new AutodetectJdbcCustomization(getDataSource())),
-          GregorianCalendar.getInstance(TimeZone.getTimeZone("CEST"))
-        ),
-        DEFAULT_TABLE_NAME,
-        defaultTaskResolver,
-        new SchedulerName.Fixed("scheduler1"),
-        new SystemClock());
+        new JdbcTaskRepository(
+            getDataSource(),
+            commitWhenAutocommitDisabled(),
+            new ZoneSpecificJdbcCustomization(
+                getJdbcCustomization().orElse(new AutodetectJdbcCustomization(getDataSource())),
+                GregorianCalendar.getInstance(TimeZone.getTimeZone("CEST"))),
+            DEFAULT_TABLE_NAME,
+            defaultTaskResolver,
+            new SchedulerName.Fixed("scheduler1"),
+            new SystemClock());
 
     Instant noonFirstJan = Instant.parse("2020-01-01T12:00:00.00Z");
 
     TaskInstance<String> instance1 = oneTime.instance("future1");
     winterTaskRepo.createIfNotExists(SchedulableInstance.of(instance1, noonFirstJan));
 
-    assertThat(winterTaskRepo.getExecution(instance1).get().executionTime,
-      is (summerTaskRepo.getExecution(instance1).get().executionTime));
+    assertThat(
+        winterTaskRepo.getExecution(instance1).get().executionTime,
+        is(summerTaskRepo.getExecution(instance1).get().executionTime));
   }
 
   private void doJDBCRepositoryCompatibilityTestUsingData(String data) {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/CompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/CompatibilityTest.java
@@ -37,12 +37,15 @@ import com.github.kagkarlsson.scheduler.task.TaskInstance;
 import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
 import com.github.kagkarlsson.scheduler.task.helper.RecurringTask;
 import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay;
+import com.github.kagkarlsson.scheduler.testhelper.SettableClock;
 import com.google.common.collect.Lists;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Optional;
+import java.util.TimeZone;
 import javax.sql.DataSource;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.junit.jupiter.api.AfterEach;
@@ -214,6 +217,46 @@ public abstract class CompatibilityTest {
     assertThat(picked, IsCollectionWithSize.hasSize(1));
 
     assertThat(jdbcTaskRepository.pick(picked.get(0), now), OptionalMatchers.empty());
+  }
+
+  @Test
+  public void test_persistent_instant() {
+    TaskResolver defaultTaskResolver = new TaskResolver(StatsRegistry.NOOP, new ArrayList<>());
+    defaultTaskResolver.addTask(oneTime);
+
+    JdbcTaskRepository winterTaskRepo =
+      new JdbcTaskRepository(
+        getDataSource(),
+        commitWhenAutocommitDisabled(),
+        new ZoneSpecificJdbcCustomization(getJdbcCustomization().orElse(new AutodetectJdbcCustomization(getDataSource())),
+          GregorianCalendar.getInstance(TimeZone.getTimeZone("CET"))
+        ),
+        DEFAULT_TABLE_NAME,
+        defaultTaskResolver,
+        new SchedulerName.Fixed("scheduler1"),
+        new SystemClock());
+
+    JdbcTaskRepository summerTaskRepo =
+      new JdbcTaskRepository(
+        getDataSource(),
+        commitWhenAutocommitDisabled(),
+        new ZoneSpecificJdbcCustomization(getJdbcCustomization().orElse(new AutodetectJdbcCustomization(getDataSource())),
+          GregorianCalendar.getInstance(TimeZone.getTimeZone("CEST"))
+        ),
+        DEFAULT_TABLE_NAME,
+        defaultTaskResolver,
+        new SchedulerName.Fixed("scheduler1"),
+        new SystemClock());
+
+
+    final Instant now = TimeHelper.truncatedInstantNow();
+    Instant noonFirstJan = Instant.parse("2020-01-01T12:00:00.00Z");
+
+    TaskInstance<String> instance1 = oneTime.instance("future1");
+    winterTaskRepo.createIfNotExists(SchedulableInstance.of(instance1, noonFirstJan));
+
+    assertThat(winterTaskRepo.getExecution(instance1).get().executionTime,
+      is (summerTaskRepo.getExecution(instance1).get().executionTime));
   }
 
   private void doJDBCRepositoryCompatibilityTestUsingData(String data) {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/CompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/CompatibilityTest.java
@@ -59,6 +59,7 @@ public abstract class CompatibilityTest {
 
   private static final int POLLING_LIMIT = 10_000;
   private final boolean supportsSelectForUpdate;
+  private final boolean shouldHavePersistentTimezone;
 
   @RegisterExtension public StopSchedulerExtension stopScheduler = new StopSchedulerExtension();
 
@@ -71,8 +72,9 @@ public abstract class CompatibilityTest {
   private TestableRegistry testableRegistry;
   private ExecutionCompletedCondition completed12Condition;
 
-  public CompatibilityTest(boolean supportsSelectForUpdate) {
+  public CompatibilityTest(boolean supportsSelectForUpdate, boolean shouldHavePersistentTimezone) {
     this.supportsSelectForUpdate = supportsSelectForUpdate;
+    this.shouldHavePersistentTimezone = shouldHavePersistentTimezone;
   }
 
   public abstract DataSource getDataSource();
@@ -220,7 +222,10 @@ public abstract class CompatibilityTest {
   }
 
   @Test
-  public void test_persistent_instant() {
+  public void test_has_peristent_time_zone() {
+    if (!shouldHavePersistentTimezone) {
+      return;
+    }
     TaskResolver defaultTaskResolver = new TaskResolver(StatsRegistry.NOOP, new ArrayList<>());
     defaultTaskResolver.addTask(oneTime);
 
@@ -248,8 +253,6 @@ public abstract class CompatibilityTest {
         new SchedulerName.Fixed("scheduler1"),
         new SystemClock());
 
-
-    final Instant now = TimeHelper.truncatedInstantNow();
     Instant noonFirstJan = Instant.parse("2020-01-01T12:00:00.00Z");
 
     TaskInstance<String> instance1 = oneTime.instance("future1");

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/MariaDB103CompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/MariaDB103CompatibilityTest.java
@@ -24,7 +24,7 @@ public class MariaDB103CompatibilityTest extends CompatibilityTest {
   private static HikariDataSource pooledDatasource;
 
   public MariaDB103CompatibilityTest() {
-    super(false); // FIXLATER: fix syntax and enable
+    super(false, false); // FIXLATER: fix syntax and enable
   }
 
   @BeforeAll

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/MssqlCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/MssqlCompatibilityTest.java
@@ -31,7 +31,7 @@ public class MssqlCompatibilityTest extends CompatibilityTest {
   private static DataSource pooledDatasource;
 
   public MssqlCompatibilityTest() {
-    super(true);
+    super(true, true);
   }
 
   @BeforeAll

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/Mysql5CompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/Mysql5CompatibilityTest.java
@@ -24,7 +24,7 @@ public class Mysql5CompatibilityTest extends CompatibilityTest {
   private static HikariDataSource pooledDatasource;
 
   public Mysql5CompatibilityTest() {
-    super(false);
+    super(false, false);
   }
 
   @BeforeAll

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/Mysql8CompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/Mysql8CompatibilityTest.java
@@ -24,7 +24,7 @@ public class Mysql8CompatibilityTest extends CompatibilityTest {
   private static HikariDataSource pooledDatasource;
 
   public Mysql8CompatibilityTest() {
-    super(false); // FIXLATER: fix syntax and enable
+    super(false, false); // FIXLATER: fix syntax and enable
   }
 
   @BeforeAll

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/NoAutoCommitPostgresqlCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/NoAutoCommitPostgresqlCompatibilityTest.java
@@ -20,7 +20,7 @@ public class NoAutoCommitPostgresqlCompatibilityTest extends CompatibilityTest {
   private static HikariDataSource pooledDatasource;
 
   public NoAutoCommitPostgresqlCompatibilityTest() {
-    super(true);
+    super(true, true);
   }
 
   @BeforeAll

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/Oracle11gCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/Oracle11gCompatibilityTest.java
@@ -22,7 +22,7 @@ public class Oracle11gCompatibilityTest extends CompatibilityTest {
   private static HikariDataSource pooledDatasource;
 
   public Oracle11gCompatibilityTest() {
-    super(false); // FIXLATER: fix syntax and enable
+    super(false, true); // FIXLATER: fix syntax and enable
   }
 
   @BeforeAll

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/PostgresqlCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/PostgresqlCompatibilityTest.java
@@ -21,7 +21,7 @@ public class PostgresqlCompatibilityTest extends CompatibilityTest {
   //    );
 
   public PostgresqlCompatibilityTest() {
-    super(true);
+    super(true, true);
   }
 
   @Override

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/PostgresqlGenericFetchAndLockCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/PostgresqlGenericFetchAndLockCompatibilityTest.java
@@ -13,7 +13,7 @@ public class PostgresqlGenericFetchAndLockCompatibilityTest extends Compatibilit
   public EmbeddedPostgresqlExtension postgres = new EmbeddedPostgresqlExtension();
 
   public PostgresqlGenericFetchAndLockCompatibilityTest() {
-    super(true);
+    super(true, true);
   }
 
   @Override
@@ -28,6 +28,6 @@ public class PostgresqlGenericFetchAndLockCompatibilityTest extends Compatibilit
 
   @Override
   public Optional<JdbcCustomization> getJdbcCustomization() {
-    return Optional.of(new PostgreSqlJdbcCustomization(true));
+    return Optional.of(new PostgreSqlJdbcCustomization(true, false));
   }
 }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/ZoneSpecificJdbcCustomization.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/ZoneSpecificJdbcCustomization.java
@@ -1,0 +1,85 @@
+package com.github.kagkarlsson.scheduler.compatibility;
+
+import com.github.kagkarlsson.scheduler.jdbc.JdbcCustomization;
+import com.github.kagkarlsson.scheduler.jdbc.JdbcTaskRepositoryContext;
+import com.github.kagkarlsson.scheduler.task.Execution;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Calendar;
+import java.util.List;
+import java.util.Optional;
+
+public class ZoneSpecificJdbcCustomization implements JdbcCustomization {
+  private final JdbcCustomization delegate;
+  private final Calendar zoneIfNonePresent;
+
+  public ZoneSpecificJdbcCustomization(JdbcCustomization delegate, Calendar zoneIfNonePresent) {
+    this.delegate = delegate;
+    this.zoneIfNonePresent = zoneIfNonePresent;
+  }
+
+  @Override
+  public String getName() {
+    return delegate.getName() + "-zoned";
+  }
+
+  @Override
+  public void setInstant(PreparedStatement p, int index, Instant value) throws SQLException {
+    p.setTimestamp(index, value != null ? Timestamp.from(value) : null, zoneIfNonePresent);
+  }
+
+  @Override
+  public Instant getInstant(ResultSet rs, String columnName) throws SQLException {
+    return Optional.ofNullable(rs.getTimestamp(columnName, zoneIfNonePresent)).map(Timestamp::toInstant).orElse(null);
+  }
+
+  @Override
+  public void setTaskData(PreparedStatement p, int index, byte[] value) throws SQLException {
+    delegate.setTaskData(p, index, value);
+  }
+
+  @Override
+  public byte[] getTaskData(ResultSet rs, String columnName) throws SQLException {
+    return delegate.getTaskData(rs, columnName);
+  }
+
+  @Override
+  public boolean supportsExplicitQueryLimitPart() {
+    return delegate.supportsExplicitQueryLimitPart();
+  }
+
+  @Override
+  public String getQueryLimitPart(int limit) {
+    return delegate.getQueryLimitPart(limit);
+  }
+
+  @Override
+  public boolean supportsSingleStatementLockAndFetch() {
+    return delegate.supportsSingleStatementLockAndFetch();
+  }
+
+  @Override
+  public List<Execution> lockAndFetchSingleStatement(JdbcTaskRepositoryContext ctx, Instant now,
+    int limit) {
+    return delegate.lockAndFetchSingleStatement(ctx, now, limit);
+  }
+
+  @Override
+  public boolean supportsGenericLockAndFetch() {
+    return delegate.supportsGenericLockAndFetch();
+  }
+
+  @Override
+  public String createGenericSelectForUpdateQuery(String tableName, int limit,
+    String requiredAndCondition) {
+    return delegate.createGenericSelectForUpdateQuery(tableName, limit, requiredAndCondition);
+  }
+
+  @Override
+  public String createSelectDueQuery(String tableName, int limit, String andCondition) {
+    return delegate.createSelectDueQuery(tableName, limit, andCondition);
+  }
+}

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/ZoneSpecificJdbcCustomization.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/ZoneSpecificJdbcCustomization.java
@@ -33,7 +33,9 @@ public class ZoneSpecificJdbcCustomization implements JdbcCustomization {
 
   @Override
   public Instant getInstant(ResultSet rs, String columnName) throws SQLException {
-    return Optional.ofNullable(rs.getTimestamp(columnName, zoneIfNonePresent)).map(Timestamp::toInstant).orElse(null);
+    return Optional.ofNullable(rs.getTimestamp(columnName, zoneIfNonePresent))
+        .map(Timestamp::toInstant)
+        .orElse(null);
   }
 
   @Override
@@ -62,8 +64,8 @@ public class ZoneSpecificJdbcCustomization implements JdbcCustomization {
   }
 
   @Override
-  public List<Execution> lockAndFetchSingleStatement(JdbcTaskRepositoryContext ctx, Instant now,
-    int limit) {
+  public List<Execution> lockAndFetchSingleStatement(
+      JdbcTaskRepositoryContext ctx, Instant now, int limit) {
     return delegate.lockAndFetchSingleStatement(ctx, now, limit);
   }
 
@@ -73,8 +75,8 @@ public class ZoneSpecificJdbcCustomization implements JdbcCustomization {
   }
 
   @Override
-  public String createGenericSelectForUpdateQuery(String tableName, int limit,
-    String requiredAndCondition) {
+  public String createGenericSelectForUpdateQuery(
+      String tableName, int limit, String requiredAndCondition) {
     return delegate.createGenericSelectForUpdateQuery(tableName, limit, requiredAndCondition);
   }
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/concurrent/PostgresClusterTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/concurrent/PostgresClusterTest.java
@@ -47,7 +47,7 @@ public class PostgresClusterTest {
         DB.getDataSource(),
         (SchedulerBuilder b) -> {
           b.pollUsingLockAndFetch(((double) NUMBER_OF_THREADS) / 2, NUMBER_OF_THREADS);
-          b.jdbcCustomization(new PostgreSqlJdbcCustomization(false));
+          b.jdbcCustomization(new PostgreSqlJdbcCustomization(false, false));
         },
         stopScheduler);
   }
@@ -59,7 +59,7 @@ public class PostgresClusterTest {
         DB.getDataSource(),
         (SchedulerBuilder b) -> {
           b.pollUsingLockAndFetch(((double) NUMBER_OF_THREADS) / 2, NUMBER_OF_THREADS);
-          b.jdbcCustomization(new PostgreSqlJdbcCustomization(true));
+          b.jdbcCustomization(new PostgreSqlJdbcCustomization(true, false));
         },
         stopScheduler);
   }

--- a/db-scheduler/src/test/resources/oracle_tables.sql
+++ b/db-scheduler/src/test/resources/oracle_tables.sql
@@ -3,13 +3,13 @@ create table scheduled_tasks
     task_name            varchar(100),
     task_instance        varchar(100),
     task_data            blob,
-    execution_time       TIMESTAMP(6),
+    execution_time       TIMESTAMP(6) WITH TIME ZONE,
     picked               NUMBER(1, 0),
     picked_by            varchar(50),
-    last_success         TIMESTAMP(6),
-    last_failure         TIMESTAMP(6),
+    last_success         TIMESTAMP(6) WITH TIME ZONE,
+    last_failure         TIMESTAMP(6) WITH TIME ZONE,
     consecutive_failures NUMBER(19, 0),
-    last_heartbeat       TIMESTAMP(6),
+    last_heartbeat       TIMESTAMP(6) WITH TIME ZONE,
     version              NUMBER(19, 0),
     PRIMARY KEY (task_name, task_instance)
 )


### PR DESCRIPTION
* Update Oracle schema to use timezone-aware type
* Adds tests verifying that persisted instants are not affected by changes to JVM timezone
* Add configuration option to `JdbcCustomization` to allow users to explicitly choose to persist timestamps in UTC