### PR TITLE
MySQL, MariaDB always store timestamps in UTC

### DIFF
--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
@@ -151,6 +151,10 @@ public class DbSchedulerAutoConfiguration {
             .jdbcCustomization()
             .orElse(new AutodetectJdbcCustomization(transactionalDataSource)));
 
+    if (config.isAlwaysPersistTimestampInUtc()) {
+      builder.alwaysPersistTimestampInUTC();
+    }
+
     if (config.isImmediateExecutionEnabled()) {
       builder.enableImmediateExecution();
     }

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
@@ -101,6 +101,11 @@ public class DbSchedulerProperties {
   @DurationUnit(SECONDS)
   private Duration shutdownMaxWait = SchedulerBuilder.SHUTDOWN_MAX_WAIT;
 
+  /**
+   * Store timestamps in UTC timezone even though the schema supports storing timezone information
+   */
+  private boolean alwaysPersistTimestampInUtc = false;
+
   /** Which log level to use when logging task failures. Defaults to {@link LogLevel#DEBUG}. */
   private LogLevel failureLoggerLevel = SchedulerBuilder.DEFAULT_FAILURE_LOG_LEVEL;
 
@@ -227,5 +232,13 @@ public class DbSchedulerProperties {
   public void setPollingStrategyUpperLimitFractionOfThreads(
       double pollingStrategyUpperLimitFractionOfThreads) {
     this.pollingStrategyUpperLimitFractionOfThreads = pollingStrategyUpperLimitFractionOfThreads;
+  }
+
+  public boolean isAlwaysPersistTimestampInUtc() {
+    return alwaysPersistTimestampInUtc;
+  }
+
+  public void setAlwaysPersistTimestampInUtc(boolean alwaysPersistTimestampInUTC) {
+    this.alwaysPersistTimestampInUtc = alwaysPersistTimestampInUTC;
   }
 }

--- a/db-scheduler/pom.xml
+++ b/db-scheduler/pom.xml
@@ -275,7 +275,7 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>8.2.1.jre8</version>
+            <version>12.4.2.jre8</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -287,7 +287,7 @@
       <dependency>
         <groupId>org.mariadb.jdbc</groupId>
         <artifactId>mariadb-java-client</artifactId>
-        <version>3.1.4</version>
+        <version>3.3.2</version>
         <scope>test</scope>
       </dependency>
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
@@ -74,6 +74,7 @@ public class SchedulerBuilder {
   protected LogLevel logLevel = DEFAULT_FAILURE_LOG_LEVEL;
   protected boolean logStackTrace = LOG_STACK_TRACE_ON_FAILURE;
   private boolean registerShutdownHook = false;
+  private boolean alwaysPersistTimestampInUTC = false;
 
   public SchedulerBuilder(DataSource dataSource, List<Task<?>> knownTasks) {
     this.dataSource = dataSource;
@@ -156,6 +157,11 @@ public class SchedulerBuilder {
     return this;
   }
 
+  public SchedulerBuilder alwaysPersistTimestampInUTC() {
+    this.alwaysPersistTimestampInUTC = true;
+    return this;
+  }
+
   public SchedulerBuilder shutdownMaxWait(Duration shutdownMaxWait) {
     this.shutdownMaxWait = shutdownMaxWait;
     return this;
@@ -208,7 +214,8 @@ public class SchedulerBuilder {
     final TaskResolver taskResolver = new TaskResolver(statsRegistry, clock, knownTasks);
     final JdbcCustomization jdbcCustomization =
         ofNullable(this.jdbcCustomization)
-            .orElseGet(() -> new AutodetectJdbcCustomization(dataSource));
+            .orElseGet(
+                () -> new AutodetectJdbcCustomization(dataSource, alwaysPersistTimestampInUTC));
     final JdbcTaskRepository schedulerTaskRepository =
         new JdbcTaskRepository(
             dataSource,

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
@@ -48,7 +48,7 @@ public class AutodetectJdbcCustomization implements JdbcCustomization {
 
       if (databaseProductName.equals(MICROSOFT_SQL_SERVER)) {
         LOG.info("Using MSSQL jdbc-overrides.");
-        detectedCustomization = new MssqlJdbcCustomization(persistTimestampInUTC);
+        detectedCustomization = new MssqlJdbcCustomization(true);
       } else if (databaseProductName.equals(POSTGRESQL)) {
         LOG.info("Using PostgreSQL jdbc-overrides.");
         detectedCustomization = new PostgreSqlJdbcCustomization(false, persistTimestampInUTC);
@@ -57,16 +57,16 @@ public class AutodetectJdbcCustomization implements JdbcCustomization {
         detectedCustomization = new OracleJdbcCustomization(persistTimestampInUTC);
       } else if (databaseProductName.contains(MARIADB)) {
         LOG.info("Using MariaDB jdbc-overrides.");
-        detectedCustomization = new MariaDBJdbcCustomization(persistTimestampInUTC);
+        detectedCustomization = new MariaDBJdbcCustomization(true);
       } else if (databaseProductName.contains(MYSQL)) {
         int databaseMajorVersion = c.getMetaData().getDatabaseMajorVersion();
         String dbVersion = c.getMetaData().getDatabaseProductVersion();
         if (databaseMajorVersion >= 8) {
           LOG.info("Using MySQL jdbc-overrides version 8 and later. (v {})", dbVersion);
-          detectedCustomization = new MySQL8JdbcCustomization(persistTimestampInUTC);
+          detectedCustomization = new MySQL8JdbcCustomization(true);
         } else {
           LOG.info("Using MySQL jdbc-overrides for version older than 8. (v {})", dbVersion);
-          detectedCustomization = new MySQLJdbcCustomization(persistTimestampInUTC);
+          detectedCustomization = new MySQLJdbcCustomization(true);
         }
       }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/DefaultJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/DefaultJdbcCustomization.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 import java.util.TimeZone;
 
 public class DefaultJdbcCustomization implements JdbcCustomization {
-  private static final Calendar UTC = GregorianCalendar.getInstance(TimeZone.getTimeZone("CET"));
+  public static final Calendar UTC = GregorianCalendar.getInstance(TimeZone.getTimeZone("UTC"));
   private final boolean persistTimestampInUTC;
 
   public DefaultJdbcCustomization(boolean persistTimestampInUTC) {
@@ -36,10 +36,15 @@ public class DefaultJdbcCustomization implements JdbcCustomization {
 
   @Override
   public void setInstant(PreparedStatement p, int index, Instant value) throws SQLException {
+    if (value == null) {
+      p.setTimestamp(index, null);
+      return;
+    }
+
     if (persistTimestampInUTC) {
-      p.setTimestamp(index, value != null ? Timestamp.from(value) : null, UTC);
+      p.setTimestamp(index, Timestamp.from(value), UTC);
     } else {
-      p.setTimestamp(index, value != null ? Timestamp.from(value) : null);
+      p.setTimestamp(index, Timestamp.from(value));
     }
   }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MariaDBJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MariaDBJdbcCustomization.java
@@ -15,10 +15,20 @@ package com.github.kagkarlsson.scheduler.jdbc;
 
 import static com.github.kagkarlsson.scheduler.jdbc.Queries.selectForUpdate;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class MariaDBJdbcCustomization extends DefaultJdbcCustomization {
+  private static final Logger LOG = LoggerFactory.getLogger(MariaDBJdbcCustomization.class);
 
   public MariaDBJdbcCustomization(boolean persistTimestampInUTC) {
     super(persistTimestampInUTC);
+    if (!persistTimestampInUTC) {
+      LOG.warn(
+          "{} does not support persistent timezones. "
+              + "It is recommended to store time in UTC to avoid issues with for example DST",
+          getClass().getName());
+    }
   }
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MssqlJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MssqlJdbcCustomization.java
@@ -15,34 +15,29 @@ package com.github.kagkarlsson.scheduler.jdbc;
 
 import static com.github.kagkarlsson.scheduler.jdbc.Queries.selectForUpdate;
 
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.util.Calendar;
-import java.util.TimeZone;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MssqlJdbcCustomization extends DefaultJdbcCustomization {
+  private static final Logger LOG = LoggerFactory.getLogger(MssqlJdbcCustomization.class);
 
   public MssqlJdbcCustomization() {
-    super(false);
+    super(true);
   }
 
   public MssqlJdbcCustomization(boolean persistTimestampInUTC) {
     super(persistTimestampInUTC);
+    if (!persistTimestampInUTC) {
+      LOG.warn(
+          "{} must explicitly specify timezone when persisting a timestamp. "
+              + "Persisting timestamp with undefined timezone is not recommended and will likely cause issues",
+          getClass().getName());
+    }
   }
 
   @Override
   public String getName() {
     return "MSSQL";
-  }
-
-  @Override
-  public void setInstant(PreparedStatement p, int index, Instant value) throws SQLException {
-    p.setTimestamp(
-        index,
-        value != null ? Timestamp.from(value) : null,
-        Calendar.getInstance(TimeZone.getTimeZone("UTC")));
   }
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MySQL8JdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MySQL8JdbcCustomization.java
@@ -15,10 +15,20 @@ package com.github.kagkarlsson.scheduler.jdbc;
 
 import static com.github.kagkarlsson.scheduler.jdbc.Queries.selectForUpdate;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class MySQL8JdbcCustomization extends DefaultJdbcCustomization {
+  private static final Logger LOG = LoggerFactory.getLogger(MySQL8JdbcCustomization.class);
 
   public MySQL8JdbcCustomization(boolean persistTimestampInUTC) {
     super(persistTimestampInUTC);
+    if (!persistTimestampInUTC) {
+      LOG.warn(
+          "{} does not support persistent timezones. "
+              + "It is recommended to store time in UTC to avoid issues with for example DST",
+          getClass().getName());
+    }
   }
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MySQLJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MySQLJdbcCustomization.java
@@ -13,10 +13,20 @@
  */
 package com.github.kagkarlsson.scheduler.jdbc;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class MySQLJdbcCustomization extends DefaultJdbcCustomization {
+  private static final Logger LOG = LoggerFactory.getLogger(MySQLJdbcCustomization.class);
 
   public MySQLJdbcCustomization(boolean persistTimestampInUTC) {
     super(persistTimestampInUTC);
+    if (!persistTimestampInUTC) {
+      LOG.warn(
+          "{} does not support persistent timezones. "
+              + "It is recommended to store time in UTC to avoid issues with for example DST",
+          getClass().getName());
+    }
   }
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/PostgreSqlJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/PostgreSqlJdbcCustomization.java
@@ -23,10 +23,6 @@ import java.util.List;
 public class PostgreSqlJdbcCustomization extends DefaultJdbcCustomization {
   private final boolean useGenericLockAndFetch;
 
-  public PostgreSqlJdbcCustomization() {
-    this(false, false);
-  }
-
   public PostgreSqlJdbcCustomization(
       boolean useGenericLockAndFetch, boolean persistTimestampInUTC) {
     super(persistTimestampInUTC);

--- a/examples/spring-boot-example/src/main/resources/application.properties
+++ b/examples/spring-boot-example/src/main/resources/application.properties
@@ -17,3 +17,4 @@ db-scheduler.polling-strategy=fetch
 db-scheduler.polling-strategy-lower-limit-fraction-of-threads=0.5
 db-scheduler.polling-strategy-upper-limit-fraction-of-threads=3.0
 db-scheduler.shutdown-max-wait=30m
+db-scheduler.always-persist-timestamp-in-utc=false


### PR DESCRIPTION
* **BREAKING CHANGE:** Since **MySQL** and **MariaDB** does not have a datatype for storing timestamps with time zones, start defaulting to storing them in UTC to avoid issues with DST
* **BREAKING CHANGE:** Change **Oracle** schema to use a datatype that supports time zones