### PR TITLE
fix: Add Automatic-Module-Name attribute to jar manifests for better Java 9+ JPMS compatibility

### DIFF
--- a/db-scheduler-boot-starter/pom.xml
+++ b/db-scheduler-boot-starter/pom.xml
@@ -148,7 +148,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -157,7 +157,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>com.github.kagkarlsson.scheduler.spring-boot</Automatic-Module-Name>
+                            <Automatic-Module-Name>com.github.kagkarlsson.scheduler.springboot</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/db-scheduler-boot-starter/pom.xml
+++ b/db-scheduler-boot-starter/pom.xml
@@ -148,4 +148,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.github.kagkarlsson.scheduler.boot</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/db-scheduler-boot-starter/pom.xml
+++ b/db-scheduler-boot-starter/pom.xml
@@ -157,7 +157,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>com.github.kagkarlsson.scheduler.boot</Automatic-Module-Name>
+                            <Automatic-Module-Name>com.github.kagkarlsson.scheduler.spring-boot</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/db-scheduler-boot-starter/pom.xml
+++ b/db-scheduler-boot-starter/pom.xml
@@ -154,6 +154,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/db-scheduler/pom.xml
+++ b/db-scheduler/pom.xml
@@ -344,6 +344,15 @@
             </plugin>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <manifestEntries>
+                                <Automatic-Module-Name>com.github.kagkarlsson.scheduler</Automatic-Module-Name>
+                            </manifestEntries>
+                        </transformer>
+                    </transformers>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/examples/spring-boot-example/src/main/java/com/github/kagkarlsson/examples/boot/App.java
+++ b/examples/spring-boot-example/src/main/java/com/github/kagkarlsson/examples/boot/App.java
@@ -36,7 +36,8 @@ public class App {
 
   /** Example hack: use a {@link CommandLineRunner} to trigger scheduling of a one-time task. */
   @Bean
-  CommandLineRunner executeOnStartup(Scheduler scheduler, @Qualifier("sampleOneTimeTask") Task<Void> sampleOneTimeTask) {
+  CommandLineRunner executeOnStartup(
+      Scheduler scheduler, @Qualifier("sampleOneTimeTask") Task<Void> sampleOneTimeTask) {
     log.info("Scheduling one time task to now!");
 
     return ignored ->


### PR DESCRIPTION
Add Automatic-Module-Name attribute to jar manifests for better Java 9+ JPMS compatibility. 
Affects: db-scheduler and db-scheduler-boot-starter.

Naturally the automatic module names I have entered are suggestions - please amend if required.


## Fixes
* Maven warning when compiling modular project: `Required filename-based automodules detected: [db-scheduler-13.0.0.jar]. Please don't publish this project to a public artifact repository!`


## Reminders
- [ ] Added/ran automated tests
- [ ] Update README and/or examples
- [x] Ran `mvn spotless:apply`

---
cc @kagkarlsson
