### PR TITLE
fix: Revert change in behavior for MariaDB and MySQL with regards to time zone assumptions for persisted timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,10 @@ How often the scheduler checks the database for due executions. Default `10s`.<b
 The Scheduler assumes that columns for persisting timestamps persist `Instant`s, not `LocalDateTime`s,
  i.e. somehow tie the timestamp to a zone. However, some databases have limited support for such types
  (which has no zone information) or other quirks, making "always store in UTC" a better alternative.
-Currently, only PostgreSQL and Oracle rely on the database preserving time zone information,
-other databases store timestamps in UTC. **NB:** For backwards compatibility, the default behavior
+For such cases, use this setting to always store Instants in UTC.
+PostgreSQL and Oracle-schemas is tested to preserve zone-information. **MySQL** and **MariaDB**-schemas
+_does not_ and should use this setting.
+**NB:** For backwards compatibility, the default behavior
 for "unknown" databases is to assume the database preserves time zone. For "known" databases,
 see the class `AutodetectJdbcCustomization`.
 

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
@@ -68,11 +68,13 @@ public class DbSchedulerProperties {
   /** What polling-strategy to use. Valid values are: FETCH,LOCK_AND_FETCH */
   private PollingStrategyConfig.Type pollingStrategy =
       SchedulerBuilder.DEFAULT_POLLING_STRATEGY.type;
+
   /**
    * The limit at which more executions are fetched from the database after fetching a full batch.
    */
   private double pollingStrategyLowerLimitFractionOfThreads =
       SchedulerBuilder.DEFAULT_POLLING_STRATEGY.lowerLimitFractionOfThreads;
+
   /**
    * For Type=FETCH, the number of due executions fetched from the database in each batch.
    *

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
@@ -162,7 +162,12 @@ public class AutodetectJdbcCustomization implements JdbcCustomization {
     if (!persistTimestampInUTC) {
       SILENCABLE_LOG.warn(
           "{}-schema does not support persistent timezones. "
-              + "It is recommended to store time in UTC to avoid issues with for example DST",
+              + "It is recommended to store time in UTC to avoid issues with for example DST. "
+            + "For first time users, use setting 'alwaysPersistTimestampInUtc' to achieve this. "
+            + "Users upgrading from a version prior to v14.0.0 can either silence this logger, "
+            + "or perform a controlled upgrade to UTC timestamps. All old instances "
+            + "of the scheduler must be stopped and timestamps migrated to UTC before starting "
+            + "again, using 'alwaysPersistTimestampInUtc=true'.",
           database);
     }
   }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
@@ -163,11 +163,11 @@ public class AutodetectJdbcCustomization implements JdbcCustomization {
       SILENCABLE_LOG.warn(
           "{}-schema does not support persistent timezones. "
               + "It is recommended to store time in UTC to avoid issues with for example DST. "
-            + "For first time users, use setting 'alwaysPersistTimestampInUtc' to achieve this. "
-            + "Users upgrading from a version prior to v14.0.0 can either silence this logger, "
-            + "or perform a controlled upgrade to UTC timestamps. All old instances "
-            + "of the scheduler must be stopped and timestamps migrated to UTC before starting "
-            + "again, using 'alwaysPersistTimestampInUtc=true'.",
+              + "For first time users, use setting 'alwaysPersistTimestampInUtc' to achieve this. "
+              + "Users upgrading from a version prior to v14.0.0 can either silence this logger, "
+              + "or perform a controlled upgrade to UTC timestamps. All old instances "
+              + "of the scheduler must be stopped and timestamps migrated to UTC before starting "
+              + "again, using 'alwaysPersistTimestampInUtc=true'.",
           database);
     }
   }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
@@ -48,6 +48,9 @@ public class AutodetectJdbcCustomization implements JdbcCustomization {
 
       if (databaseProductName.equals(MICROSOFT_SQL_SERVER)) {
         LOG.info("Using MSSQL jdbc-overrides.");
+        if (persistTimestampInUTC) {
+          LOG.info("Redundant 'persistTimestampInUTC' setting. MSSQL will always persist in UTC.");
+        }
         detectedCustomization = new MssqlJdbcCustomization(true);
       } else if (databaseProductName.equals(POSTGRESQL)) {
         LOG.info("Using PostgreSQL jdbc-overrides.");
@@ -57,16 +60,16 @@ public class AutodetectJdbcCustomization implements JdbcCustomization {
         detectedCustomization = new OracleJdbcCustomization(persistTimestampInUTC);
       } else if (databaseProductName.contains(MARIADB)) {
         LOG.info("Using MariaDB jdbc-overrides.");
-        detectedCustomization = new MariaDBJdbcCustomization(true);
+        detectedCustomization = new MariaDBJdbcCustomization(persistTimestampInUTC);
       } else if (databaseProductName.contains(MYSQL)) {
         int databaseMajorVersion = c.getMetaData().getDatabaseMajorVersion();
         String dbVersion = c.getMetaData().getDatabaseProductVersion();
         if (databaseMajorVersion >= 8) {
           LOG.info("Using MySQL jdbc-overrides version 8 and later. (v {})", dbVersion);
-          detectedCustomization = new MySQL8JdbcCustomization(true);
+          detectedCustomization = new MySQL8JdbcCustomization(persistTimestampInUTC);
         } else {
           LOG.info("Using MySQL jdbc-overrides for version older than 8. (v {})", dbVersion);
-          detectedCustomization = new MySQLJdbcCustomization(true);
+          detectedCustomization = new MySQLJdbcCustomization(persistTimestampInUTC);
         }
       } else {
         if (persistTimestampInUTC) {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MariaDBJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MariaDBJdbcCustomization.java
@@ -23,12 +23,6 @@ public class MariaDBJdbcCustomization extends DefaultJdbcCustomization {
 
   public MariaDBJdbcCustomization(boolean persistTimestampInUTC) {
     super(persistTimestampInUTC);
-    if (!persistTimestampInUTC) {
-      LOG.warn(
-          "{} does not support persistent timezones. "
-              + "It is recommended to store time in UTC to avoid issues with for example DST",
-          getClass().getName());
-    }
   }
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MySQL8JdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MySQL8JdbcCustomization.java
@@ -23,12 +23,6 @@ public class MySQL8JdbcCustomization extends DefaultJdbcCustomization {
 
   public MySQL8JdbcCustomization(boolean persistTimestampInUTC) {
     super(persistTimestampInUTC);
-    if (!persistTimestampInUTC) {
-      LOG.warn(
-          "{} does not support persistent timezones. "
-              + "It is recommended to store time in UTC to avoid issues with for example DST",
-          getClass().getName());
-    }
   }
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MySQLJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MySQLJdbcCustomization.java
@@ -21,12 +21,6 @@ public class MySQLJdbcCustomization extends DefaultJdbcCustomization {
 
   public MySQLJdbcCustomization(boolean persistTimestampInUTC) {
     super(persistTimestampInUTC);
-    if (!persistTimestampInUTC) {
-      LOG.warn(
-          "{} does not support persistent timezones. "
-              + "It is recommended to store time in UTC to avoid issues with for example DST",
-          getClass().getName());
-    }
   }
 
   @Override

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
@@ -39,6 +39,7 @@ public class SchedulerTest {
 
   @RegisterExtension
   public EmbeddedPostgresqlExtension postgres = new EmbeddedPostgresqlExtension();
+
   //    @RegisterExtension
   //        public ChangeLogLevelsExtension changeLogLevels = new ChangeLogLevelsExtension(
   //        new ChangeLogLevelsExtension.LogLevelOverride("com.github.kagkarlsson.scheduler",

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/PostgresqlCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/PostgresqlCompatibilityTest.java
@@ -11,6 +11,7 @@ public class PostgresqlCompatibilityTest extends CompatibilityTest {
 
   @RegisterExtension
   public EmbeddedPostgresqlExtension postgres = new EmbeddedPostgresqlExtension();
+
   //    Enable if test gets flaky!
   //    @RegisterExtension
   //    public ChangeLogLevelsExtension changeLogLevels = new ChangeLogLevelsExtension(

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/ExecutorPoolTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/ExecutorPoolTest.java
@@ -35,6 +35,7 @@ public class ExecutorPoolTest {
   public EmbeddedPostgresqlExtension postgres = new EmbeddedPostgresqlExtension();
 
   @RegisterExtension public StopSchedulerExtension stopScheduler = new StopSchedulerExtension();
+
   //    Enable if test gets flaky!
   //    @RegisterExtension
   //    public ChangeLogLevelsExtension changeLogLevels = new ChangeLogLevelsExtension(

--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
 			<plugin>
 				<groupId>com.diffplug.spotless</groupId>
 				<artifactId>spotless-maven-plugin</artifactId>
-				<version>2.36.0</version>
+				<version>2.43.0</version>
 				<configuration>
 					<java>
 						<includes>
@@ -289,7 +289,7 @@
 							<include>src/test/java/**/*.java</include> <!-- Check application tests code -->
 						</includes>
 						<googleJavaFormat>
-							<version>1.16.0</version>
+							<version>1.17.0</version>
 							<style>GOOGLE</style>
 						</googleJavaFormat>
 						<importOrder />


### PR DESCRIPTION
Change back to default behavior for MySQL and MariaDB with regards to timestamp persistence and assumptions. It is recommended to persist timestamps in UTC for users of MariaDB and MySQL, but db-scheduler will not enforce it as default, since it in reality requires a controlled upgrade. 

Ideally the upgrade-process should be:
1. All instances of the scheduler should be shutdown
2. Timestamps in the database-table migrated to UTC
3. Configuration updated to use `alwaysPersistTimestampInUTC()`
4. Instances started again