### PR TITLE
fix: Respect always-persist-timestamp-in-utc in Spring Starter (#487)

### DIFF
--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
@@ -23,7 +23,6 @@ import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerStarter;
 import com.github.kagkarlsson.scheduler.boot.config.startup.ContextReadyStart;
 import com.github.kagkarlsson.scheduler.boot.config.startup.ImmediateStart;
 import com.github.kagkarlsson.scheduler.exceptions.SerializationException;
-import com.github.kagkarlsson.scheduler.jdbc.AutodetectJdbcCustomization;
 import com.github.kagkarlsson.scheduler.serializer.Serializer;
 import com.github.kagkarlsson.scheduler.stats.StatsRegistry;
 import com.github.kagkarlsson.scheduler.task.OnStartup;
@@ -146,10 +145,7 @@ public class DbSchedulerAutoConfiguration {
     builder.serializer(customizer.serializer().orElse(SPRING_JAVA_SERIALIZER));
 
     // Use custom JdbcCustomizer if provided.
-    builder.jdbcCustomization(
-        customizer
-            .jdbcCustomization()
-            .orElse(new AutodetectJdbcCustomization(transactionalDataSource)));
+    customizer.jdbcCustomization().ifPresent(builder::jdbcCustomization);
 
     if (config.isAlwaysPersistTimestampInUtc()) {
       builder.alwaysPersistTimestampInUTC();


### PR DESCRIPTION
## Brief, plain english overview of your changes here
I've changed the Spring Boot auto-configuration to ensure that the `jdbcCustomization` default does not override the configured `alwaysPersistTimestampInUTC` default. The previous `orElse` part is not necessary because the correct `jdbcCustomization` default later gets applied in `SchedulerBuilder#build`.

## Fixes
Fixes #487 


## Reminders
- [ ] Added/ran automated tests
  - I don't know how to add an efficient test for this.
  - I ran the tests but I got an unrelated error in an Oracle compatibility test, even without this change.
- [ ] Update README and/or examples
  - I don't think this is relevant.
- [ ] Ran `mvn spotless:apply`
  - This only changed unrelated code.

---
cc @kagkarlsson
