### PR TITLE
fix: Eagerly load DBSchedulerStarter (491)

### DIFF
--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.LazyInitializationExcludeFilter;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -194,6 +195,11 @@ public class DbSchedulerAutoConfiguration {
     }
 
     return new ImmediateStart(scheduler);
+  }
+
+  @Bean
+  public LazyInitializationExcludeFilter eagerDbSchedulerStarter() {
+    return LazyInitializationExcludeFilter.forBeanTypes(DbSchedulerStarter.class);
   }
 
   private static DataSource configureDataSource(DataSource existingDataSource) {

--- a/db-scheduler-boot-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
+++ b/db-scheduler-boot-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
@@ -29,6 +29,7 @@ import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.LazyInitializationExcludeFilter;
 import org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
@@ -239,6 +240,17 @@ public class DbSchedulerAutoConfigurationTest {
               assertThat(ctx).doesNotHaveBean(DefaultStatsRegistry.class);
               assertThat(ctx).doesNotHaveBean(MicrometerStatsRegistry.class);
             });
+  }
+
+  @Test
+  void it_should_exclude_db_scheduler_starter_from_lazy_init() {
+    ctxRunner.run(
+        (context) -> {
+          LazyInitializationExcludeFilter filter =
+              context.getBean(LazyInitializationExcludeFilter.class);
+
+          assertThat(filter.isExcluded(null, null, DbSchedulerStarter.class)).isTrue();
+        });
   }
 
   @Configuration


### PR DESCRIPTION
## Brief, plain english overview of your changes here
Excludes DbSchedulerStarter from being lazily initialized.

## Fixes
The DbSchedulerStarter isn't created in a application where lazy initialization is enabled via `spring.main.lazy-initialization=true`.

Fixes: #491

## Reminders
- [X] Added/ran automated tests
- [ ] Update README and/or examples
- [x] Ran `mvn spotless:apply`

---
cc @kagkarlsson
