### PR TITLE
feat: rename client.schedule(..) to clarify hidden behavior where nothing is scheduled if the instance already exists

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -253,6 +253,16 @@ public class Scheduler implements SchedulerClient {
   }
 
   @Override
+  public <T> boolean scheduleIfNotExists(TaskInstance<T> taskInstance, Instant executionTime) {
+    return this.delegate.scheduleIfNotExists(taskInstance, executionTime);
+  }
+
+  @Override
+  public <T> boolean scheduleIfNotExists(SchedulableInstance<T> schedulableInstance) {
+    return this.delegate.scheduleIfNotExists(schedulableInstance);
+  }
+
+  @Override
   public <T> void schedule(TaskInstance<T> taskInstance, Instant executionTime) {
     this.delegate.schedule(taskInstance, executionTime);
   }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
@@ -46,10 +46,14 @@ public interface SchedulerClient {
    * @param executionTime Instant it should run
    * @see java.time.Instant
    * @see com.github.kagkarlsson.scheduler.task.TaskInstance
+   * @deprecated use {@link #scheduleIfNotExists(TaskInstance, Instant)} instead.
    */
   @Deprecated
   <T> void schedule(TaskInstance<T> taskInstance, Instant executionTime);
 
+  /**
+   * @deprecated use {@link #scheduleIfNotExists(SchedulableInstance)} instead.
+   */
   @Deprecated
   <T> void schedule(SchedulableInstance<T> schedulableInstance);
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
@@ -5,6 +5,7 @@ import static java.time.Duration.ofSeconds;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import co.unruly.matchers.OptionalMatchers;
@@ -79,10 +80,20 @@ public class SchedulerClientTest {
   @Test
   public void client_should_be_able_to_schedule_executions() {
     SchedulerClient client = create(DB.getDataSource()).build();
+
+    // test deprecated method
     client.schedule(oneTimeTaskA.instance("1"), settableClock.now());
+    assertFalse(client.scheduleIfNotExists(oneTimeTaskA.instance("1"), settableClock.now()));
 
     scheduler.runAnyDueExecutions();
     assertThat(onetimeTaskHandlerA.timesExecuted.get(), CoreMatchers.is(1));
+
+    // test new method
+    client.scheduleIfNotExists(oneTimeTaskA.instance("1"), settableClock.now());
+    assertFalse(client.scheduleIfNotExists(oneTimeTaskA.instance("1"), settableClock.now()));
+
+    scheduler.runAnyDueExecutions();
+    assertThat(onetimeTaskHandlerA.timesExecuted.get(), CoreMatchers.is(2));
   }
 
   @Test


### PR DESCRIPTION
Rename `client.schedule(...)` method to `client.scheduleIfNotExists(...)` to clarify default but slightly hidden behavior where nothing is scheduled if the instance already exists.

Deprecated old `client.schedule(...)` methods.

Fixes  #326 