### PR TITLE
feat: add missing indexes to the oracle ddl script

### DIFF
--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/Oracle11gCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/Oracle11gCompatibilityTest.java
@@ -44,7 +44,7 @@ public class Oracle11gCompatibilityTest extends CompatibilityTest {
     pooledDatasource = new HikariDataSource(hikariConfig);
 
     // init schema
-    DbUtils.runSqlResource("/oracle_tables.sql").accept(pooledDatasource);
+    DbUtils.runSqlResource("/oracle_tables.sql", true).accept(pooledDatasource);
   }
 
   @BeforeEach

--- a/db-scheduler/src/test/resources/oracle_tables.sql
+++ b/db-scheduler/src/test/resources/oracle_tables.sql
@@ -12,5 +12,7 @@ create table scheduled_tasks
     last_heartbeat       TIMESTAMP(6) WITH TIME ZONE,
     version              NUMBER(19, 0),
     PRIMARY KEY (task_name, task_instance)
-)
+);
 
+CREATE INDEX scheduled_tasks__execution_time__idx on scheduled_tasks(execution_time);
+CREATE INDEX scheduled_tasks__last_heartbeat__idx on scheduled_tasks(last_heartbeat);


### PR DESCRIPTION
## Add missing indexes to the oracle ddl script

Every example for other databases (Postgres, Mssql, Mysql) contains indexes on `execution_time` and `last_heartbeat` while for Oracle DB they are missing.

I also expanded `DbUtiils` method to allow splitting sql statements from an sql file. `jdbcRunner.execute(statement, NOOP)` can run only one statement at a time for Oracle Db.

PS: two tests for oracle db are failing on master, is that expected?

## Reminders
- [x] Added/ran automated tests
- [x] Update README and/or examples
    - no need
- [x] Ran `mvn spotless:apply`

---
cc @kagkarlsson
