### PR TITLE
fix: Avoid false warning about UTC timestamps

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
@@ -219,11 +219,15 @@ public interface SchedulerClient {
       TaskResolver taskResolver = new TaskResolver(StatsRegistry.NOOP, knownTasks);
       final SystemClock clock = new SystemClock();
 
+      final JdbcCustomization jdbcCustomization =
+          ofNullable(this.jdbcCustomization)
+              .orElseGet(() -> new AutodetectJdbcCustomization(dataSource));
+
       TaskRepository taskRepository =
           new JdbcTaskRepository(
               dataSource,
               false,
-              ofNullable(jdbcCustomization).orElse(new AutodetectJdbcCustomization(dataSource)),
+              jdbcCustomization,
               tableName,
               taskResolver,
               new SchedulerClientName(),


### PR DESCRIPTION
If the JDBC customization is already correctly configured, `SchedulerClient.Builder.build` should not instantiate an unused incorrectly configured one.

## Fixes

Instantiating a `SchedulerClient` on MariaDB always logged the UTC warning, even when using a correctly configured JDBC customization:

```java
SchedulerClient.Builder.create(dataSource)
            .jdbcCustomization(AutodetectJdbcCustomization(dataSource, true))
            .build()
```

```
2024-06-21T15:44:33.427+02:00  WARN 57277 --- [  restartedMain] c.g.k.s.j.A.utc_warning                  : MariaDB-schema does not support persistent timezones. It is recommended to store time in UTC to avoid issues with for example DST. For first time users, use setting 'alwaysPersistTimestampInUtc' to achieve this. Users upgrading from a version prior to v14.0.0 can either silence this logger, or perform a controlled upgrade to UTC timestamps. All old instances of the scheduler must be stopped and timestamps migrated to UTC before starting again, using 'alwaysPersistTimestampInUtc=true'.
```

(I did not create a separate issue for this.)

---
cc @kagkarlsson
