### PR TITLE
fix: 511 - Declare DbSchedulerAutoConfiguration#eagerDbSchedulerStarter as static

### DIFF
--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
@@ -194,7 +194,7 @@ public class DbSchedulerAutoConfiguration {
   }
 
   @Bean
-  public LazyInitializationExcludeFilter eagerDbSchedulerStarter() {
+  static LazyInitializationExcludeFilter eagerDbSchedulerStarter() {
     return LazyInitializationExcludeFilter.forBeanTypes(DbSchedulerStarter.class);
   }
 


### PR DESCRIPTION
The `DbSchedulerAutoConfiguration#eagerDbSchedulerStarter` must be declared as static to ensure it is available before the `initialization` of `DbSchedulerAutoConfiguration`. Spring Boot will otherwise try to instantiate the `DbSchedulerAutoConfiguration` class using a no-args constructor.

> NOTE: Beans of this type will be instantiated very early in the spring application lifecycle so they should generally be declared static and not have any dependencies.

https://docs.spring.io/spring-boot/api/java/org/springframework/boot/LazyInitializationExcludeFilter.html#:~:text=NOTE%3A%20Beans%20of%20this%20type%20will%20be%20instantiated%20very%20early%20in%20the%20spring%20application%20lifecycle%20so%20they%20should%20generally%20be%20declared%20static%20and%20not%20have%20any%20dependencies.

Example - auto-configuration class with an args-constructor;
https://github.com/spring-projects/spring-boot/blob/ef303e74f7b92373e32d1cf95a121b37d377960a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/jmx/JmxEndpointAutoConfiguration.java#L116

Fixes #511

## Reminders
- [ ] Added/ran automated tests
- [ ] Update README and/or examples
- [X] Ran `mvn spotless:apply`

---
cc @kagkarlsson