### PR TITLE
Adding the ability to prioritize tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,25 @@ in queue (applicable if `upperLimitFractionOfThreads > 1.0`). If they stay there
 unlocked again (determined by `DeadExecutionHandler`).  Currently supported by **postgres**. **sql-server** also supports
 this, but testing has shown this is prone to deadlocks and thus not recommended until understood/resolved.
 
+### Prioritization
+
+If you have a mix of tasks with different priorities, you might want to enable prioritization.
+
+:gear: `.enablePrioritization()`<br/>
+An executor will always run the tasks with the highest priority first even if the `execution_time` is greater than other tasks. <br />
+You can set the priority of a task using the `setPriority(int)` method on the task instance, by default the priority of task is set to `0`.
+
+```java
+scheduler.schedule(
+  onetimeTask.instanceBuilder("1").setPriority(100),
+  Instant.now()
+);
+
+scheduler.schedule(
+  onetimeTask.instanceBuilder("2").setPriority(200),
+  Instant.now()
+);
+```
 
 #### Less commonly tuned
 
@@ -406,6 +425,7 @@ db-scheduler.table-name=scheduled_tasks
 db-scheduler.immediate-execution-enabled=false
 db-scheduler.scheduler-name=
 db-scheduler.threads=10
+db-scheduler.prioritization-enabled=false
 
 # Ignored if a custom DbSchedulerStarter bean is defined
 db-scheduler.delay-startup-until-context-ready=false
@@ -576,6 +596,9 @@ There are a number of users that are using db-scheduler for high throughput use-
 ## Versions / upgrading
 
 See [releases](https://github.com/kagkarlsson/db-scheduler/releases) for release-notes.
+
+**Upgrading to 15.x**
+* Add column `priority` and `priority_execution_time_idx` index to the database schema. See table definitions for [postgresql](./b-scheduler/src/test/resources/postgresql_tables.sql), [oracle](./db-scheduler/src/test/resources/oracle_tables.sql) or [mysql](./db-scheduler/src/test/resources/mysql_tables.sql). Note that when `enablePrioritization()` is used, the `null` value in order of prioritization is handled differently depending on the database used.
 
 **Upgrading to 8.x**
 * Custom Schedules must implement a method `boolean isDeterministic()` to indicate whether they will always produce the same instants or not.

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
@@ -164,6 +164,10 @@ public class DbSchedulerAutoConfiguration {
       builder.enableImmediateExecution();
     }
 
+    if (config.isPrioritizationEnabled()) {
+      builder.enablePrioritization();
+    }
+
     // Use custom executor service if provided
     customizer.executorService().ifPresent(builder::executorService);
 

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
@@ -114,6 +114,9 @@ public class DbSchedulerProperties {
   /** Whether or not to log the {@link Throwable} that caused a task to fail. */
   private boolean failureLoggerLogStackTrace = SchedulerBuilder.LOG_STACK_TRACE_ON_FAILURE;
 
+  /** Whether or not to prioritization of tasks is enabled. */
+  private boolean prioritizationEnabled = false;
+
   public boolean isEnabled() {
     return enabled;
   }
@@ -242,5 +245,13 @@ public class DbSchedulerProperties {
 
   public void setAlwaysPersistTimestampInUtc(boolean alwaysPersistTimestampInUTC) {
     this.alwaysPersistTimestampInUtc = alwaysPersistTimestampInUTC;
+  }
+
+  public boolean isPrioritizationEnabled() {
+    return prioritizationEnabled;
+  }
+
+  public void setPrioritizationEnabled(boolean prioritizationEnabled) {
+    this.prioritizationEnabled = prioritizationEnabled;
   }
 }

--- a/db-scheduler-boot-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
+++ b/db-scheduler-boot-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
@@ -183,6 +183,20 @@ public class DbSchedulerAutoConfigurationTest {
   }
 
   @Test
+  public void it_should_enable_prioritization() {
+    ctxRunner
+        .withPropertyValues("db-scheduler.prioritization-enabled=true")
+        .run(
+            (AssertableApplicationContext ctx) -> {
+              assertThat(ctx).hasSingleBean(DataSource.class);
+              assertThat(ctx).hasSingleBean(Scheduler.class);
+
+              DbSchedulerProperties props = ctx.getBean(DbSchedulerProperties.class);
+              assertThat(props.isPrioritizationEnabled()).isTrue();
+            });
+  }
+
+  @Test
   public void it_should_support_custom_starting_strategies() {
     ctxRunner
         .withUserConfiguration(CustomStarterConfiguration.class)

--- a/db-scheduler-boot-starter/src/test/resources/schema.sql
+++ b/db-scheduler-boot-starter/src/test/resources/schema.sql
@@ -10,5 +10,6 @@ create table if not exists scheduled_tasks (
 	consecutive_failures INT,
 	last_heartbeat TIMESTAMP WITH TIME ZONE,
 	version BIGINT,
+	priority INT,
 	PRIMARY KEY (task_name, task_instance)
 );

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/FetchCandidates.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/FetchCandidates.java
@@ -44,6 +44,7 @@ public class FetchCandidates implements PollStrategy {
   AtomicInteger currentGenerationNumber = new AtomicInteger(0);
   private final int lowerLimit;
   private final int upperLimit;
+  private final boolean prioritization;
 
   public FetchCandidates(
       Executor executor,
@@ -58,7 +59,8 @@ public class FetchCandidates implements PollStrategy {
       Clock clock,
       PollingStrategyConfig pollingStrategyConfig,
       Runnable triggerCheckForNewExecutions,
-      HeartbeatConfig heartbeatConfig) {
+      HeartbeatConfig heartbeatConfig,
+      boolean prioritization) {
     this.executor = executor;
     this.taskRepository = taskRepository;
     this.schedulerClient = schedulerClient;
@@ -71,6 +73,7 @@ public class FetchCandidates implements PollStrategy {
     this.pollingStrategyConfig = pollingStrategyConfig;
     this.triggerCheckForNewExecutions = triggerCheckForNewExecutions;
     this.heartbeatConfig = heartbeatConfig;
+    this.prioritization = prioritization;
     lowerLimit = pollingStrategyConfig.getLowerLimit(threadpoolSize);
     // FIXLATER: this is not "upper limit", but rather nr of executions to get. those already in
     // queue will become stale
@@ -84,7 +87,8 @@ public class FetchCandidates implements PollStrategy {
     // Fetch new candidates for execution. Old ones still in ExecutorService will become stale and
     // be discarded
     final int executionsToFetch = upperLimit;
-    List<Execution> fetchedDueExecutions = taskRepository.getDue(now, executionsToFetch);
+    List<Execution> fetchedDueExecutions =
+        taskRepository.getDue(now, executionsToFetch, prioritization);
     LOG.trace(
         "Fetched {} task instances due for execution at {}", fetchedDueExecutions.size(), now);
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/LockAndFetchCandidates.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/LockAndFetchCandidates.java
@@ -41,6 +41,7 @@ public class LockAndFetchCandidates implements PollStrategy {
   private final int lowerLimit;
   private final int upperLimit;
   private AtomicBoolean moreExecutionsInDatabase = new AtomicBoolean(false);
+  private final boolean prioritization;
 
   public LockAndFetchCandidates(
       Executor executor,
@@ -55,7 +56,8 @@ public class LockAndFetchCandidates implements PollStrategy {
       Clock clock,
       PollingStrategyConfig pollingStrategyConfig,
       Runnable triggerCheckForNewExecutions,
-      HeartbeatConfig maxAgeBeforeConsideredDead) {
+      HeartbeatConfig maxAgeBeforeConsideredDead,
+      boolean prioritization) {
     this.executor = executor;
     this.taskRepository = taskRepository;
     this.schedulerClient = schedulerClient;
@@ -68,6 +70,7 @@ public class LockAndFetchCandidates implements PollStrategy {
     this.pollingStrategyConfig = pollingStrategyConfig;
     this.triggerCheckForNewExecutions = triggerCheckForNewExecutions;
     this.maxAgeBeforeConsideredDead = maxAgeBeforeConsideredDead;
+    this.prioritization = prioritization;
     lowerLimit = pollingStrategyConfig.getLowerLimit(threadpoolSize);
     upperLimit = pollingStrategyConfig.getUpperLimit(threadpoolSize);
   }
@@ -85,7 +88,8 @@ public class LockAndFetchCandidates implements PollStrategy {
     }
 
     // FIXLATER: should it fetch here if not under lowerLimit? probably
-    List<Execution> pickedExecutions = taskRepository.lockAndGetDue(now, executionsToFetch);
+    List<Execution> pickedExecutions =
+        taskRepository.lockAndGetDue(now, executionsToFetch, prioritization);
     LOG.trace("Picked {} taskinstances due for execution", pickedExecutions.size());
 
     // Shared indicator for if there are more due executions in the database.

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
@@ -74,6 +74,7 @@ public class SchedulerBuilder {
   protected PollingStrategyConfig pollingStrategyConfig = DEFAULT_POLLING_STRATEGY;
   protected LogLevel logLevel = DEFAULT_FAILURE_LOG_LEVEL;
   protected boolean logStackTrace = LOG_STACK_TRACE_ON_FAILURE;
+  protected boolean prioritization = false;
   private boolean registerShutdownHook = false;
   private int numberOfMissedHeartbeatsBeforeDead = DEFAULT_MISSED_HEARTBEATS_LIMIT;
   private boolean alwaysPersistTimestampInUTC = false;
@@ -230,6 +231,11 @@ public class SchedulerBuilder {
     return this;
   }
 
+  public SchedulerBuilder enablePrioritization() {
+    this.prioritization = true;
+    return this;
+  }
+
   public Scheduler build() {
     if (schedulerName == null) {
       schedulerName = new SchedulerName.Hostname();
@@ -249,6 +255,7 @@ public class SchedulerBuilder {
             taskResolver,
             schedulerName,
             serializer,
+            prioritization,
             clock);
     final JdbcTaskRepository clientTaskRepository =
         new JdbcTaskRepository(
@@ -259,6 +266,7 @@ public class SchedulerBuilder {
             taskResolver,
             schedulerName,
             serializer,
+            prioritization,
             clock);
 
     ExecutorService candidateExecutorService = executorService;
@@ -316,7 +324,8 @@ public class SchedulerBuilder {
             logStackTrace,
             startTasks,
             candidateDueExecutor,
-            candidateHousekeeperExecutor);
+            candidateHousekeeperExecutor,
+            prioritization);
 
     if (enableImmediateExecution) {
       scheduler.registerSchedulerListener(new ImmediateCheckForDueExecutions(scheduler, clock));

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
@@ -213,6 +213,7 @@ public interface SchedulerClient {
     private Serializer serializer = Serializer.DEFAULT_JAVA_SERIALIZER;
     private String tableName = JdbcTaskRepository.DEFAULT_TABLE_NAME;
     private JdbcCustomization jdbcCustomization;
+    private boolean prioritization = false;
 
     private Builder(DataSource dataSource, List<Task<?>> knownTasks) {
       this.dataSource = dataSource;
@@ -242,6 +243,11 @@ public interface SchedulerClient {
       return this;
     }
 
+    public Builder enablePrioritization() {
+      this.prioritization = true;
+      return this;
+    }
+
     public SchedulerClient build() {
       TaskResolver taskResolver = new TaskResolver(StatsRegistry.NOOP, knownTasks);
       final SystemClock clock = new SystemClock();
@@ -259,6 +265,7 @@ public interface SchedulerClient {
               taskResolver,
               new SchedulerClientName(),
               serializer,
+              prioritization,
               clock);
 
       return new StandardSchedulerClient(taskRepository, clock);

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
@@ -26,7 +26,7 @@ public interface TaskRepository {
 
   boolean createIfNotExists(SchedulableInstance execution);
 
-  List<Execution> getDue(Instant now, int limit);
+  List<Execution> getDue(Instant now, int limit, boolean prioritization);
 
   Instant replace(Execution toBeReplaced, SchedulableInstance newInstance);
 
@@ -37,7 +37,7 @@ public interface TaskRepository {
 
   List<Execution> lockAndFetchGeneric(Instant now, int limit);
 
-  List<Execution> lockAndGetDue(Instant now, int limit);
+  List<Execution> lockAndGetDue(Instant now, int limit, boolean prioritization);
 
   void remove(Execution execution);
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
@@ -126,14 +126,19 @@ public class AutodetectJdbcCustomization implements JdbcCustomization {
   }
 
   @Override
+  public String getQueryOrderPart(boolean prioritization) {
+    return jdbcCustomization.getQueryOrderPart(prioritization);
+  }
+
+  @Override
   public boolean supportsSingleStatementLockAndFetch() {
     return jdbcCustomization.supportsSingleStatementLockAndFetch();
   }
 
   @Override
   public List<Execution> lockAndFetchSingleStatement(
-      JdbcTaskRepositoryContext ctx, Instant now, int limit) {
-    return jdbcCustomization.lockAndFetchSingleStatement(ctx, now, limit);
+      JdbcTaskRepositoryContext ctx, Instant now, int limit, boolean prioritization) {
+    return jdbcCustomization.lockAndFetchSingleStatement(ctx, now, limit, prioritization);
   }
 
   @Override
@@ -143,14 +148,15 @@ public class AutodetectJdbcCustomization implements JdbcCustomization {
 
   @Override
   public String createGenericSelectForUpdateQuery(
-      String tableName, int limit, String requiredAndCondition) {
+      String tableName, int limit, String requiredAndCondition, boolean prioritization) {
     return jdbcCustomization.createGenericSelectForUpdateQuery(
-        tableName, limit, requiredAndCondition);
+        tableName, limit, requiredAndCondition, prioritization);
   }
 
   @Override
-  public String createSelectDueQuery(String tableName, int limit, String andCondition) {
-    return jdbcCustomization.createSelectDueQuery(tableName, limit, andCondition);
+  public String createSelectDueQuery(
+      String tableName, int limit, String andCondition, boolean prioritization) {
+    return jdbcCustomization.createSelectDueQuery(tableName, limit, andCondition, prioritization);
   }
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcCustomization.java
@@ -36,15 +36,18 @@ public interface JdbcCustomization {
 
   String getQueryLimitPart(int limit);
 
+  String getQueryOrderPart(boolean prioritization);
+
   boolean supportsSingleStatementLockAndFetch();
 
   List<Execution> lockAndFetchSingleStatement(
-      JdbcTaskRepositoryContext ctx, Instant now, int limit);
+      JdbcTaskRepositoryContext ctx, Instant now, int limit, boolean prioritization);
 
   boolean supportsGenericLockAndFetch();
 
   String createGenericSelectForUpdateQuery(
-      String tableName, int limit, String requiredAndCondition);
+      String tableName, int limit, String requiredAndCondition, boolean prioritization);
 
-  String createSelectDueQuery(String tableName, int limit, String andCondition);
+  String createSelectDueQuery(
+      String tableName, int limit, String andCondition, boolean prioritization);
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MariaDBJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MariaDBJdbcCustomization.java
@@ -43,9 +43,10 @@ public class MariaDBJdbcCustomization extends DefaultJdbcCustomization {
 
   @Override
   public String createGenericSelectForUpdateQuery(
-      String tableName, int limit, String requiredAndCondition) {
+      String tableName, int limit, String requiredAndCondition, boolean prioritization) {
     return selectForUpdate(
         tableName,
+        Queries.ansiSqlOrderPart(prioritization),
         Queries.postgresSqlLimitPart(limit),
         requiredAndCondition,
         " FOR UPDATE SKIP LOCKED ",

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MssqlJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MssqlJdbcCustomization.java
@@ -47,22 +47,24 @@ public class MssqlJdbcCustomization extends DefaultJdbcCustomization {
   }
 
   @Override
-  public String createSelectDueQuery(String tableName, int limit, String andCondition) {
+  public String createSelectDueQuery(
+      String tableName, int limit, String andCondition, boolean prioritization) {
     return "SELECT "
         + " * FROM "
         + tableName
         // try reading past locked rows to see if that helps on deadlock-warnings
         + " WITH (READPAST) WHERE picked = ? AND execution_time <= ? "
         + andCondition
-        + " ORDER BY execution_time ASC "
+        + getQueryOrderPart(prioritization)
         + getQueryLimitPart(limit);
   }
 
   @Override
   public String createGenericSelectForUpdateQuery(
-      String tableName, int limit, String requiredAndCondition) {
+      String tableName, int limit, String requiredAndCondition, boolean prioritization) {
     return selectForUpdate(
         tableName,
+        Queries.ansiSqlOrderPart(prioritization),
         Queries.ansiSqlLimitPart(limit),
         requiredAndCondition,
         null,

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MySQL8JdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MySQL8JdbcCustomization.java
@@ -43,9 +43,10 @@ public class MySQL8JdbcCustomization extends DefaultJdbcCustomization {
 
   @Override
   public String createGenericSelectForUpdateQuery(
-      String tableName, int limit, String requiredAndCondition) {
+      String tableName, int limit, String requiredAndCondition, boolean prioritization) {
     return selectForUpdate(
         tableName,
+        Queries.ansiSqlOrderPart(prioritization),
         Queries.postgresSqlLimitPart(limit),
         requiredAndCondition,
         " FOR UPDATE SKIP LOCKED ",

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/OracleJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/OracleJdbcCustomization.java
@@ -34,9 +34,10 @@ public class OracleJdbcCustomization extends DefaultJdbcCustomization {
 
   @Override
   public String createGenericSelectForUpdateQuery(
-      String tableName, int limit, String requiredAndCondition) {
+      String tableName, int limit, String requiredAndCondition, boolean prioritization) {
     return selectForUpdate(
         tableName,
+        Queries.ansiSqlOrderPart(prioritization),
         Queries.ansiSqlLimitPart(limit),
         requiredAndCondition,
         " FOR UPDATE SKIP LOCKED ",

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/Queries.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/Queries.java
@@ -19,6 +19,7 @@ public class Queries {
 
   public static String selectForUpdate(
       String tableName,
+      String orderPart,
       String limitPart,
       String requiredAndCondition,
       String postgresOracleStyleForUpdate,
@@ -28,7 +29,7 @@ public class Queries {
         + Optional.ofNullable(sqlServerStyleForUpdate).orElse("")
         + " WHERE picked = ? AND execution_time <= ? "
         + requiredAndCondition
-        + " ORDER BY execution_time ASC "
+        + orderPart
         + Optional.ofNullable(postgresOracleStyleForUpdate).orElse("")
         + limitPart;
   }
@@ -39,5 +40,11 @@ public class Queries {
 
   public static String ansiSqlLimitPart(int limit) {
     return " OFFSET 0 ROWS FETCH FIRST " + limit + " ROWS ONLY ";
+  }
+
+  public static String ansiSqlOrderPart(boolean prioritization) {
+    return prioritization
+        ? " ORDER BY priority DESC, execution_time ASC "
+        : " ORDER BY execution_time ASC ";
   }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/AbstractTask.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/AbstractTask.java
@@ -14,6 +14,7 @@
 package com.github.kagkarlsson.scheduler.task;
 
 public abstract class AbstractTask<T> implements Task<T> {
+
   protected final String name;
   private final FailureHandler<T> failureHandler;
   private final DeadExecutionHandler<T> deadExecutionHandler;
@@ -42,12 +43,17 @@ public abstract class AbstractTask<T> implements Task<T> {
 
   @Override
   public TaskInstance<T> instance(String id) {
-    return new TaskInstance<>(this.name, id);
+    return instanceBuilder(id).build();
   }
 
   @Override
   public TaskInstance<T> instance(String id, T data) {
-    return new TaskInstance<>(this.name, id, data);
+    return instanceBuilder(id).setData(data).build();
+  }
+
+  @Override
+  public TaskInstance.Builder<T> instanceBuilder(String id) {
+    return new TaskInstance.Builder<>(this.name, id);
   }
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/Task.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/Task.java
@@ -14,6 +14,7 @@
 package com.github.kagkarlsson.scheduler.task;
 
 public interface Task<T> extends ExecutionHandler<T>, HasTaskName {
+
   String getName();
 
   Class<T> getDataClass();
@@ -21,6 +22,8 @@ public interface Task<T> extends ExecutionHandler<T>, HasTaskName {
   TaskInstance<T> instance(String id);
 
   TaskInstance<T> instance(String id, T data);
+
+  TaskInstance.Builder<T> instanceBuilder(String id);
 
   default TaskInstanceId instanceId(String id) {
     return TaskInstanceId.of(getName(), id);

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/TaskInstance.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/TaskInstance.java
@@ -17,22 +17,26 @@ import java.util.function.Supplier;
 
 public final class TaskInstance<T> implements TaskInstanceId {
 
+  private static final int DEFAULT_PRIORITY = 0;
+
   private final String taskName;
   private final String id;
   private final Supplier<T> dataSupplier;
+  private final int priority;
 
   public TaskInstance(String taskName, String id) {
     this(taskName, id, (T) null);
   }
 
   public TaskInstance(String taskName, String id, T data) {
-    this(taskName, id, () -> data);
+    this(taskName, id, () -> data, DEFAULT_PRIORITY);
   }
 
-  public TaskInstance(String taskName, String id, Supplier<T> dataSupplier) {
+  public TaskInstance(String taskName, String id, Supplier<T> dataSupplier, int priority) {
     this.taskName = taskName;
     this.id = id;
     this.dataSupplier = dataSupplier;
+    this.priority = priority;
   }
 
   public String getTaskAndInstance() {
@@ -50,6 +54,10 @@ public final class TaskInstance<T> implements TaskInstanceId {
 
   public T getData() {
     return dataSupplier.get();
+  }
+
+  public int getPriority() {
+    return priority;
   }
 
   @Override
@@ -72,6 +80,39 @@ public final class TaskInstance<T> implements TaskInstanceId {
 
   @Override
   public String toString() {
-    return "TaskInstance: " + "task=" + taskName + ", id=" + id;
+    return "TaskInstance: " + "task=" + taskName + ", id=" + id + ", priority=" + priority;
+  }
+
+  public static class Builder<T> {
+
+    private final String taskName;
+    private final String id;
+    private Supplier<T> dataSupplier = () -> (T) null;
+    private int priority = DEFAULT_PRIORITY;
+
+    public Builder(String taskName, String id) {
+      this.id = id;
+      this.taskName = taskName;
+    }
+
+    public Builder<T> setDataSupplier(Supplier<T> dataSupplier) {
+      this.dataSupplier = dataSupplier;
+      return this;
+    }
+
+    public Builder<T> setData(T data) {
+      this.dataSupplier = () -> (T) data;
+      ;
+      return this;
+    }
+
+    public Builder<T> setPriority(int priority) {
+      this.priority = priority;
+      return this;
+    }
+
+    public TaskInstance<T> build() {
+      return new TaskInstance<>(taskName, id, dataSupplier, priority);
+    }
   }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/ManualScheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/ManualScheduler.java
@@ -48,7 +48,8 @@ public class ManualScheduler extends Scheduler {
       boolean logStackTrace,
       List<OnStartup> onStartup,
       ExecutorService dueExecutor,
-      ScheduledExecutorService houseKeeperExecutor) {
+      ScheduledExecutorService houseKeeperExecutor,
+      boolean prioritization) {
     super(
         clock,
         schedulerTaskRepository,
@@ -69,7 +70,8 @@ public class ManualScheduler extends Scheduler {
         logStackTrace,
         onStartup,
         dueExecutor,
-        houseKeeperExecutor);
+        houseKeeperExecutor,
+        prioritization);
     this.clock = clock;
   }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
@@ -81,6 +81,7 @@ public class TestHelper {
               taskResolver,
               new SchedulerName.Fixed("manual"),
               serializer,
+              prioritization,
               clock);
       final JdbcTaskRepository clientTaskRepository =
           new JdbcTaskRepository(
@@ -91,6 +92,7 @@ public class TestHelper {
               taskResolver,
               new SchedulerName.Fixed("manual"),
               serializer,
+              prioritization,
               clock);
 
       return new ManualScheduler(
@@ -111,7 +113,8 @@ public class TestHelper {
           true,
           startTasks,
           new ThrowingScheduledExecutorService(),
-          new ThrowingScheduledExecutorService());
+          new ThrowingScheduledExecutorService(),
+          false);
     }
 
     public ManualScheduler start() {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/CustomTableNameTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/CustomTableNameTest.java
@@ -41,6 +41,7 @@ public class CustomTableNameTest {
             CUSTOM_TABLENAME,
             new TaskResolver(StatsRegistry.NOOP, knownTasks),
             new SchedulerName.Fixed(SCHEDULER_NAME),
+            false,
             new SystemClock());
 
     DbUtils.runSqlResource("postgresql_custom_tablename.sql").accept(DB.getDataSource());

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
@@ -56,6 +56,7 @@ public class DeadExecutionsTest {
             DEFAULT_TABLE_NAME,
             taskResolver,
             new SchedulerName.Fixed("scheduler1"),
+            false,
             settableClock);
 
     scheduler =
@@ -73,7 +74,7 @@ public class DeadExecutionsTest {
         new SchedulableTaskInstance<>(taskInstance, now.minus(Duration.ofDays(1)));
     jdbcTaskRepository.createIfNotExists(execution1);
 
-    final List<Execution> due = jdbcTaskRepository.getDue(now, POLLING_LIMIT);
+    final List<Execution> due = jdbcTaskRepository.getDue(now, POLLING_LIMIT, false);
     assertThat(due, Matchers.hasSize(1));
     final Execution execution = due.get(0);
     final Optional<Execution> pickedExecution = jdbcTaskRepository.pick(execution, now);
@@ -86,7 +87,7 @@ public class DeadExecutionsTest {
     assertThat(rescheduled.get().picked, is(false));
     assertThat(rescheduled.get().pickedBy, nullValue());
 
-    assertThat(jdbcTaskRepository.getDue(Instant.now(), POLLING_LIMIT), hasSize(1));
+    assertThat(jdbcTaskRepository.getDue(Instant.now(), POLLING_LIMIT, false), hasSize(1));
   }
 
   @Test

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/ZoneSpecificJdbcCustomization.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/ZoneSpecificJdbcCustomization.java
@@ -59,14 +59,19 @@ public class ZoneSpecificJdbcCustomization implements JdbcCustomization {
   }
 
   @Override
+  public String getQueryOrderPart(boolean prioritization) {
+    return delegate.getQueryOrderPart(prioritization);
+  }
+
+  @Override
   public boolean supportsSingleStatementLockAndFetch() {
     return delegate.supportsSingleStatementLockAndFetch();
   }
 
   @Override
   public List<Execution> lockAndFetchSingleStatement(
-      JdbcTaskRepositoryContext ctx, Instant now, int limit) {
-    return delegate.lockAndFetchSingleStatement(ctx, now, limit);
+      JdbcTaskRepositoryContext ctx, Instant now, int limit, boolean prioritization) {
+    return delegate.lockAndFetchSingleStatement(ctx, now, limit, prioritization);
   }
 
   @Override
@@ -76,12 +81,14 @@ public class ZoneSpecificJdbcCustomization implements JdbcCustomization {
 
   @Override
   public String createGenericSelectForUpdateQuery(
-      String tableName, int limit, String requiredAndCondition) {
-    return delegate.createGenericSelectForUpdateQuery(tableName, limit, requiredAndCondition);
+      String tableName, int limit, String requiredAndCondition, boolean prioritization) {
+    return delegate.createGenericSelectForUpdateQuery(
+        tableName, limit, requiredAndCondition, prioritization);
   }
 
   @Override
-  public String createSelectDueQuery(String tableName, int limit, String andCondition) {
-    return delegate.createSelectDueQuery(tableName, limit, andCondition);
+  public String createSelectDueQuery(
+      String tableName, int limit, String andCondition, boolean prioritization) {
+    return delegate.createSelectDueQuery(tableName, limit, andCondition, prioritization);
   }
 }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/PriorityExecutionTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/PriorityExecutionTest.java
@@ -1,0 +1,91 @@
+package com.github.kagkarlsson.scheduler.functional;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import com.github.kagkarlsson.scheduler.EmbeddedPostgresqlExtension;
+import com.github.kagkarlsson.scheduler.Scheduler;
+import com.github.kagkarlsson.scheduler.SchedulerName;
+import com.github.kagkarlsson.scheduler.StopSchedulerExtension;
+import com.github.kagkarlsson.scheduler.TestTasks;
+import com.github.kagkarlsson.scheduler.helper.TestableRegistry;
+import com.github.kagkarlsson.scheduler.task.ExecutionComplete;
+import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
+import com.github.kagkarlsson.scheduler.testhelper.SettableClock;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class PriorityExecutionTest {
+
+  private SettableClock clock;
+
+  @RegisterExtension
+  public EmbeddedPostgresqlExtension postgres = new EmbeddedPostgresqlExtension();
+
+  @RegisterExtension public StopSchedulerExtension stopScheduler = new StopSchedulerExtension();
+
+  @BeforeEach
+  public void setUp() {
+    clock = new SettableClock();
+  }
+
+  @RepeatedTest(10)
+  public void test_immediate_execution() {
+    String[] sequence = new String[] {"priority-3", "priority-2", "priority-1", "priority-0"};
+
+    AtomicInteger index = new AtomicInteger();
+
+    OneTimeTask<Void> task = TestTasks.oneTime("onetime-a", Void.class, TestTasks.DO_NOTHING);
+
+    TestableRegistry.Condition condition = TestableRegistry.Conditions.completed(4);
+    TestableRegistry registry = TestableRegistry.create().waitConditions(condition).build();
+
+    Scheduler scheduler =
+        Scheduler.create(postgres.getDataSource(), task)
+            .threads(1) // 1 thread to force being sequential
+            .pollingInterval(Duration.ofMinutes(1))
+            .schedulerName(new SchedulerName.Fixed("test"))
+            .statsRegistry(registry)
+            .enablePrioritization()
+            .build();
+
+    stopScheduler.register(scheduler);
+
+    // no matter when they are scheduled, the highest priority should always be executed first
+    scheduler.schedule(
+        task.instanceBuilder(sequence[3]).setPriority(-1).build(), clock.now().minus(3, MINUTES));
+
+    scheduler.schedule(
+        task.instanceBuilder(sequence[1]).setPriority(1).build(), clock.now().minus(2, MINUTES));
+
+    scheduler.schedule(
+        task.instanceBuilder(sequence[0]).setPriority(2).build(), clock.now().minus(1, MINUTES));
+
+    scheduler.schedule(task.instanceBuilder(sequence[2]).setPriority(0).build(), clock.now());
+
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(5),
+        () -> {
+          scheduler.start();
+          condition.waitFor();
+
+          List<ExecutionComplete> completed = registry.getCompleted();
+          assertThat(completed, hasSize(4));
+
+          completed.forEach(
+              e -> {
+                assertEquals(
+                    sequence[index.getAndIncrement()], e.getExecution().taskInstance.getId());
+              });
+
+          registry.assertNoFailures();
+        });
+  }
+}

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepositoryExceptionsTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepositoryExceptionsTest.java
@@ -42,7 +42,7 @@ public class JdbcTaskRepositoryExceptionsTest {
     expectedTableName = randomAlphanumeric(5);
     jdbcTaskRepository =
         new JdbcTaskRepository(
-            null, expectedTableName, null, null, null, mockJdbcRunner, new SystemClock());
+            null, expectedTableName, null, null, null, mockJdbcRunner, false, new SystemClock());
   }
 
   @Test
@@ -60,7 +60,7 @@ public class JdbcTaskRepositoryExceptionsTest {
             ArgumentMatchers.eq(
                 "insert into "
                     + expectedTableName
-                    + "(task_name, task_instance, task_data, execution_time, picked, version) values(?, ?, ?, ?, ?, ?)"),
+                    + "(task_name, task_instance, task_data, execution_time, picked, version, priority) values(?, ?, ?, ?, ?, ?, ?)"),
             any(PreparedStatementSetter.class)))
         .thenThrow(rootCause);
 

--- a/db-scheduler/src/test/resources/com/github/kagkarlsson/scheduler/postgresql_custom_tablename.sql
+++ b/db-scheduler/src/test/resources/com/github/kagkarlsson/scheduler/postgresql_custom_tablename.sql
@@ -9,5 +9,6 @@ create table custom_tablename (
   last_failure timestamp with time zone,
   last_heartbeat timestamp with time zone,
   version BIGINT not null,
+  priority INT,
   PRIMARY KEY (task_name, task_instance)
 )

--- a/db-scheduler/src/test/resources/hsql_tables.sql
+++ b/db-scheduler/src/test/resources/hsql_tables.sql
@@ -10,5 +10,6 @@ create table scheduled_tasks (
     consecutive_failures INT,
     last_heartbeat TIMESTAMP WITH TIME ZONE,
     version BIGINT,
+    priority INT,
     PRIMARY KEY (task_name, task_instance)
 )

--- a/db-scheduler/src/test/resources/mariadb_tables.sql
+++ b/db-scheduler/src/test/resources/mariadb_tables.sql
@@ -11,7 +11,9 @@ create table test.scheduled_tasks (
   consecutive_failures INT,
   last_heartbeat timestamp(6) null,
   version BIGINT not null,
+  priority INT,
   PRIMARY KEY (task_name, task_instance),
   INDEX execution_time_idx (execution_time),
-  INDEX last_heartbeat_idx (last_heartbeat)
+  INDEX last_heartbeat_idx (last_heartbeat),
+  INDEX priority_execution_time_idx (priority desc, execution_time asc)
 )

--- a/db-scheduler/src/test/resources/mssql_tables.sql
+++ b/db-scheduler/src/test/resources/mssql_tables.sql
@@ -11,7 +11,9 @@ create table scheduled_tasks
   consecutive_failures int,
   last_heartbeat       datetimeoffset,
   [version]            bigint         not null,
+  priority             int            not null,
   primary key (task_name, task_instance),
   index execution_time_idx (execution_time),
-  index last_heartbeat_idx (last_heartbeat)
+  index last_heartbeat_idx (last_heartbeat),
+  index priority_execution_time_idx (priority desc, execution_time asc)
 )

--- a/db-scheduler/src/test/resources/mysql_tables.sql
+++ b/db-scheduler/src/test/resources/mysql_tables.sql
@@ -10,7 +10,9 @@ create table test.scheduled_tasks (
   consecutive_failures INT,
   last_heartbeat timestamp(6) null,
   version BIGINT not null,
+  priority INT,
   PRIMARY KEY (task_name, task_instance),
   INDEX execution_time_idx (execution_time),
-  INDEX last_heartbeat_idx (last_heartbeat)
+  INDEX last_heartbeat_idx (last_heartbeat),
+  INDEX priority_execution_time_idx (priority desc, execution_time asc)
 )

--- a/db-scheduler/src/test/resources/oracle_tables.sql
+++ b/db-scheduler/src/test/resources/oracle_tables.sql
@@ -11,8 +11,10 @@ create table scheduled_tasks
     consecutive_failures NUMBER(19, 0),
     last_heartbeat       TIMESTAMP(6) WITH TIME ZONE,
     version              NUMBER(19, 0),
+    priority             NUMBER(19, 0),
     PRIMARY KEY (task_name, task_instance)
 );
 
 CREATE INDEX scheduled_tasks__execution_time__idx on scheduled_tasks(execution_time);
 CREATE INDEX scheduled_tasks__last_heartbeat__idx on scheduled_tasks(last_heartbeat);
+CREATE INDEX scheduled_tasks__priority__execution_time__idx on scheduled_tasks(priority desc, execution_time asc);

--- a/db-scheduler/src/test/resources/postgresql_tables.sql
+++ b/db-scheduler/src/test/resources/postgresql_tables.sql
@@ -10,8 +10,10 @@ create table scheduled_tasks (
   consecutive_failures INT,
   last_heartbeat timestamp with time zone,
   version BIGINT not null,
+  priority INT,
   PRIMARY KEY (task_name, task_instance)
 );
 
 CREATE INDEX execution_time_idx ON scheduled_tasks (execution_time);
 CREATE INDEX last_heartbeat_idx ON scheduled_tasks (last_heartbeat);
+CREATE INDEX priority_execution_time_idx on scheduled_tasks (priority desc, execution_time asc);

--- a/examples/features/src/main/java/com/github/kagkarlsson/examples/SerializingExperimentMain.java
+++ b/examples/features/src/main/java/com/github/kagkarlsson/examples/SerializingExperimentMain.java
@@ -33,7 +33,7 @@ import org.postgresql.ds.PGSimpleDataSource;
 
    docker run -d --name my_postgres -v my_dbdata:/var/lib/postgresql/data -p 54320:5432 -e POSTGRES_PASSWORD=my_password postgres:13
    psql -h localhost -p 54320 postgres postgres
-   create table scheduled_tasks (  task_name text not null,  task_instance text not null,  task_data bytea,  execution_time timestamp with time zone not null,  picked BOOLEAN not null,  picked_by text,  last_success timestamp with time zone,  last_failure timestamp with time zone,  consecutive_failures INT,  last_heartbeat timestamp with time zone,  version BIGINT not null,  PRIMARY KEY (task_name, task_instance));
+   create table scheduled_tasks (  task_name text not null,  task_instance text not null,  task_data bytea,  execution_time timestamp with time zone not null,  picked BOOLEAN not null,  picked_by text,  last_success timestamp with time zone,  last_failure timestamp with time zone,  consecutive_failures INT,  last_heartbeat timestamp with time zone,  version BIGINT not null,  priority INT,  PRIMARY KEY (task_name, task_instance));
 
    get json data
      select convert_from(task_data, 'UTF-8') from scheduled_tasks ;

--- a/examples/features/src/main/resources/hsql_tables.sql
+++ b/examples/features/src/main/resources/hsql_tables.sql
@@ -10,5 +10,6 @@ create table scheduled_tasks (
     consecutive_failures INT,
     last_heartbeat TIMESTAMP WITH TIME ZONE,
     version BIGINT,
+    priority INT,
     PRIMARY KEY (task_name, task_instance)
 )

--- a/examples/spring-boot-example/src/main/resources/schema.sql
+++ b/examples/spring-boot-example/src/main/resources/schema.sql
@@ -12,5 +12,6 @@ create table if not exists scheduled_tasks (
 	consecutive_failures INT,
 	last_heartbeat TIMESTAMP WITH TIME ZONE,
 	version BIGINT,
+	priority INT,
 	PRIMARY KEY (task_name, task_instance)
 );

--- a/test/benchmark/infra/notes.txt
+++ b/test/benchmark/infra/notes.txt
@@ -21,8 +21,8 @@ EOF
 
 # create test-data
 psql bench gustavkarlsson <<EOF
-        INSERT INTO scheduled_tasks (task_name, task_instance, execution_time, picked, version)
-            SELECT 'task1', 'instance'||i::text, now(), false, 1
+        INSERT INTO scheduled_tasks (task_name, task_instance, execution_time, picked, version, priority)
+            SELECT 'task1', 'instance'||i::text, now(), false, 1, 0
             FROM generate_series(1, 1000000) s(i)
 EOF
 ```


### PR DESCRIPTION
This change introduces the possibility of using a task prioritization mechanism. This mechanism is disabled by default, and can be enabled using the `enablePrioritization()` method.

## Reminders
- [x] Added/ran automated tests
- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`

---
cc @kagkarlsson open to any suggestions and comments regarding tests that would be worth adding  
