### PR TITLE
feat: fix lock-and-fetch for MySQL

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MariaDBJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MariaDBJdbcCustomization.java
@@ -49,6 +49,7 @@ public class MariaDBJdbcCustomization extends DefaultJdbcCustomization {
         Queries.postgresSqlLimitPart(limit),
         requiredAndCondition,
         " FOR UPDATE SKIP LOCKED ",
+        null,
         null);
   }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MssqlJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MssqlJdbcCustomization.java
@@ -66,6 +66,7 @@ public class MssqlJdbcCustomization extends DefaultJdbcCustomization {
         Queries.ansiSqlLimitPart(limit),
         requiredAndCondition,
         null,
-        " WITH (READPAST,ROWLOCK) ");
+        " WITH (READPAST,ROWLOCK) ",
+        null);
   }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MySQL8JdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MySQL8JdbcCustomization.java
@@ -37,8 +37,7 @@ public class MySQL8JdbcCustomization extends DefaultJdbcCustomization {
 
   @Override
   public boolean supportsGenericLockAndFetch() {
-    // FIXLATER: fix syntax and enable
-    return false;
+    return true;
   }
 
   @Override
@@ -48,7 +47,8 @@ public class MySQL8JdbcCustomization extends DefaultJdbcCustomization {
         tableName,
         Queries.postgresSqlLimitPart(limit),
         requiredAndCondition,
-        " FOR UPDATE SKIP LOCKED ",
-        null);
+        null,
+        null,
+        " FOR UPDATE SKIP LOCKED ");
   }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/OracleJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/OracleJdbcCustomization.java
@@ -40,6 +40,7 @@ public class OracleJdbcCustomization extends DefaultJdbcCustomization {
         Queries.ansiSqlLimitPart(limit),
         requiredAndCondition,
         " FOR UPDATE SKIP LOCKED ",
+        null,
         null);
   }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/PostgreSqlJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/PostgreSqlJdbcCustomization.java
@@ -57,6 +57,7 @@ public class PostgreSqlJdbcCustomization extends DefaultJdbcCustomization {
         getQueryLimitPart(limit),
         requiredAndCondition,
         " FOR UPDATE SKIP LOCKED ",
+        null,
         null);
   }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/Queries.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/Queries.java
@@ -22,7 +22,8 @@ public class Queries {
       String limitPart,
       String requiredAndCondition,
       String postgresOracleStyleForUpdate,
-      String sqlServerStyleForUpdate) {
+      String sqlServerStyleForUpdate,
+      String mysqlOracleStyleForUpdate) {
     return "SELECT * FROM "
         + tableName
         + Optional.ofNullable(sqlServerStyleForUpdate).orElse("")
@@ -30,7 +31,9 @@ public class Queries {
         + requiredAndCondition
         + " ORDER BY execution_time ASC "
         + Optional.ofNullable(postgresOracleStyleForUpdate).orElse("")
-        + limitPart;
+        + limitPart
+        // Note: Compared to Postgres, MySQL expects `FOR UPDATE SKIP LOCKED` after `LIMIT`
+        + Optional.ofNullable(mysqlOracleStyleForUpdate).orElse("");
   }
 
   public static String postgresSqlLimitPart(int limit) {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/Mysql8CompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/Mysql8CompatibilityTest.java
@@ -24,7 +24,7 @@ public class Mysql8CompatibilityTest extends CompatibilityTest {
   private static HikariDataSource pooledDatasource;
 
   public Mysql8CompatibilityTest() {
-    super(false, false); // FIXLATER: fix syntax and enable
+    super(true, false);
   }
 
   @BeforeAll


### PR DESCRIPTION
## Brief, plain english overview of your changes here
The support was nearly finished in #371 but later commented out due to "some issue [..] and limited time".

I tried to find out what those issues were and discovered that the syntax of the select was wrong. In MySQL the `LIMIT` comes before the `FOR UPDATE SKIP LOCKED`.

Using that fix `Mysql8CompatibilityTest` passes, I have done no further testing yet.

## Fixes
#264


## Reminders
- [x] Added/ran automated tests
- [ ] Update README and/or examples (not applicable?)
- [x] Ran `mvn spotless:apply`

---
cc @kagkarlsson
