### PR TITLE
Fixed typo in the log msg of the SmokeTest class

### DIFF
--- a/examples/spring-boot-example/src/test/java/com/github/kagkarlsson/examples/boot/SmokeTest.java
+++ b/examples/spring-boot-example/src/test/java/com/github/kagkarlsson/examples/boot/SmokeTest.java
@@ -75,7 +75,7 @@ public class SmokeTest {
           });
     } catch (SimulatedException e) {
       LOG.info(
-          "Caught expected SimulatedException. Should rollback ongoing transation for instance2");
+          "Caught expected SimulatedException. Should rollback ongoing transaction for instance2");
     }
 
     assertFalse(


### PR DESCRIPTION
## Fixed typo in the log msg of the SmokeTest class


## Fixes
Fixed one typo in a test file. 


## Reminders
- [x] Added/ran automated tests
- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`

---
cc @kagkarlsson
