### PR TITLE
feat: Add schedule-or-reschedule method to the SchedulerClient

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -270,28 +270,30 @@ public class Scheduler implements SchedulerClient {
   }
 
   @Override
-  public void reschedule(TaskInstanceId taskInstanceId, Instant newExecutionTime) {
-    this.delegate.reschedule(taskInstanceId, newExecutionTime);
+  public boolean reschedule(TaskInstanceId taskInstanceId, Instant newExecutionTime) {
+    return this.delegate.reschedule(taskInstanceId, newExecutionTime);
   }
 
   @Override
-  public <T> void reschedule(SchedulableInstance<T> schedulableInstance) {
-    this.delegate.reschedule(schedulableInstance);
+  public <T> boolean reschedule(SchedulableInstance<T> schedulableInstance) {
+    return this.delegate.reschedule(schedulableInstance);
   }
 
   @Override
-  public <T> void reschedule(TaskInstanceId taskInstanceId, Instant newExecutionTime, T newData) {
-    this.delegate.reschedule(taskInstanceId, newExecutionTime, newData);
+  public <T> boolean reschedule(
+      TaskInstanceId taskInstanceId, Instant newExecutionTime, T newData) {
+    return this.delegate.reschedule(taskInstanceId, newExecutionTime, newData);
   }
 
   @Override
-  public <T> void rescheduleOrCreate(TaskInstance<T> taskInstance, Instant executionTime) {
-    this.delegate.rescheduleOrCreate(taskInstance, executionTime);
+  public <T> boolean schedule(
+      TaskInstance<T> taskInstance, Instant executionTime, WhenExists whenExists) {
+    return this.delegate.schedule(taskInstance, executionTime, whenExists);
   }
 
   @Override
-  public <T> void rescheduleOrCreate(SchedulableInstance<T> schedulableInstance) {
-    this.delegate.rescheduleOrCreate(schedulableInstance);
+  public <T> boolean schedule(SchedulableInstance<T> schedulableInstance, WhenExists whenExists) {
+    return this.delegate.schedule(schedulableInstance, whenExists);
   }
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -287,13 +287,13 @@ public class Scheduler implements SchedulerClient {
 
   @Override
   public <T> boolean schedule(
-      TaskInstance<T> taskInstance, Instant executionTime, WhenExists whenExists) {
-    return this.delegate.schedule(taskInstance, executionTime, whenExists);
+      TaskInstance<T> taskInstance, Instant executionTime, ScheduleOptions scheduleOptions) {
+    return this.delegate.schedule(taskInstance, executionTime, scheduleOptions);
   }
 
   @Override
-  public <T> boolean schedule(SchedulableInstance<T> schedulableInstance, WhenExists whenExists) {
-    return this.delegate.schedule(schedulableInstance, whenExists);
+  public <T> boolean schedule(SchedulableInstance<T> schedulableInstance, ScheduleOptions scheduleOptions) {
+    return this.delegate.schedule(schedulableInstance, scheduleOptions);
   }
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -292,7 +292,8 @@ public class Scheduler implements SchedulerClient {
   }
 
   @Override
-  public <T> boolean schedule(SchedulableInstance<T> schedulableInstance, ScheduleOptions scheduleOptions) {
+  public <T> boolean schedule(
+      SchedulableInstance<T> schedulableInstance, ScheduleOptions scheduleOptions) {
     return this.delegate.schedule(schedulableInstance, scheduleOptions);
   }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -285,6 +285,16 @@ public class Scheduler implements SchedulerClient {
   }
 
   @Override
+  public <T> void rescheduleOrCreate(TaskInstance<T> taskInstance, Instant executionTime) {
+    this.delegate.rescheduleOrCreate(taskInstance, executionTime);
+  }
+
+  @Override
+  public <T> void rescheduleOrCreate(SchedulableInstance<T> schedulableInstance) {
+    this.delegate.rescheduleOrCreate(schedulableInstance);
+  }
+
+  @Override
   public void cancel(TaskInstanceId taskInstanceId) {
     this.delegate.cancel(taskInstanceId);
   }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
@@ -58,7 +58,8 @@ public interface SchedulerClient {
    * @see com.github.kagkarlsson.scheduler.task.TaskInstance
    * @see com.github.kagkarlsson.scheduler.exceptions.TaskInstanceCurrentlyExecutingException
    */
-  <T> boolean schedule(TaskInstance<T> taskInstance, Instant executionTime, ScheduleOptions scheduleOptions);
+  <T> boolean schedule(
+      TaskInstance<T> taskInstance, Instant executionTime, ScheduleOptions scheduleOptions);
 
   /**
    * Schedule a new execution for the given task instance.
@@ -246,14 +247,13 @@ public interface SchedulerClient {
    */
   Optional<ScheduledExecution<Object>> getScheduledExecution(TaskInstanceId taskInstanceId);
 
-
   class ScheduleOptions {
 
     public static final ScheduleOptions WHEN_EXISTS_DO_NOTHING =
         defaultOptions().whenExistsDoNothing();
 
     public static final ScheduleOptions WHEN_EXISTS_RESCHEDULE =
-      defaultOptions().whenExistsReschedule();
+        defaultOptions().whenExistsReschedule();
 
     public enum WhenExists {
       RESCHEDULE,
@@ -418,9 +418,9 @@ public interface SchedulerClient {
         if (existing.isEmpty()) {
           // something must have processed it and deleted it
           LOG.warn(
-            "Task-instance should already exist, but failed to find it. "
-              + "It must have been processed and deleted. task-instance={}",
-            taskInstance);
+              "Task-instance should already exist, but failed to find it. "
+                  + "It must have been processed and deleted. task-instance={}",
+              taskInstance);
           return false;
         }
 
@@ -433,7 +433,8 @@ public interface SchedulerClient {
     }
 
     @Override
-    public <T> boolean schedule(SchedulableInstance<T> schedulableInstance, ScheduleOptions whenExists) {
+    public <T> boolean schedule(
+        SchedulableInstance<T> schedulableInstance, ScheduleOptions whenExists) {
       return schedule(
           schedulableInstance.getTaskInstance(),
           schedulableInstance.getNextExecutionTime(clock.now()),

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
@@ -161,6 +161,26 @@ public class SchedulerClientTest {
     assertThat(savingHandler.savedData, CoreMatchers.is(data2));
   }
 
+  @Test
+  public void client_should_be_able_to_rescheduleOrCreate_executions() {
+    String data1 = "data1";
+    String data2 = "data2";
+
+    scheduler.rescheduleOrCreate(savingTask.instance("1", data1), settableClock.now());
+    scheduler.runAnyDueExecutions();
+    assertThat(savingHandler.savedData, CoreMatchers.is(data1));
+
+    scheduler.rescheduleOrCreate(
+        savingTask.instance("2", "none"), settableClock.now().plusSeconds(1));
+    scheduler.rescheduleOrCreate(savingTask.instance("2", data2), settableClock.now());
+    scheduler.runAnyDueExecutions();
+    assertThat(savingHandler.savedData, CoreMatchers.is(data2));
+
+    scheduler.tick(ofSeconds(1));
+    scheduler.runAnyDueExecutions();
+    assertThat(savingHandler.savedData, CoreMatchers.is(data2));
+  }
+
   @SuppressWarnings("OptionalGetWithoutIsPresent")
   @Test
   public void raw_client_should_be_able_to_fetch_executions() {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
@@ -170,15 +170,17 @@ public class SchedulerClientTest {
     String data2 = "data2";
     String data3 = "data3";
 
-    scheduler.schedule(savingTask.instance("1", data1), settableClock.now(), WHEN_EXISTS_RESCHEDULE);
+    scheduler.schedule(
+        savingTask.instance("1", data1), settableClock.now(), WHEN_EXISTS_RESCHEDULE);
     scheduler.runAnyDueExecutions();
     assertThat(savingHandler.savedData, CoreMatchers.is(data1));
 
     scheduler.schedule(
         savingTask.instance("2", data3),
         settableClock.now().plusSeconds(1),
-      WHEN_EXISTS_RESCHEDULE);
-    scheduler.schedule(savingTask.instance("2", data2), settableClock.now(), WHEN_EXISTS_RESCHEDULE);
+        WHEN_EXISTS_RESCHEDULE);
+    scheduler.schedule(
+        savingTask.instance("2", data2), settableClock.now(), WHEN_EXISTS_RESCHEDULE);
     scheduler.runAnyDueExecutions();
     assertThat(savingHandler.savedData, CoreMatchers.is(data2));
 
@@ -195,12 +197,12 @@ public class SchedulerClientTest {
     String data3 = "data3";
 
     Instant now = settableClock.now();
-    scheduler.schedule(savingTask.instance("1", data1), now, defaultOptions().whenExistsReschedule());
+    scheduler.schedule(
+        savingTask.instance("1", data1), now, defaultOptions().whenExistsReschedule());
     scheduler.runAnyDueExecutions();
     assertThat(savingHandler.savedData, CoreMatchers.is(data1));
 
-    scheduler.schedule(
-        savingTask.instance("2", data3), now.plusSeconds(1), WHEN_EXISTS_DO_NOTHING);
+    scheduler.schedule(savingTask.instance("2", data3), now.plusSeconds(1), WHEN_EXISTS_DO_NOTHING);
     // try to overwrite with new data
     scheduler.schedule(savingTask.instance("2", data2), now, WHEN_EXISTS_DO_NOTHING);
     scheduler.runAnyDueExecutions();

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
@@ -1,6 +1,9 @@
 package com.github.kagkarlsson.scheduler;
 
 import static com.github.kagkarlsson.scheduler.SchedulerClient.Builder.create;
+import static com.github.kagkarlsson.scheduler.SchedulerClient.ScheduleOptions.WHEN_EXISTS_DO_NOTHING;
+import static com.github.kagkarlsson.scheduler.SchedulerClient.ScheduleOptions.WHEN_EXISTS_RESCHEDULE;
+import static com.github.kagkarlsson.scheduler.SchedulerClient.ScheduleOptions.defaultOptions;
 import static java.time.Duration.ofSeconds;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -9,7 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import co.unruly.matchers.OptionalMatchers;
-import com.github.kagkarlsson.scheduler.SchedulerClient.WhenExists;
 import com.github.kagkarlsson.scheduler.TestTasks.SavingHandler;
 import com.github.kagkarlsson.scheduler.serializer.JavaSerializer;
 import com.github.kagkarlsson.scheduler.task.ExecutionContext;
@@ -166,16 +168,17 @@ public class SchedulerClientTest {
   public void client_should_be_able_to_reschedule_executions_via_schedule_when_exists_reschedule() {
     String data1 = "data1";
     String data2 = "data2";
+    String data3 = "data3";
 
-    scheduler.schedule(savingTask.instance("1", data1), settableClock.now(), WhenExists.RESCHEDULE);
+    scheduler.schedule(savingTask.instance("1", data1), settableClock.now(), WHEN_EXISTS_RESCHEDULE);
     scheduler.runAnyDueExecutions();
     assertThat(savingHandler.savedData, CoreMatchers.is(data1));
 
     scheduler.schedule(
-        savingTask.instance("2", "none"),
+        savingTask.instance("2", data3),
         settableClock.now().plusSeconds(1),
-        WhenExists.RESCHEDULE);
-    scheduler.schedule(savingTask.instance("2", data2), settableClock.now(), WhenExists.RESCHEDULE);
+      WHEN_EXISTS_RESCHEDULE);
+    scheduler.schedule(savingTask.instance("2", data2), settableClock.now(), WHEN_EXISTS_RESCHEDULE);
     scheduler.runAnyDueExecutions();
     assertThat(savingHandler.savedData, CoreMatchers.is(data2));
 
@@ -189,22 +192,23 @@ public class SchedulerClientTest {
       client_should_do_nothing_when_task_instance_exists_and_schedule_with_when_exists_do_nothing() {
     String data1 = "data1";
     String data2 = "data2";
+    String data3 = "data3";
 
-    scheduler.schedule(savingTask.instance("1", data1), settableClock.now(), WhenExists.DO_NOTHING);
+    Instant now = settableClock.now();
+    scheduler.schedule(savingTask.instance("1", data1), now, defaultOptions().whenExistsReschedule());
     scheduler.runAnyDueExecutions();
     assertThat(savingHandler.savedData, CoreMatchers.is(data1));
 
     scheduler.schedule(
-        savingTask.instance("2", "none"),
-        settableClock.now().plusSeconds(1),
-        WhenExists.DO_NOTHING);
-    scheduler.schedule(savingTask.instance("2", data2), settableClock.now(), WhenExists.DO_NOTHING);
+        savingTask.instance("2", data3), now.plusSeconds(1), WHEN_EXISTS_DO_NOTHING);
+    // try to overwrite with new data
+    scheduler.schedule(savingTask.instance("2", data2), now, WHEN_EXISTS_DO_NOTHING);
     scheduler.runAnyDueExecutions();
-    assertThat(savingHandler.savedData, CoreMatchers.is("data1"));
+    assertThat(savingHandler.savedData, CoreMatchers.is(data1));
 
     scheduler.tick(ofSeconds(1));
     scheduler.runAnyDueExecutions();
-    assertThat(savingHandler.savedData, CoreMatchers.is("none"));
+    assertThat(savingHandler.savedData, CoreMatchers.is(data3));
   }
 
   @SuppressWarnings("OptionalGetWithoutIsPresent")


### PR DESCRIPTION
## feat: Add rescheduleOrCreate method to the SchedulerClient
When invoking SchedulerClient.reschedule() with a non-existent TaskInstance, an exception will be raised. Therefore, it's essential to verify the existence of a scheduled TaskInstance prior to attempting a reschedule. To streamline this process, we propose the introduction of a scheduleOrCreate method. This method would automatically schedule a TaskInstance if none exists, making it particularly beneficial for dynamically recurring tasks that require initial setup.

We have given considerable thought to finding an appropriate name for this method, but unfortunately, we haven't arrived at a satisfactory conclusion. The verb "schedule" best describes its functionality; however, it cannot be used as there is already a method with that name. Since "rescheduleOrSchedule" sounds awkward, we have settled on "rescheduleOrCreate" for now. We are open to considering other names for this method.

## Fixes
[#539](https://github.com/kagkarlsson/db-scheduler/issues/539)


## Reminders
- [x] Added/ran automated tests
- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`

---
cc @kagkarlsson
