### PR TITLE
fix: Adding equals and hashcode for CronSchedule

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/CronSchedule.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/CronSchedule.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Objects;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -132,6 +133,21 @@ public class CronSchedule implements Schedule, Serializable {
   @Override
   public boolean isDeterministic() {
     return true;
+  }
+
+  @Override
+  public final boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof CronSchedule)) return false;
+    CronSchedule that = (CronSchedule) o;
+    return Objects.equals(this.cronStyle, that.cronStyle)
+        && Objects.equals(this.zoneId, that.zoneId)
+        && Objects.equals(this.pattern, that.pattern);
+  }
+
+  @Override
+  public final int hashCode() {
+    return Objects.hash(cronStyle, zoneId, pattern);
   }
 
   @Override

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/CronTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/CronTest.java
@@ -2,7 +2,9 @@ package com.github.kagkarlsson.scheduler.task;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.kagkarlsson.scheduler.task.schedule.CronSchedule;
@@ -12,6 +14,7 @@ import com.github.kagkarlsson.scheduler.task.schedule.Schedules;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -125,7 +128,28 @@ public class CronTest {
   public void should_not_fail_on_cronschedule_without_next_execution_time() {
     CronSchedule cron =
         new CronSchedule("0 0 0 29 2 MON#1", ZoneId.systemDefault(), CronStyle.SPRING53);
-    Assertions.assertEquals(Schedule.NEVER, cron.getNextExecutionTime(complete(Instant.now())));
+    assertEquals(Schedule.NEVER, cron.getNextExecutionTime(complete(Instant.now())));
+  }
+
+  @Test
+  public void validate_cron_schedule_equals() {
+    assertEquals(
+        new CronSchedule("* * * * *", ZoneId.systemDefault(), CronStyle.UNIX),
+        new CronSchedule("* * * * *", ZoneId.systemDefault(), CronStyle.UNIX));
+    assertNotEquals(
+        new CronSchedule("1 * * * *", ZoneId.systemDefault(), CronStyle.UNIX),
+        new CronSchedule("* * * * *", ZoneId.systemDefault(), CronStyle.UNIX));
+    assertNotEquals(
+        new CronSchedule("1 * * * *", london, CronStyle.UNIX),
+        new CronSchedule("1 * * * *", newYork, CronStyle.UNIX));
+    assertNotEquals(
+        new CronSchedule("* * * * * *", ZoneId.systemDefault(), CronStyle.SPRING53),
+        new CronSchedule("* * * * * *", ZoneId.systemDefault(), CronStyle.SPRING));
+  }
+
+  @Test
+  public void equals_and_hash_code() {
+    EqualsVerifier.forClass(CronSchedule.class).verify();
   }
 
   private void assertNextExecutionTime(


### PR DESCRIPTION
## Brief, plain english overview of your changes here

Adding Equals and HasCode for CronSchedule

## Fixes
<!--- Which issue # does this fix? --->


## Reminders
- [x] Added/ran automated tests
- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`

---
cc @kagkarlsson
