### PR TITLE
fix typo in links

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ See [releases](https://github.com/kagkarlsson/db-scheduler/releases) for release
 **Upgrading to 15.x**
 * Priority is a new opt-in feature. To be able to use it, column `priority` and index `priority_execution_time_idx`
   must be added to the database schema. See table definitions for
-  [postgresql](./b-scheduler/src/test/resources/postgresql_tables.sql),
+  [postgresql](./db-scheduler/src/test/resources/postgresql_tables.sql),
   [oracle](./db-scheduler/src/test/resources/oracle_tables.sql) or
   [mysql](./db-scheduler/src/test/resources/mysql_tables.sql).
   At some point, this column will be made mandatory. This will be made clear in future release/upgrade-notes.
@@ -632,7 +632,7 @@ See [releases](https://github.com/kagkarlsson/db-scheduler/releases) for release
 * Task creation are preferrably done through builders in `Tasks` class
 
 **Upgrading to 2.x**
-* Add column `task_data` to the database schema. See table definitions for [postgresql](./b-scheduler/src/test/resources/postgresql_tables.sql), [oracle](./db-scheduler/src/test/resources/oracle_tables.sql) or [mysql](./db-scheduler/src/test/resources/mysql_tables.sql).
+* Add column `task_data` to the database schema. See table definitions for [postgresql](./db-scheduler/src/test/resources/postgresql_tables.sql), [oracle](./db-scheduler/src/test/resources/oracle_tables.sql) or [mysql](./db-scheduler/src/test/resources/mysql_tables.sql).
 
 ## Building the source
 


### PR DESCRIPTION
## Brief, plain english overview of your changes here

There was a typo in the latest documentation

## Fixes

The typo gets fixed


---
cc @kagkarlsson
