### PR TITLE
fix: Adjusting primary-key order for SQL Server to reduce deadlocking

### DIFF
--- a/db-scheduler/src/test/resources/mssql_tables.sql
+++ b/db-scheduler/src/test/resources/mssql_tables.sql
@@ -12,7 +12,7 @@ create table scheduled_tasks
   last_heartbeat       datetimeoffset,
   [version]            bigint         not null,
   priority             smallint,
-  primary key (task_name, task_instance),
+  primary key (task_instance, task_name),
   index execution_time_idx (execution_time),
   index last_heartbeat_idx (last_heartbeat),
   index priority_execution_time_idx (priority desc, execution_time asc)


### PR DESCRIPTION
Adjusting primary-key order for SQL Server to reduce deadlocking after analysis and testing presented in #527


## Fixes

#527


## Reminders
- [x] Added/ran automated tests
- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`
