### PR TITLE
#515: improve unresolved task deletion job

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskResolver.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskResolver.java
@@ -79,16 +79,6 @@ public class TaskResolver {
     return new ArrayList<>(unresolvedTasks.values());
   }
 
-  public List<String> getUnresolvedTaskNames(Duration unresolvedFor) {
-    return unresolvedTasks.values().stream()
-        .filter(
-            unresolved ->
-                Duration.between(unresolved.firstUnresolved, clock.now()).toMillis()
-                    > unresolvedFor.toMillis())
-        .map(UnresolvedTask::getTaskName)
-        .collect(Collectors.toList());
-  }
-
   public void clearUnresolved(String taskName) {
     unresolvedTasks.remove(taskName);
   }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskResolver.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskResolver.java
@@ -17,7 +17,6 @@ import static java.util.function.Function.identity;
 
 import com.github.kagkarlsson.scheduler.stats.StatsRegistry;
 import com.github.kagkarlsson.scheduler.task.Task;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
@@ -24,6 +24,7 @@ import com.github.kagkarlsson.scheduler.stats.StatsRegistry;
 import com.github.kagkarlsson.scheduler.stats.StatsRegistryAdapter;
 import com.github.kagkarlsson.scheduler.task.OnStartup;
 import com.github.kagkarlsson.scheduler.task.Task;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -67,6 +68,11 @@ public class TestHelper {
 
     public ManualSchedulerBuilder pollingStrategy(PollingStrategyConfig pollingStrategyConfig) {
       super.pollingStrategyConfig = pollingStrategyConfig;
+      return this;
+    }
+
+    public ManualSchedulerBuilder deleteUnresolvedAfter(Duration deleteUnresolvedAfter) {
+      super.deleteUnresolvedAfter = deleteUnresolvedAfter;
       return this;
     }
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
@@ -118,6 +118,7 @@ public class DeadExecutionsTest {
     assertThat(nonCompletingExecutionHandler.timesExecuted.get(), is(2));
   }
 
+
   public static class NonCompletingTask<T> extends OneTimeTask<T> {
     private final VoidExecutionHandler<T> handler;
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/DeadExecutionsTest.java
@@ -118,7 +118,6 @@ public class DeadExecutionsTest {
     assertThat(nonCompletingExecutionHandler.timesExecuted.get(), is(2));
   }
 
-
   public static class NonCompletingTask<T> extends OneTimeTask<T> {
     private final VoidExecutionHandler<T> handler;
 


### PR DESCRIPTION
## Brief, plain english overview of your changes here
Calculates age of unresolved execution based on it's execution time instead of first scheduler run. 
More in issue: https://github.com/kagkarlsson/db-scheduler/issues/515#issuecomment-2569905886

## Fixes
#515

## Reminders
- [/] Added/ran automated tests
- [/] Update README and/or examples
- [/] Ran `mvn spotless:apply` - also added `.gitattributes` because spotless went mad with CRLF on Windows

---
cc @kagkarlsson
