### PR TITLE
feat: Support for batch scheduling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,6 @@ jobs:
         cache: 'maven'
 
     - name: Run all tests
-      run: mvn -B -Pall-tests,publication clean package --file pom.xml
+      run: mvn -B -Ptests-for-ci,publication clean package --file pom.xml
       env:
         TZ: UTC

--- a/README.md
+++ b/README.md
@@ -153,6 +153,21 @@ scheduler.schedule(
         .scheduledTo(Instant.now().plusSeconds(5)));
 ```
 
+### Batch scheduling
+
+It is possible to schedule a batch of executions at once. This is useful when scheduling a large number of executions for better performance.
+
+```java
+Stream<TaskInstance<?>> taskInstances = Stream.of(
+    MY_TASK.instance("my-task-1", 1),
+    MY_TASK.instance("my-task-2", 2),
+    MY_TASK.instance("my-task-3", 3));
+
+scheduler.scheduleBatch(taskInstances, Instant.now());
+```
+
+**Note:** If any of the executions already exists, the scheduling will fail and an exception will be thrown.
+
 ### More examples
 
 #### Plain Java

--- a/README.md
+++ b/README.md
@@ -153,9 +153,7 @@ scheduler.schedule(
         .scheduledTo(Instant.now().plusSeconds(5)));
 ```
 
-### Batch scheduling
-
-It is possible to schedule a batch of executions at once. This is useful when scheduling a large number of executions for better performance.
+... or schedule in batches using:
 
 ```java
 Stream<TaskInstance<?>> taskInstances = Stream.of(
@@ -165,8 +163,6 @@ Stream<TaskInstance<?>> taskInstances = Stream.of(
 
 scheduler.scheduleBatch(taskInstances, Instant.now());
 ```
-
-**Note:** If any of the executions already exists, the scheduling will fail and an exception will be thrown.
 
 ### More examples
 

--- a/db-scheduler/pom.xml
+++ b/db-scheduler/pom.xml
@@ -369,15 +369,9 @@
             </properties>
         </profile>
         <profile>
-            <id>compatibility</id>
+            <id>tests-for-ci</id>
             <properties>
                 <test.excludedTags>compatibility-cluster</test.excludedTags>
-            </properties>
-        </profile>
-        <profile>
-            <id>compatibility-cluster</id>
-            <properties>
-                <test.excludedTags>compatibility</test.excludedTags>
             </properties>
         </profile>
     </profiles>

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -39,6 +39,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -262,6 +263,16 @@ public class Scheduler implements SchedulerClient {
   @Override
   public <T> boolean scheduleIfNotExists(SchedulableInstance<T> schedulableInstance) {
     return this.delegate.scheduleIfNotExists(schedulableInstance);
+  }
+
+  @Override
+  public void scheduleBatch(Stream<TaskInstance<?>> taskInstances, Instant executionTime) {
+    this.delegate.scheduleBatch(taskInstances, executionTime);
+  }
+
+  @Override
+  public void scheduleBatch(Stream<SchedulableInstance<?>> schedulableInstances) {
+    this.delegate.scheduleBatch(schedulableInstances);
   }
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -39,7 +39,6 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
-import java.util.stream.Stream;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -266,12 +265,12 @@ public class Scheduler implements SchedulerClient {
   }
 
   @Override
-  public void scheduleBatch(Stream<TaskInstance<?>> taskInstances, Instant executionTime) {
+  public void scheduleBatch(List<TaskInstance<?>> taskInstances, Instant executionTime) {
     this.delegate.scheduleBatch(taskInstances, executionTime);
   }
 
   @Override
-  public void scheduleBatch(Stream<SchedulableInstance<?>> schedulableInstances) {
+  public void scheduleBatch(List<SchedulableInstance<?>> schedulableInstances) {
     this.delegate.scheduleBatch(schedulableInstances);
   }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
@@ -26,6 +26,7 @@ import com.github.kagkarlsson.scheduler.serializer.Serializer;
 import com.github.kagkarlsson.scheduler.stats.StatsRegistry;
 import com.github.kagkarlsson.scheduler.task.Execution;
 import com.github.kagkarlsson.scheduler.task.SchedulableInstance;
+import com.github.kagkarlsson.scheduler.task.SchedulableTaskInstance;
 import com.github.kagkarlsson.scheduler.task.Task;
 import com.github.kagkarlsson.scheduler.task.TaskInstance;
 import com.github.kagkarlsson.scheduler.task.TaskInstanceId;
@@ -35,6 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -115,6 +117,26 @@ public interface SchedulerClient {
    * @return true if scheduled successfully
    */
   <T> boolean scheduleIfNotExists(SchedulableInstance<T> schedulableInstance);
+
+  /**
+   * Schedule a batch of executions. If any of the executions already exists, the scheduling will
+   * fail and an exception will be thrown.
+   *
+   * @param taskInstances Task-instance, optionally with data
+   * @param executionTime Instant it should run
+   * @see java.time.Instant
+   * @see com.github.kagkarlsson.scheduler.task.TaskInstance
+   */
+  void scheduleBatch(Stream<TaskInstance<?>> taskInstances, Instant executionTime);
+
+  /**
+   * Schedule a batch of executions. If any of the executions already exists, the scheduling will
+   * fail and an exception will be thrown.
+   *
+   * @param schedulableInstances Task-instances with invididual schedules
+   * @see com.github.kagkarlsson.scheduler.task.SchedulableInstance
+   */
+  void scheduleBatch(Stream<SchedulableInstance<?>> schedulableInstances);
 
   /**
    * Update an existing execution to a new execution-time. If the execution does not exist or if it
@@ -355,6 +377,8 @@ public interface SchedulerClient {
     private final Clock clock;
     private final SchedulerListeners schedulerListeners;
 
+    private final int BATCH_SIZE = 100;
+
     StandardSchedulerClient(TaskRepository taskRepository, Clock clock) {
       this(taskRepository, SchedulerListeners.NOOP, clock);
     }
@@ -387,6 +411,20 @@ public interface SchedulerClient {
       return scheduleIfNotExists(
           schedulableInstance.getTaskInstance(),
           schedulableInstance.getNextExecutionTime(clock.now()));
+    }
+
+    @Override
+    public void scheduleBatch(Stream<TaskInstance<?>> taskInstances, Instant executionTime) {
+      Stream<SchedulableInstance<?>> schedulableInstances =
+          taskInstances.map(
+              taskInstance -> new SchedulableTaskInstance<>(taskInstance, executionTime));
+      scheduleBatch(schedulableInstances);
+    }
+
+    @Override
+    public void scheduleBatch(Stream<SchedulableInstance<?>> schedulableInstances) {
+      StreamUtils.chunkStream(schedulableInstances, BATCH_SIZE)
+          .forEach(taskRepository::createBatch);
     }
 
     @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/StreamUtils.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/StreamUtils.java
@@ -1,0 +1,26 @@
+package com.github.kagkarlsson.scheduler;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class StreamUtils {
+
+  public static <T> Stream<List<T>> chunkStream(Stream<T> stream, int chunkSize) {
+    if (chunkSize <= 0) {
+      throw new IllegalArgumentException("Chunk size must be greater than 0");
+    }
+
+    Iterator<T> iterator = stream.iterator();
+    return Stream.generate(
+            () -> {
+              List<T> chunk = new ArrayList<>();
+              for (int i = 0; i < chunkSize && iterator.hasNext(); i++) {
+                chunk.add(iterator.next());
+              }
+              return chunk;
+            })
+        .takeWhile(chunk -> !chunk.isEmpty());
+  }
+}

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/StreamUtils.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/StreamUtils.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright (C) Gustav Karlsson
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.kagkarlsson.scheduler;
 
 import java.util.ArrayList;

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
@@ -24,11 +24,11 @@ import java.util.function.Consumer;
 
 public interface TaskRepository {
 
-  boolean createIfNotExists(SchedulableInstance execution);
+  boolean createIfNotExists(SchedulableInstance<?> execution);
 
   List<Execution> getDue(Instant now, int limit);
 
-  Instant replace(Execution toBeReplaced, SchedulableInstance newInstance);
+  Instant replace(Execution toBeReplaced, SchedulableInstance<?> newInstance);
 
   void getScheduledExecutions(ScheduledExecutionsFilter filter, Consumer<Execution> consumer);
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
@@ -15,6 +15,7 @@ package com.github.kagkarlsson.scheduler;
 
 import com.github.kagkarlsson.scheduler.task.Execution;
 import com.github.kagkarlsson.scheduler.task.SchedulableInstance;
+import com.github.kagkarlsson.scheduler.task.ScheduledTaskInstance;
 import com.github.kagkarlsson.scheduler.task.TaskInstanceId;
 import java.time.Duration;
 import java.time.Instant;
@@ -24,12 +25,20 @@ import java.util.function.Consumer;
 
 public interface TaskRepository {
 
+  /** Prefer ScheduledTaskInstance which has a fixed execution-time */
+  @Deprecated
   boolean createIfNotExists(SchedulableInstance<?> execution);
+
+  boolean createIfNotExists(ScheduledTaskInstance execution);
 
   List<Execution> getDue(Instant now, int limit);
 
-  void createBatch(List<SchedulableInstance<?>> executions);
+  void createBatch(List<ScheduledTaskInstance> executions);
 
+  Instant replace(Execution toBeReplaced, ScheduledTaskInstance newInstance);
+
+  /** Prefer ScheduledTaskInstance which has a fixed execution-time */
+  @Deprecated
   Instant replace(Execution toBeReplaced, SchedulableInstance<?> newInstance);
 
   void getScheduledExecutions(ScheduledExecutionsFilter filter, Consumer<Execution> consumer);

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
@@ -28,6 +28,8 @@ public interface TaskRepository {
 
   List<Execution> getDue(Instant now, int limit);
 
+  void createBatch(List<SchedulableInstance<?>> executions);
+
   Instant replace(Execution toBeReplaced, SchedulableInstance<?> newInstance);
 
   void getScheduledExecutions(ScheduledExecutionsFilter filter, Consumer<Execution> consumer);
@@ -71,7 +73,6 @@ public interface TaskRepository {
   default Optional<Execution> getExecution(TaskInstanceId taskInstance) {
     return getExecution(taskInstance.getTaskName(), taskInstance.getId());
   }
-  ;
 
   int removeExecutions(String taskName);
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/exceptions/DbSchedulerException.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/exceptions/DbSchedulerException.java
@@ -14,7 +14,7 @@
 package com.github.kagkarlsson.scheduler.exceptions;
 
 public abstract class DbSchedulerException extends RuntimeException {
-  static final long serialVersionUID = -2132850112553296790L;
+  private static final long serialVersionUID = -2132850112553296790L;
 
   public DbSchedulerException(String message) {
     super(message);

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/exceptions/FailedToScheduleBatchException.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/exceptions/FailedToScheduleBatchException.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright (C) Gustav Karlsson
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.kagkarlsson.scheduler.exceptions;
 
 public class FailedToScheduleBatchException extends DbSchedulerException {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/exceptions/FailedToScheduleBatchException.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/exceptions/FailedToScheduleBatchException.java
@@ -1,0 +1,13 @@
+package com.github.kagkarlsson.scheduler.exceptions;
+
+public class FailedToScheduleBatchException extends DbSchedulerException {
+  private static final long serialVersionUID = -2132850112553296792L;
+
+  public FailedToScheduleBatchException(String message) {
+    super(message);
+  }
+
+  public FailedToScheduleBatchException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/exceptions/TaskInstanceException.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/exceptions/TaskInstanceException.java
@@ -14,7 +14,7 @@
 package com.github.kagkarlsson.scheduler.exceptions;
 
 public class TaskInstanceException extends DbSchedulerException {
-  static final long serialVersionUID = -2132850112553296790L;
+  private static final long serialVersionUID = -2132850112553296791L;
   private static final String TASK_NAME_INSTANCE_MESSAGE_PART = " (task name: %s, instance id: %s)";
 
   private final String taskName;

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
@@ -199,15 +199,15 @@ public class JdbcTaskRepository implements TaskRepository {
   private void setInsertParameters(ScheduledTaskInstance value, PreparedStatement ps)
       throws SQLException {
     var taskInstance = value.getTaskInstance();
-    int index = 0;
-    ps.setString(++index, taskInstance.getTaskName());
-    ps.setString(++index, taskInstance.getId());
-    jdbcCustomization.setTaskData(ps, ++index, serializer.serialize(taskInstance.getData()));
-    jdbcCustomization.setInstant(ps, ++index, value.getExecutionTime());
-    ps.setBoolean(++index, false);
-    ps.setLong(++index, 1L);
+    int index = 1;
+    ps.setString(index++, taskInstance.getTaskName());
+    ps.setString(index++, taskInstance.getId());
+    jdbcCustomization.setTaskData(ps, index++, serializer.serialize(taskInstance.getData()));
+    jdbcCustomization.setInstant(ps, index++, value.getExecutionTime());
+    ps.setBoolean(index++, false);
+    ps.setLong(index++, 1L);
     if (orderByPriority) {
-      ps.setInt(++index, taskInstance.getPriority());
+      ps.setInt(index, taskInstance.getPriority());
     }
   }
 
@@ -263,22 +263,22 @@ public class JdbcTaskRepository implements TaskRepository {
                 + "and task_instance = ? "
                 + "and version = ?",
             ps -> {
-              int index = 0;
-              ps.setString(++index, newExecution.taskInstance.getTaskName()); // task_name
-              ps.setString(++index, newExecution.taskInstance.getId()); // task_instance
-              ps.setBoolean(++index, false); // picked
-              ps.setString(++index, null); // picked_by
-              jdbcCustomization.setInstant(ps, ++index, null); // last_heartbeat
-              jdbcCustomization.setInstant(ps, ++index, null); // last_success
-              jdbcCustomization.setInstant(ps, ++index, null); // last_failure
-              ps.setInt(++index, 0); // consecutive_failures
-              jdbcCustomization.setInstant(ps, ++index, newExecutionTime); // execution_time
+              int index = 1;
+              ps.setString(index++, newExecution.taskInstance.getTaskName()); // task_name
+              ps.setString(index++, newExecution.taskInstance.getId()); // task_instance
+              ps.setBoolean(index++, false); // picked
+              ps.setString(index++, null); // picked_by
+              jdbcCustomization.setInstant(ps, index++, null); // last_heartbeat
+              jdbcCustomization.setInstant(ps, index++, null); // last_success
+              jdbcCustomization.setInstant(ps, index++, null); // last_failure
+              ps.setInt(index++, 0); // consecutive_failures
+              jdbcCustomization.setInstant(ps, index++, newExecutionTime); // execution_time
               // may cause datbase-specific problems, might have to use setNull instead
               jdbcCustomization.setTaskData(
-                  ps, ++index, serializer.serialize(newData)); // task_data
-              ps.setString(++index, toBeReplaced.taskInstance.getTaskName()); // task_name
-              ps.setString(++index, toBeReplaced.taskInstance.getId()); // task_instance
-              ps.setLong(++index, toBeReplaced.version); // version
+                  ps, index++, serializer.serialize(newData)); // task_data
+              ps.setString(index++, toBeReplaced.taskInstance.getTaskName()); // task_name
+              ps.setString(index++, toBeReplaced.taskInstance.getId()); // task_instance
+              ps.setLong(index, toBeReplaced.version); // version
             });
 
     if (updated == 0) {
@@ -525,22 +525,22 @@ public class JdbcTaskRepository implements TaskRepository {
                 + "and task_instance = ? "
                 + "and version = ?",
             ps -> {
-              int index = 0;
-              ps.setBoolean(++index, false);
-              ps.setString(++index, null);
-              jdbcCustomization.setInstant(ps, ++index, null);
-              jdbcCustomization.setInstant(ps, ++index, lastSuccess);
-              jdbcCustomization.setInstant(ps, ++index, lastFailure);
-              ps.setInt(++index, consecutiveFailures);
-              jdbcCustomization.setInstant(ps, ++index, nextExecutionTime);
+              int index = 1;
+              ps.setBoolean(index++, false);
+              ps.setString(index++, null);
+              jdbcCustomization.setInstant(ps, index++, null);
+              jdbcCustomization.setInstant(ps, index++, lastSuccess);
+              jdbcCustomization.setInstant(ps, index++, lastFailure);
+              ps.setInt(index++, consecutiveFailures);
+              jdbcCustomization.setInstant(ps, index++, nextExecutionTime);
               if (newData != null) {
                 // may cause datbase-specific problems, might have to use setNull instead
                 // FIXLATER: optionally support bypassing serializer if byte[] already
-                jdbcCustomization.setTaskData(ps, ++index, serializer.serialize(newData.data));
+                jdbcCustomization.setTaskData(ps, index++, serializer.serialize(newData.data));
               }
-              ps.setString(++index, execution.taskInstance.getTaskName());
-              ps.setString(++index, execution.taskInstance.getId());
-              ps.setLong(++index, execution.version);
+              ps.setString(index++, execution.taskInstance.getTaskName());
+              ps.setString(index++, execution.taskInstance.getId());
+              ps.setLong(index, execution.version);
             });
 
     if (updated != 1) {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
@@ -147,7 +147,6 @@ public class JdbcTaskRepository implements TaskRepository {
   }
 
   @Override
-  @SuppressWarnings({"unchecked"})
   public boolean createIfNotExists(SchedulableInstance instance) {
     final TaskInstance taskInstance = instance.getTaskInstance();
     try {
@@ -188,7 +187,7 @@ public class JdbcTaskRepository implements TaskRepository {
     } catch (SQLRuntimeException e) {
       LOG.debug("Exception when inserting execution. Assuming it to be a constraint violation.", e);
       Optional<Execution> existingExecution = getExecution(taskInstance);
-      if (!existingExecution.isPresent()) {
+      if (existingExecution.isEmpty()) {
         throw new TaskInstanceException(
             "Failed to add new execution.", instance.getTaskName(), instance.getId(), e);
       }
@@ -228,22 +227,22 @@ public class JdbcTaskRepository implements TaskRepository {
                 + "and task_instance = ? "
                 + "and version = ?",
             ps -> {
-              int index = 1;
-              ps.setString(index++, newExecution.taskInstance.getTaskName()); // task_name
-              ps.setString(index++, newExecution.taskInstance.getId()); // task_instance
-              ps.setBoolean(index++, false); // picked
-              ps.setString(index++, null); // picked_by
-              jdbcCustomization.setInstant(ps, index++, null); // last_heartbeat
-              jdbcCustomization.setInstant(ps, index++, null); // last_success
-              jdbcCustomization.setInstant(ps, index++, null); // last_failure
-              ps.setInt(index++, 0); // consecutive_failures
-              jdbcCustomization.setInstant(ps, index++, newExecutionTime); // execution_time
+              int index = 0;
+              ps.setString(++index, newExecution.taskInstance.getTaskName()); // task_name
+              ps.setString(++index, newExecution.taskInstance.getId()); // task_instance
+              ps.setBoolean(++index, false); // picked
+              ps.setString(++index, null); // picked_by
+              jdbcCustomization.setInstant(ps, ++index, null); // last_heartbeat
+              jdbcCustomization.setInstant(ps, ++index, null); // last_success
+              jdbcCustomization.setInstant(ps, ++index, null); // last_failure
+              ps.setInt(++index, 0); // consecutive_failures
+              jdbcCustomization.setInstant(ps, ++index, newExecutionTime); // execution_time
               // may cause datbase-specific problems, might have to use setNull instead
               jdbcCustomization.setTaskData(
-                  ps, index++, serializer.serialize(newData)); // task_data
-              ps.setString(index++, toBeReplaced.taskInstance.getTaskName()); // task_name
-              ps.setString(index++, toBeReplaced.taskInstance.getId()); // task_instance
-              ps.setLong(index++, toBeReplaced.version); // version
+                  ps, ++index, serializer.serialize(newData)); // task_data
+              ps.setString(++index, toBeReplaced.taskInstance.getTaskName()); // task_name
+              ps.setString(++index, toBeReplaced.taskInstance.getId()); // task_instance
+              ps.setLong(++index, toBeReplaced.version); // version
             });
 
     if (updated == 0) {
@@ -251,13 +250,10 @@ public class JdbcTaskRepository implements TaskRepository {
           "Failed to replace execution, found none matching " + toBeReplaced);
     } else if (updated > 1) {
       LOG.error(
-          "Expected one execution to be updated, but updated "
-              + updated
-              + ". Indicates a bug. "
-              + "Replaced "
-              + toBeReplaced.taskInstance
-              + " with "
-              + newExecution.taskInstance);
+          "Expected one execution to be updated, but updated {}. Indicates a bug. Replaced {} with {}",
+          updated,
+          toBeReplaced.taskInstance,
+          newExecution.taskInstance);
     }
     return newExecutionTime;
   }
@@ -303,18 +299,7 @@ public class JdbcTaskRepository implements TaskRepository {
         jdbcCustomization.createSelectDueQuery(
             tableName, limit, unresolvedFilter.andCondition(), orderByPriority);
 
-    return jdbcRunner.query(
-        selectDueQuery,
-        (PreparedStatement p) -> {
-          int index = 1;
-          p.setBoolean(index++, false);
-          jdbcCustomization.setInstant(p, index++, now);
-          unresolvedFilter.setParameters(p, index);
-          if (!jdbcCustomization.supportsExplicitQueryLimitPart()) {
-            p.setMaxRows(limit);
-          }
-        },
-        new ExecutionResultSetMapper(false, true));
+    return getExecutions(jdbcRunner, selectDueQuery, now, limit, unresolvedFilter);
   }
 
   @Override
@@ -327,20 +312,9 @@ public class JdbcTaskRepository implements TaskRepository {
               jdbcCustomization.createGenericSelectForUpdateQuery(
                   tableName, limit, unresolvedFilter.andCondition(), orderByPriority);
           List<Execution> candidates =
-              txRunner.query(
-                  selectForUpdateQuery,
-                  (PreparedStatement p) -> {
-                    int index = 1;
-                    p.setBoolean(index++, false);
-                    jdbcCustomization.setInstant(p, index++, now);
-                    unresolvedFilter.setParameters(p, index);
-                    if (!jdbcCustomization.supportsExplicitQueryLimitPart()) {
-                      p.setMaxRows(limit);
-                    }
-                  },
-                  new ExecutionResultSetMapper(false, true));
+              getExecutions(txRunner, selectForUpdateQuery, now, limit, unresolvedFilter);
 
-          if (candidates.size() == 0) {
+          if (candidates.isEmpty()) {
             return new ArrayList<>();
           }
 
@@ -368,12 +342,9 @@ public class JdbcTaskRepository implements TaskRepository {
 
           if (totalUpdated != candidates.size()) {
             LOG.error(
-                "Did not update same amount of executions that were locked in the transaction. "
-                    + "This might mean some assumption is wrong here, or that transaction is not working. "
-                    + "Needs to be investigated. Updated: "
-                    + totalUpdated
-                    + ", expected: "
-                    + candidates.size());
+                "Did not update same amount of executions that were locked in the transaction. This might mean some assumption is wrong here, or that transaction is not working. Needs to be investigated. Updated: {}, expected: {}",
+                totalUpdated,
+                candidates.size());
 
             List<Execution> locked = new ArrayList<>();
             List<Execution> noLock = new ArrayList<>();
@@ -390,14 +361,34 @@ public class JdbcTaskRepository implements TaskRepository {
             String instancesNotLocked =
                 noLock.stream().map(e -> e.taskInstance.toString()).collect(joining(","));
             LOG.warn(
-                "Returning picked executions for processing. Did not manage to pick executions: "
-                    + instancesNotLocked);
+                "Returning picked executions for processing. Did not manage to pick executions: {}",
+                instancesNotLocked);
 
             return updateToPicked(locked, pickedBy, lastHeartbeat);
           } else {
             return updateToPicked(candidates, pickedBy, lastHeartbeat);
           }
         });
+  }
+
+  private List<Execution> getExecutions(
+      JdbcRunner jdbcRunner,
+      String query,
+      Instant now,
+      int limit,
+      UnresolvedFilter unresolvedFilter) {
+    return jdbcRunner.query(
+        query,
+        (PreparedStatement p) -> {
+          int index = 1;
+          p.setBoolean(index++, false);
+          jdbcCustomization.setInstant(p, index++, now);
+          unresolvedFilter.setParameters(p, index);
+          if (!jdbcCustomization.supportsExplicitQueryLimitPart()) {
+            p.setMaxRows(limit);
+          }
+        },
+        new ExecutionResultSetMapper(false, true));
   }
 
   private List<Execution> updateToPicked(
@@ -498,22 +489,22 @@ public class JdbcTaskRepository implements TaskRepository {
                 + "and task_instance = ? "
                 + "and version = ?",
             ps -> {
-              int index = 1;
-              ps.setBoolean(index++, false);
-              ps.setString(index++, null);
-              jdbcCustomization.setInstant(ps, index++, null);
-              jdbcCustomization.setInstant(ps, index++, ofNullable(lastSuccess).orElse(null));
-              jdbcCustomization.setInstant(ps, index++, ofNullable(lastFailure).orElse(null));
-              ps.setInt(index++, consecutiveFailures);
-              jdbcCustomization.setInstant(ps, index++, nextExecutionTime);
+              int index = 0;
+              ps.setBoolean(++index, false);
+              ps.setString(++index, null);
+              jdbcCustomization.setInstant(ps, ++index, null);
+              jdbcCustomization.setInstant(ps, ++index, lastSuccess);
+              jdbcCustomization.setInstant(ps, ++index, lastFailure);
+              ps.setInt(++index, consecutiveFailures);
+              jdbcCustomization.setInstant(ps, ++index, nextExecutionTime);
               if (newData != null) {
                 // may cause datbase-specific problems, might have to use setNull instead
                 // FIXLATER: optionally support bypassing serializer if byte[] already
-                jdbcCustomization.setTaskData(ps, index++, serializer.serialize(newData.data));
+                jdbcCustomization.setTaskData(ps, ++index, serializer.serialize(newData.data));
               }
-              ps.setString(index++, execution.taskInstance.getTaskName());
-              ps.setString(index++, execution.taskInstance.getId());
-              ps.setLong(index++, execution.version);
+              ps.setString(++index, execution.taskInstance.getTaskName());
+              ps.setString(++index, execution.taskInstance.getId());
+              ps.setLong(++index, execution.version);
             });
 
     if (updated != 1) {
@@ -521,11 +512,10 @@ public class JdbcTaskRepository implements TaskRepository {
           "Expected one execution to be updated, but updated " + updated + ". Indicates a bug.",
           execution);
     }
-    return updated > 0;
+    return true;
   }
 
   @Override
-  @SuppressWarnings({"unchecked"})
   public Optional<Execution> pick(Execution e, Instant timePicked) {
     final int updated =
         jdbcRunner.execute(
@@ -547,11 +537,11 @@ public class JdbcTaskRepository implements TaskRepository {
             });
 
     if (updated == 0) {
-      LOG.trace("Failed to pick execution. It must have been picked by another scheduler.", e);
+      LOG.trace("Failed to pick execution. It must have been picked by another scheduler. {}", e);
       return Optional.empty();
     } else if (updated == 1) {
       final Optional<Execution> pickedExecution = getExecution(e.taskInstance);
-      if (!pickedExecution.isPresent()) {
+      if (pickedExecution.isEmpty()) {
         throw new IllegalStateException(
             "Unable to find picked execution. Must have been deleted by another thread. Indicates a bug.");
       } else if (!pickedExecution.get().isPicked()) {
@@ -631,12 +621,11 @@ public class JdbcTaskRepository implements TaskRepository {
     } else {
       if (updated > 1) {
         LOG.error(
-            "Updated multiple rows updating heartbeat for execution. Should never happen since "
-                + "name and id is primary key. Execution: "
-                + e);
+            "Updated multiple rows updating heartbeat for execution. Should never happen since name and id is primary key. Execution: {}",
+            e);
         return true;
       }
-      LOG.debug("Updated heartbeat for execution: " + e);
+      LOG.debug("Updated heartbeat for execution: {}", e);
       return true;
     }
   }
@@ -686,9 +675,7 @@ public class JdbcTaskRepository implements TaskRepository {
   public int removeExecutions(String taskName) {
     return jdbcRunner.execute(
         "delete from " + tableName + " where task_name = ?",
-        (PreparedStatement p) -> {
-          p.setString(1, taskName);
-        });
+        (PreparedStatement p) -> p.setString(1, taskName));
   }
 
   @Override
@@ -714,12 +701,7 @@ public class JdbcTaskRepository implements TaskRepository {
   private QueryBuilder queryForFilter(ScheduledExecutionsFilter filter, boolean orderByPriority) {
     final QueryBuilder q = QueryBuilder.selectFromTable(tableName);
 
-    filter
-        .getPickedValue()
-        .ifPresent(
-            value -> {
-              q.andCondition(new PickedCondition(value));
-            });
+    filter.getPickedValue().ifPresent(value -> q.andCondition(new PickedCondition(value)));
 
     q.orderBy(orderByPriority ? "priority desc, execution_time asc" : "execution_time asc");
     return q;
@@ -751,7 +733,7 @@ public class JdbcTaskRepository implements TaskRepository {
 
     private final Consumer<Execution> consumer;
     private final boolean includeUnresolved;
-    private boolean addUnresolvedToExclusionFilter;
+    private final boolean addUnresolvedToExclusionFilter;
 
     private ExecutionResultSetConsumer(Consumer<Execution> consumer) {
       this(consumer, false, true);
@@ -773,7 +755,7 @@ public class JdbcTaskRepository implements TaskRepository {
         String taskName = rs.getString("task_name");
         Optional<Task> task = taskResolver.resolve(taskName, addUnresolvedToExclusionFilter);
 
-        if (!task.isPresent() && !includeUnresolved) {
+        if (task.isEmpty() && !includeUnresolved) {
           if (addUnresolvedToExclusionFilter) {
             LOG.warn(
                 "Failed to find implementation for task with name '{}'. Execution will be excluded from due. "
@@ -804,7 +786,7 @@ public class JdbcTaskRepository implements TaskRepository {
         Supplier dataSupplier =
             memoize(
                 () -> {
-                  if (!task.isPresent()) {
+                  if (task.isEmpty()) {
                     // return the data raw if the type is not known
                     //  a case for standalone clients, with no "known tasks"
                     return data;
@@ -829,7 +811,7 @@ public class JdbcTaskRepository implements TaskRepository {
   }
 
   private static <T> Supplier<T> memoize(Supplier<T> original) {
-    return new Supplier<T>() {
+    return new Supplier<>() {
       boolean initialized;
 
       public T get() {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/ScheduledTaskInstance.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/ScheduledTaskInstance.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) Gustav Karlsson
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.kagkarlsson.scheduler.task;
+
+import com.github.kagkarlsson.scheduler.Clock;
+import java.time.Instant;
+
+public class ScheduledTaskInstance implements TaskInstanceId {
+  private final TaskInstance<?> taskInstance;
+  private final Instant executionTime;
+
+  public ScheduledTaskInstance(TaskInstance<?> taskInstance, Instant executionTime) {
+    this.taskInstance = taskInstance;
+    this.executionTime = executionTime;
+  }
+
+  public static ScheduledTaskInstance fixExecutionTime(
+      SchedulableInstance<?> schedulableInstance, Clock clock) {
+    return new ScheduledTaskInstance(
+        schedulableInstance.getTaskInstance(),
+        schedulableInstance.getNextExecutionTime(clock.now()));
+  }
+
+  public TaskInstance<?> getTaskInstance() {
+    return taskInstance;
+  }
+
+  public Instant getExecutionTime() {
+    return executionTime;
+  }
+
+  @Override
+  public String getTaskName() {
+    return taskInstance.getTaskName();
+  }
+
+  @Override
+  public String getId() {
+    return taskInstance.getId();
+  }
+}

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
@@ -10,9 +10,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import co.unruly.matchers.OptionalMatchers;
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@SuppressWarnings("unchecked")
 public class JdbcTaskRepositoryTest {
 
   public static final String SCHEDULER_NAME = "scheduler1";
@@ -87,10 +86,9 @@ public class JdbcTaskRepositoryTest {
     Instant now = TimeHelper.truncatedInstantNow();
     TaskInstance<Void> instance1 = oneTimeTask.instance("id1");
     TaskInstance<Void> instance2 = oneTimeTask.instance("id2");
-    List<SchedulableInstance<?>> executions =
+    List<ScheduledTaskInstance> executions =
         List.of(
-            new SchedulableTaskInstance<>(instance1, now),
-            new SchedulableTaskInstance<>(instance2, now));
+            new ScheduledTaskInstance(instance1, now), new ScheduledTaskInstance(instance2, now));
 
     taskRepository.createBatch(executions);
 
@@ -103,10 +101,9 @@ public class JdbcTaskRepositoryTest {
     Instant now = TimeHelper.truncatedInstantNow();
     TaskInstance<Void> instance1 = oneTimeTask.instance("id1");
     TaskInstance<Void> instance2 = oneTimeTask.instance("id2");
-    List<SchedulableInstance<?>> executions =
+    List<ScheduledTaskInstance> executions =
         List.of(
-            new SchedulableTaskInstance<>(instance1, now),
-            new SchedulableTaskInstance<>(instance2, now));
+            new ScheduledTaskInstance(instance1, now), new ScheduledTaskInstance(instance2, now));
     taskRepository.createIfNotExists(new SchedulableTaskInstance<>(instance2, now));
 
     assertThrows(

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientTest.java
@@ -26,6 +26,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -96,6 +97,17 @@ public class SchedulerClientTest {
     assertFalse(client.scheduleIfNotExists(oneTimeTaskA.instance("1"), settableClock.now()));
 
     scheduler.runAnyDueExecutions();
+    assertThat(onetimeTaskHandlerA.timesExecuted.get(), CoreMatchers.is(2));
+  }
+
+  @Test
+  public void client_should_be_able_to_schedule_batch_executions() {
+    SchedulerClient client = create(DB.getDataSource()).build();
+
+    client.scheduleBatch(
+        Stream.of(oneTimeTaskA.instance("1"), oneTimeTaskA.instance("2")), settableClock.now());
+    scheduler.runAnyDueExecutions();
+
     assertThat(onetimeTaskHandlerA.timesExecuted.get(), CoreMatchers.is(2));
   }
 

--- a/examples/features/src/main/java/com/github/kagkarlsson/examples/SchedulerClientMain.java
+++ b/examples/features/src/main/java/com/github/kagkarlsson/examples/SchedulerClientMain.java
@@ -21,6 +21,7 @@ import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
 import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 import java.time.Instant;
+import java.util.stream.Stream;
 import javax.sql.DataSource;
 
 public class SchedulerClientMain extends Example {
@@ -51,6 +52,13 @@ public class SchedulerClientMain extends Example {
       clientWithTypeInformation.scheduleIfNotExists(
           MY_TASK.instance("id" + i).data(i).scheduledTo(now.plusSeconds(i)));
     }
+
+    clientWithTypeInformation.scheduleBatch(
+        Stream.of(
+            MY_TASK.instance("batch-id-1").data(1).build(),
+            MY_TASK.instance("batch-id-2").data(2).build(),
+            MY_TASK.instance("batch-id-3").data(3).build()),
+        now.plusSeconds(8));
 
     System.out.println("Listing scheduled executions");
     clientWithTypeInformation

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -17,7 +17,7 @@ release:
     owner: kagkarlsson
     overwrite: false
     skipRelease: false
-    draft: true
+    draft: false
     skipTag: false
     releaseName: '{{tagName}}'
     changelog:


### PR DESCRIPTION
## Brief, plain english overview of your changes here

This PR adds support for scheduling new tasks using batch inserts.

Known issues:
- Updates are not supported; if any of the tasks in a batch exists, the batch will fail
- Hard-coded batch size of 100 when using `Stream` as parameter. Inserts are committed after each batch.

## Fixes
#595 


## Reminders
- [x] Added/ran automated tests
- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`

