### PR TITLE
fix: recurring tasks get correct default priority without data (#604)

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/AbstractTask.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/AbstractTask.java
@@ -50,12 +50,12 @@ public abstract class AbstractTask<T> implements Task<T> {
 
   @Override
   public TaskInstance<T> instance(String id, T data) {
-    return instanceBuilder(id).priority(getDefaultPriority()).data(data).build();
+    return instanceBuilder(id).data(data).build();
   }
 
   @Override
   public TaskInstance.Builder<T> instanceBuilder(String id) {
-    return new Builder<>(this.name, id);
+    return new Builder<T>(this.name, id).priority(getDefaultPriority());
   }
 
   @Override

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/AbstractTaskTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/AbstractTaskTest.java
@@ -1,0 +1,39 @@
+package com.github.kagkarlsson.scheduler.task;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.github.kagkarlsson.scheduler.task.helper.RecurringTask;
+import com.github.kagkarlsson.scheduler.task.helper.Tasks;
+import com.github.kagkarlsson.scheduler.task.schedule.Daily;
+import java.time.LocalTime;
+import org.junit.jupiter.api.Test;
+
+class AbstractTaskTest {
+
+  @Test
+  void test_default_priority_with_data() {
+    RecurringTask<String> task =
+        Tasks.recurring("task", new Daily(LocalTime.MIDNIGHT), String.class)
+            .executeStateful((taskInstance, executionContext) -> "");
+
+    assertEquals(task.getDefaultPriority(), task.instance("id", "data").getPriority());
+  }
+
+  @Test
+  void test_default_priority_without_data() {
+    RecurringTask<Void> task =
+        Tasks.recurring("task", new Daily(LocalTime.MIDNIGHT))
+            .execute((taskInstance, executionContext) -> {});
+
+    assertEquals(task.getDefaultPriority(), task.instance("id").getPriority());
+  }
+
+  @Test
+  void test_default_priority_with_instance_builder() {
+    RecurringTask<Void> task =
+        Tasks.recurring("task", new Daily(LocalTime.MIDNIGHT))
+            .execute((taskInstance, executionContext) -> {});
+
+    assertEquals(task.getDefaultPriority(), task.instanceBuilder("id").build().getPriority());
+  }
+}


### PR DESCRIPTION
## Brief, plain english overview of your changes here

Include the default priority of a task class when creating an instance without data

## Fixes
#604 

## Reminders
- [x] Added/ran automated tests
- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`

---
cc @kagkarlsson
