### PR TITLE
feat: set default priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,14 @@ Set the priority per instance using the `TaskInstance.Builder`:
             .scheduledTo(Instant.now()));
 ```
 
+You can also set the default priority for all tasks of a given type:
+
+```java
+Tasks.recurring("my-task", FixedDelay.ofSeconds(5))
+    .defaultPriority(Priority.LOW)
+    .execute(...);
+```
+
 **Note:**
 * When enabling this feature, make sure you have the new necessary indexes defined. If you
 regularly have a state with large amounts of executions both due and future, it might be beneficial

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/AbstractTask.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/AbstractTask.java
@@ -22,15 +22,32 @@ public abstract class AbstractTask<T> implements Task<T> {
   private final DeadExecutionHandler<T> deadExecutionHandler;
   private final Class<T> dataClass;
 
+  private final int defaultPriority;
+
   public AbstractTask(
       String name,
       Class<T> dataClass,
       FailureHandler<T> failureHandler,
       DeadExecutionHandler<T> deadExecutionHandler) {
+    this(name, dataClass, failureHandler, deadExecutionHandler, DEFAULT_PRIORITY);
+  }
+
+  public AbstractTask(
+      String name,
+      Class<T> dataClass,
+      FailureHandler<T> failureHandler,
+      DeadExecutionHandler<T> deadExecutionHandler,
+      int defaultPriority) {
     this.name = name;
     this.dataClass = dataClass;
     this.failureHandler = failureHandler;
     this.deadExecutionHandler = deadExecutionHandler;
+    this.defaultPriority = defaultPriority;
+  }
+
+  @Override
+  public int getDefaultPriority() {
+    return defaultPriority;
   }
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/Task.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/Task.java
@@ -43,6 +43,8 @@ public interface Task<T> extends ExecutionHandler<T>, HasTaskName {
   }
 
   default int getDefaultPriority() {
-    return Priority.MEDIUM;
+    return DEFAULT_PRIORITY;
   }
+
+  int DEFAULT_PRIORITY = Priority.MEDIUM;
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/CustomTask.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/CustomTask.java
@@ -20,6 +20,7 @@ import com.github.kagkarlsson.scheduler.task.DeadExecutionHandler;
 import com.github.kagkarlsson.scheduler.task.FailureHandler;
 import com.github.kagkarlsson.scheduler.task.NextExecutionTime;
 import com.github.kagkarlsson.scheduler.task.OnStartup;
+import com.github.kagkarlsson.scheduler.task.Priority;
 import com.github.kagkarlsson.scheduler.task.SchedulableInstance;
 import com.github.kagkarlsson.scheduler.task.SchedulableTaskInstance;
 import java.time.Instant;
@@ -27,7 +28,8 @@ import java.util.function.Function;
 
 public abstract class CustomTask<T> extends AbstractTask<T> implements OnStartup {
   private final NextExecutionTime defaultExecutionTime;
-  private ScheduleOnStartup<T> scheduleOnStartup;
+  private final ScheduleOnStartup<T> scheduleOnStartup;
+  public static final int DEFAULT_PRIORITY = Priority.MEDIUM;
 
   public CustomTask(
       String name,
@@ -36,7 +38,25 @@ public abstract class CustomTask<T> extends AbstractTask<T> implements OnStartup
       Function<Instant, Instant> defaultExecutionTime,
       FailureHandler<T> failureHandler,
       DeadExecutionHandler<T> deadExecutionHandler) {
-    super(name, dataClass, failureHandler, deadExecutionHandler);
+    this(
+        name,
+        dataClass,
+        scheduleOnStartup,
+        defaultExecutionTime,
+        failureHandler,
+        deadExecutionHandler,
+        DEFAULT_PRIORITY);
+  }
+
+  public CustomTask(
+      String name,
+      Class<T> dataClass,
+      ScheduleOnStartup<T> scheduleOnStartup,
+      Function<Instant, Instant> defaultExecutionTime,
+      FailureHandler<T> failureHandler,
+      DeadExecutionHandler<T> deadExecutionHandler,
+      int defaultPriority) {
+    super(name, dataClass, failureHandler, deadExecutionHandler, defaultPriority);
     this.scheduleOnStartup = scheduleOnStartup;
     this.defaultExecutionTime = NextExecutionTime.from(defaultExecutionTime);
   }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/OneTimeTask.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/OneTimeTask.java
@@ -20,6 +20,7 @@ import com.github.kagkarlsson.scheduler.task.FailureHandler.OnFailureRetryLater;
 import java.time.Duration;
 
 public abstract class OneTimeTask<T> extends AbstractTask<T> {
+  public static final int DEFAULT_PRIORITY = Priority.MEDIUM;
 
   public OneTimeTask(String name, Class<T> dataClass) {
     this(
@@ -38,7 +39,16 @@ public abstract class OneTimeTask<T> extends AbstractTask<T> {
       Class<T> dataClass,
       FailureHandler<T> failureHandler,
       DeadExecutionHandler<T> deadExecutionHandler) {
-    super(name, dataClass, failureHandler, deadExecutionHandler);
+    this(name, dataClass, failureHandler, deadExecutionHandler, DEFAULT_PRIORITY);
+  }
+
+  public OneTimeTask(
+      String name,
+      Class<T> dataClass,
+      FailureHandler<T> failureHandler,
+      DeadExecutionHandler<T> deadExecutionHandler,
+      int defaultPriority) {
+    super(name, dataClass, failureHandler, deadExecutionHandler, defaultPriority);
   }
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTask.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTask.java
@@ -26,6 +26,7 @@ public abstract class RecurringTask<T> extends AbstractTask<T> implements OnStar
   private final OnCompleteReschedule<T> onComplete;
   private final Schedule schedule;
   private final ScheduleOnStartup<T> scheduleOnStartup;
+  public static final int DEFAULT_PRIORITY = Priority.HIGH;
 
   public RecurringTask(String name, Schedule schedule, Class<T> dataClass) {
     this(
@@ -65,15 +66,28 @@ public abstract class RecurringTask<T> extends AbstractTask<T> implements OnStar
       ScheduleRecurringOnStartup<T> scheduleOnStartup,
       FailureHandler<T> failureHandler,
       DeadExecutionHandler<T> deadExecutionHandler) {
-    super(name, dataClass, failureHandler, deadExecutionHandler);
+    this(
+        name,
+        schedule,
+        dataClass,
+        scheduleOnStartup,
+        failureHandler,
+        deadExecutionHandler,
+        DEFAULT_PRIORITY);
+  }
+
+  public RecurringTask(
+      String name,
+      Schedule schedule,
+      Class<T> dataClass,
+      ScheduleRecurringOnStartup<T> scheduleOnStartup,
+      FailureHandler<T> failureHandler,
+      DeadExecutionHandler<T> deadExecutionHandler,
+      int defaultPriority) {
+    super(name, dataClass, failureHandler, deadExecutionHandler, defaultPriority);
     onComplete = new OnCompleteReschedule<>(schedule);
     this.schedule = schedule;
     this.scheduleOnStartup = scheduleOnStartup;
-  }
-
-  @Override
-  public int getDefaultPriority() {
-    return Priority.HIGH;
   }
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTaskWithPersistentSchedule.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTaskWithPersistentSchedule.java
@@ -23,13 +23,25 @@ import com.github.kagkarlsson.scheduler.task.TaskInstance;
 public abstract class RecurringTaskWithPersistentSchedule<T extends ScheduleAndData>
     extends AbstractTask<T> {
 
+  public static final int DEFAULT_PRIORITY = RecurringTask.DEFAULT_PRIORITY;
+
   public RecurringTaskWithPersistentSchedule(String name, Class<T> dataClass) {
     this(name, dataClass, new FailureHandler.OnFailureRescheduleUsingTaskDataSchedule<>());
   }
 
   public RecurringTaskWithPersistentSchedule(
       String name, Class<T> dataClass, FailureHandler<T> onFailure) {
-    super(name, dataClass, onFailure, new DeadExecutionHandler.ReviveDeadExecution<>());
+    this(name, dataClass, onFailure, DEFAULT_PRIORITY);
+  }
+
+  public RecurringTaskWithPersistentSchedule(
+      String name, Class<T> dataClass, FailureHandler<T> onFailure, int defaultPriority) {
+    super(
+        name,
+        dataClass,
+        onFailure,
+        new DeadExecutionHandler.ReviveDeadExecution<>(),
+        defaultPriority);
   }
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/Tasks.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/Tasks.java
@@ -79,6 +79,7 @@ public class Tasks {
     private FailureHandler<T> onFailure;
     private DeadExecutionHandler<T> onDeadExecution;
     private ScheduleRecurringOnStartup<T> scheduleOnStartup;
+    private int defaultPriority = RecurringTask.DEFAULT_PRIORITY;
 
     public RecurringTaskBuilder(String name, Schedule schedule, Class<T> dataClass) {
       this.name = name;
@@ -116,6 +117,11 @@ public class Tasks {
       return this;
     }
 
+    public RecurringTaskBuilder<T> defaultPriority(int priority) {
+      this.defaultPriority = priority;
+      return this;
+    }
+
     /**
      * Disable 'scheduleOnStartup' to get control over when and show the executions is scheduled.
      * Schedules will not be updated etc, so not really recommended.
@@ -132,8 +138,14 @@ public class Tasks {
     }
 
     public RecurringTask<T> execute(VoidExecutionHandler<T> executionHandler) {
-      return new RecurringTask<T>(
-          name, schedule, dataClass, scheduleOnStartup, onFailure, onDeadExecution) {
+      return new RecurringTask<>(
+          name,
+          schedule,
+          dataClass,
+          scheduleOnStartup,
+          onFailure,
+          onDeadExecution,
+          defaultPriority) {
 
         @Override
         public void executeRecurringly(
@@ -144,8 +156,14 @@ public class Tasks {
     }
 
     public RecurringTask<T> executeStateful(StateReturningExecutionHandler<T> executionHandler) {
-      return new RecurringTask<T>(
-          name, schedule, dataClass, scheduleOnStartup, onFailure, onDeadExecution) {
+      return new RecurringTask<>(
+          name,
+          schedule,
+          dataClass,
+          scheduleOnStartup,
+          onFailure,
+          onDeadExecution,
+          defaultPriority) {
 
         @Override
         public CompletionHandler<T> execute(
@@ -169,9 +187,16 @@ public class Tasks {
     private FailureHandler<T> onFailure =
         new FailureHandler.OnFailureRescheduleUsingTaskDataSchedule<>();
 
+    private int defaultPriority = RecurringTaskWithPersistentSchedule.DEFAULT_PRIORITY;
+
     public RecurringTaskWithPersistentScheduleBuilder(String name, Class<T> dataClass) {
       this.name = name;
       this.dataClass = dataClass;
+    }
+
+    public RecurringTaskWithPersistentScheduleBuilder<T> defaultPriority(int priority) {
+      this.defaultPriority = priority;
+      return this;
     }
 
     public RecurringTaskWithPersistentScheduleBuilder<T> onFailure(
@@ -182,7 +207,8 @@ public class Tasks {
 
     public RecurringTaskWithPersistentSchedule<T> execute(
         VoidExecutionHandler<T> executionHandler) {
-      return new RecurringTaskWithPersistentSchedule<T>(name, dataClass, onFailure) {
+      return new RecurringTaskWithPersistentSchedule<>(
+          name, dataClass, onFailure, defaultPriority) {
         @Override
         public CompletionHandler<T> execute(
             TaskInstance<T> taskInstance, ExecutionContext executionContext) {
@@ -199,7 +225,8 @@ public class Tasks {
 
     public RecurringTaskWithPersistentSchedule<T> executeStateful(
         StateReturningExecutionHandler<T> executionHandler) {
-      return new RecurringTaskWithPersistentSchedule<T>(name, dataClass, onFailure) {
+      return new RecurringTaskWithPersistentSchedule<>(
+          name, dataClass, onFailure, defaultPriority) {
 
         @Override
         public CompletionHandler<T> execute(
@@ -222,6 +249,7 @@ public class Tasks {
     private final Class<T> dataClass;
     private FailureHandler<T> onFailure;
     private DeadExecutionHandler<T> onDeadExecution;
+    private int defaultPriority = OneTimeTask.DEFAULT_PRIORITY;
 
     public OneTimeTaskBuilder(String name, Class<T> dataClass) {
       this.name = name;
@@ -250,8 +278,13 @@ public class Tasks {
       return this;
     }
 
+    public OneTimeTaskBuilder<T> defaultPriority(int priority) {
+      this.defaultPriority = priority;
+      return this;
+    }
+
     public OneTimeTask<T> execute(VoidExecutionHandler<T> executionHandler) {
-      return new OneTimeTask<T>(name, dataClass, onFailure, onDeadExecution) {
+      return new OneTimeTask<>(name, dataClass, onFailure, onDeadExecution, defaultPriority) {
         @Override
         public void executeOnce(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
           executionHandler.execute(taskInstance, executionContext);
@@ -267,6 +300,7 @@ public class Tasks {
     private DeadExecutionHandler<T> onDeadExecution;
     private ScheduleOnStartup<T> onStartup;
     private Function<Instant, Instant> defaultExecutionTime = Function.identity();
+    private int defaultPriority = CustomTask.DEFAULT_PRIORITY;
 
     public TaskBuilder(String name, Class<T> dataClass) {
       this.name = name;
@@ -295,6 +329,11 @@ public class Tasks {
       return this;
     }
 
+    public TaskBuilder<T> defaultPriority(int priority) {
+      this.defaultPriority = priority;
+      return this;
+    }
+
     public TaskBuilder<T> scheduleOnStartup(
         String instance, T initialData, Function<Instant, Instant> firstExecutionTime) {
       this.onStartup = new ScheduleOnceOnStartup<T>(instance, initialData, firstExecutionTime);
@@ -316,8 +355,14 @@ public class Tasks {
     }
 
     public CustomTask<T> execute(ExecutionHandler<T> executionHandler) {
-      return new CustomTask<T>(
-          name, dataClass, onStartup, defaultExecutionTime, onFailure, onDeadExecution) {
+      return new CustomTask<>(
+          name,
+          dataClass,
+          onStartup,
+          defaultExecutionTime,
+          onFailure,
+          onDeadExecution,
+          defaultPriority) {
         @Override
         public CompletionHandler<T> execute(
             TaskInstance<T> taskInstance, ExecutionContext executionContext) {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/RecurringTaskScheduleTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/functional/RecurringTaskScheduleTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class RecurringTaskTest {
+public class RecurringTaskScheduleTest {
 
   public static final ZoneId ZONE = ZoneId.systemDefault();
   private static final LocalDate DATE = LocalDate.of(2018, 3, 1);

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/helper/CustomTaskTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/helper/CustomTaskTest.java
@@ -1,0 +1,27 @@
+package com.github.kagkarlsson.scheduler.task.helper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.github.kagkarlsson.scheduler.task.Priority;
+import org.junit.jupiter.api.Test;
+
+class CustomTaskTest {
+
+  @Test
+  public void should_have_default_priority() {
+    CustomTask<Void> customTask =
+        Tasks.custom("name", Void.class).execute((taskInstance, executionContext) -> null);
+
+    assertEquals(CustomTask.DEFAULT_PRIORITY, customTask.getDefaultPriority());
+  }
+
+  @Test
+  public void should_override_default_priority() {
+    CustomTask<Void> customTask =
+        Tasks.custom("name", Void.class)
+            .defaultPriority(Priority.LOW)
+            .execute((taskInstance, executionContext) -> null);
+
+    assertEquals(Priority.LOW, customTask.getDefaultPriority());
+  }
+}

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/helper/OneTimeTaskTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/helper/OneTimeTaskTest.java
@@ -1,0 +1,28 @@
+package com.github.kagkarlsson.scheduler.task.helper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.github.kagkarlsson.scheduler.TestTasks;
+import com.github.kagkarlsson.scheduler.task.Priority;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import org.junit.jupiter.api.Test;
+
+class OneTimeTaskTest {
+
+  @Test
+  public void should_have_default_priority() {
+    OneTimeTask<Void> oneTimeTask = Tasks.oneTime("name").execute(TestTasks.DO_NOTHING);
+    TaskInstance<Void> taskInstance = oneTimeTask.instance("id1");
+
+    assertEquals(OneTimeTask.DEFAULT_PRIORITY, taskInstance.getPriority());
+  }
+
+  @Test
+  public void should_override_default_priority() {
+    OneTimeTask<Void> oneTimeTask =
+        Tasks.oneTime("name").defaultPriority(Priority.LOW).execute(TestTasks.DO_NOTHING);
+    TaskInstance<Void> taskInstance = oneTimeTask.instance("id1");
+
+    assertEquals(Priority.LOW, taskInstance.getPriority());
+  }
+}

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTaskTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTaskTest.java
@@ -1,0 +1,36 @@
+package com.github.kagkarlsson.scheduler.task.helper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.github.kagkarlsson.scheduler.TestTasks;
+import com.github.kagkarlsson.scheduler.task.Priority;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import com.github.kagkarlsson.scheduler.task.schedule.Schedules;
+import java.time.LocalTime;
+import org.junit.jupiter.api.Test;
+
+class RecurringTaskTest {
+
+  public static final String RECURRING_A = "recurring-a";
+
+  @Test
+  public void should_have_default_priority() {
+    RecurringTask<Void> recurringTask =
+        Tasks.recurring(RECURRING_A, Schedules.daily(LocalTime.MIDNIGHT))
+            .execute(TestTasks.DO_NOTHING);
+    TaskInstance<Void> taskInstance = recurringTask.instance("id1");
+
+    assertEquals(RecurringTask.DEFAULT_PRIORITY, taskInstance.getPriority());
+  }
+
+  @Test
+  public void should_override_default_priority() {
+    RecurringTask<Void> recurringTask =
+        Tasks.recurring(RECURRING_A, Schedules.daily(LocalTime.MIDNIGHT))
+            .defaultPriority(Priority.LOW)
+            .execute(TestTasks.DO_NOTHING);
+    TaskInstance<Void> taskInstance = recurringTask.instance("id1");
+
+    assertEquals(Priority.LOW, taskInstance.getPriority());
+  }
+}

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTaskWithPersistentScheduleTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTaskWithPersistentScheduleTest.java
@@ -1,0 +1,30 @@
+package com.github.kagkarlsson.scheduler.task.helper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.github.kagkarlsson.scheduler.serializer.jackson.ScheduleAndDataForTest;
+import com.github.kagkarlsson.scheduler.task.Priority;
+import org.junit.jupiter.api.Test;
+
+class RecurringTaskWithPersistentScheduleTest {
+
+  @Test
+  public void should_have_default_priority() {
+    RecurringTaskWithPersistentSchedule<ScheduleAndDataForTest> recurringTask =
+        Tasks.recurringWithPersistentSchedule("name", ScheduleAndDataForTest.class)
+            .execute((taskInstance, executionContext) -> new ScheduleAndDataForTest(null, null));
+
+    assertEquals(
+        RecurringTaskWithPersistentSchedule.DEFAULT_PRIORITY, recurringTask.getDefaultPriority());
+  }
+
+  @Test
+  public void should_override_default_priority() {
+    RecurringTaskWithPersistentSchedule<ScheduleAndDataForTest> recurringTask =
+        Tasks.recurringWithPersistentSchedule("name", ScheduleAndDataForTest.class)
+            .defaultPriority(Priority.LOW)
+            .execute((taskInstance, executionContext) -> new ScheduleAndDataForTest(null, null));
+
+    assertEquals(Priority.LOW, recurringTask.getDefaultPriority());
+  }
+}


### PR DESCRIPTION
## Brief, plain english overview of your changes here

This PR makes it possible to set a default priority for all built-in task types.

This makes it possible to e.g. define recurring tasks that only will run when the queue is otherwise empty.

## Fixes
<!--- Which issue # does this fix? --->


## Reminders
- [x] Added/ran automated tests
- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`

---
cc @kagkarlsson
