### PR TITLE
Use correct logger for CancelDeadExecution

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/DeadExecutionHandler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/DeadExecutionHandler.java
@@ -34,7 +34,7 @@ public interface DeadExecutionHandler<T> {
   }
 
   class CancelDeadExecution<T> implements DeadExecutionHandler<T> {
-    private static final Logger LOG = LoggerFactory.getLogger(ReviveDeadExecution.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CancelDeadExecution.class);
 
     @Override
     public void deadExecution(


### PR DESCRIPTION
## Brief, plain english overview of your changes here
This is a one liner to use the correct logger in the `CancelDeadExecution` class.

## Fixes
<!--- Which issue # does this fix? --->


## Reminders
- [x] Added/ran automated tests
- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`

---
cc @kagkarlsson
