### PR TITLE
fix: Compile with -parameters flag

### DIFF
--- a/db-scheduler-boot-starter/pom.xml
+++ b/db-scheduler-boot-starter/pom.xml
@@ -149,7 +149,21 @@
         </dependency>
     </dependencies>
 
-<!--  TODO: enable when we get working -->
+    <build>
+      <pluginManagement>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <parameters>true</parameters>
+            </configuration>
+          </plugin>
+        </plugins>
+      </pluginManagement>
+    </build>
+
+
+  <!--  TODO: enable when we get working -->
 <!--    <build>-->
 <!--        <pluginManagement>-->
 <!--          <plugins>-->


### PR DESCRIPTION
For Boot compatibility

## Fixes
#613


## Reminders
- [ ] Added/ran automated tests
- [ ] Update README and/or examples
- [ ] Ran `mvn spotless:apply`
