### PR TITLE
fix: ManualSchedulerBuilder uses provided SchedulerListeners

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -476,4 +476,8 @@ public class Scheduler implements SchedulerClient {
   public static SchedulerBuilder create(DataSource dataSource, List<Task<?>> knownTasks) {
     return new SchedulerBuilder(dataSource, knownTasks);
   }
+
+  public SchedulerListeners getSchedulerListeners() {
+    return this.schedulerListeners;
+  }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/event/SchedulerListeners.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/event/SchedulerListeners.java
@@ -40,6 +40,7 @@ public class SchedulerListeners implements SchedulerListener {
       .collect(Collectors.toList());
   }
 
+  @SuppressWarnings("CodeBlock2Expr")
   @Override
   public void onExecutionScheduled(TaskInstanceId taskInstanceId, Instant executionTime) {
     schedulerListeners.forEach(
@@ -51,6 +52,7 @@ public class SchedulerListeners implements SchedulerListener {
         });
   }
 
+  @SuppressWarnings("CodeBlock2Expr")
   @Override
   public void onExecutionStart(CurrentlyExecuting currentlyExecuting) {
     schedulerListeners.forEach(
@@ -60,6 +62,7 @@ public class SchedulerListeners implements SchedulerListener {
         });
   }
 
+  @SuppressWarnings("CodeBlock2Expr")
   @Override
   public void onExecutionComplete(ExecutionComplete executionComplete) {
     schedulerListeners.forEach(
@@ -71,6 +74,7 @@ public class SchedulerListeners implements SchedulerListener {
         });
   }
 
+  @SuppressWarnings("CodeBlock2Expr")
   @Override
   public void onExecutionDead(Execution execution) {
     schedulerListeners.forEach(
@@ -79,6 +83,7 @@ public class SchedulerListeners implements SchedulerListener {
         });
   }
 
+  @SuppressWarnings("CodeBlock2Expr")
   @Override
   public void onExecutionFailedHeartbeat(CurrentlyExecuting currentlyExecuting) {
     schedulerListeners.forEach(
@@ -90,6 +95,7 @@ public class SchedulerListeners implements SchedulerListener {
         });
   }
 
+  @SuppressWarnings("CodeBlock2Expr")
   @Override
   public void onSchedulerEvent(SchedulerEventType type) {
     schedulerListeners.forEach(
@@ -98,6 +104,7 @@ public class SchedulerListeners implements SchedulerListener {
         });
   }
 
+  @SuppressWarnings("CodeBlock2Expr")
   @Override
   public void onCandidateEvent(CandidateEventType type) {
     schedulerListeners.forEach(

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/event/SchedulerListeners.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/event/SchedulerListeners.java
@@ -40,6 +40,10 @@ public class SchedulerListeners implements SchedulerListener {
       .collect(Collectors.toList());
   }
 
+  public List<SchedulerListener> getSchedulerListeners() {
+    return this.schedulerListeners;
+  }
+
   @SuppressWarnings("CodeBlock2Expr")
   @Override
   public void onExecutionScheduled(TaskInstanceId taskInstanceId, Instant executionTime) {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/event/SchedulerListeners.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/event/SchedulerListeners.java
@@ -14,13 +14,13 @@
 package com.github.kagkarlsson.scheduler.event;
 
 import com.github.kagkarlsson.scheduler.CurrentlyExecuting;
-import com.github.kagkarlsson.scheduler.event.SchedulerListener.CandidateEventType;
-import com.github.kagkarlsson.scheduler.event.SchedulerListener.SchedulerEventType;
 import com.github.kagkarlsson.scheduler.task.Execution;
 import com.github.kagkarlsson.scheduler.task.ExecutionComplete;
 import com.github.kagkarlsson.scheduler.task.TaskInstanceId;
 import java.time.Instant;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,14 +28,16 @@ public class SchedulerListeners implements SchedulerListener {
   public static final SchedulerListeners NOOP = new SchedulerListeners(List.of());
   private static final Logger LOG = LoggerFactory.getLogger(SchedulerListeners.class);
 
-  private final List<SchedulerListener> schedulerListeners;
+  private List<SchedulerListener> schedulerListeners;
 
   public SchedulerListeners(List<SchedulerListener> schedulerListeners) {
     this.schedulerListeners = schedulerListeners;
   }
 
   public void add(SchedulerListener listener) {
-    schedulerListeners.add(listener);
+    schedulerListeners = Stream
+      .concat(schedulerListeners.stream(), Stream.of(listener))
+      .collect(Collectors.toList());
   }
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/event/SchedulerListeners.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/event/SchedulerListeners.java
@@ -35,9 +35,9 @@ public class SchedulerListeners implements SchedulerListener {
   }
 
   public void add(SchedulerListener listener) {
-    schedulerListeners = Stream
-      .concat(schedulerListeners.stream(), Stream.of(listener))
-      .collect(Collectors.toList());
+    schedulerListeners =
+        Stream.concat(schedulerListeners.stream(), Stream.of(listener))
+            .collect(Collectors.toList());
   }
 
   public List<SchedulerListener> getSchedulerListeners() {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
@@ -30,6 +30,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.sql.DataSource;
 
 public class TestHelper {
@@ -70,6 +72,13 @@ public class TestHelper {
 
     public ManualSchedulerBuilder pollingStrategy(PollingStrategyConfig pollingStrategyConfig) {
       super.pollingStrategyConfig = pollingStrategyConfig;
+      return this;
+    }
+
+    public ManualSchedulerBuilder addSchedulerListener(SchedulerListener schedulerListener) {
+      schedulerListeners = Stream
+        .concat(schedulerListeners.stream(), Stream.of(schedulerListener))
+        .collect(Collectors.toList());
       return this;
     }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
@@ -17,6 +17,7 @@ import com.github.kagkarlsson.scheduler.PollingStrategyConfig;
 import com.github.kagkarlsson.scheduler.SchedulerBuilder;
 import com.github.kagkarlsson.scheduler.SchedulerName;
 import com.github.kagkarlsson.scheduler.TaskResolver;
+import com.github.kagkarlsson.scheduler.event.SchedulerListener;
 import com.github.kagkarlsson.scheduler.jdbc.DefaultJdbcCustomization;
 import com.github.kagkarlsson.scheduler.jdbc.JdbcTaskRepository;
 import com.github.kagkarlsson.scheduler.logging.LogLevel;
@@ -45,6 +46,8 @@ public class TestHelper {
 
   public static class ManualSchedulerBuilder extends SchedulerBuilder {
     private SettableClock clock;
+
+    protected List<SchedulerListener> schedulerListeners = List.of(new StatsRegistryAdapter(statsRegistry));
 
     public ManualSchedulerBuilder(DataSource dataSource, List<Task<?>> knownTasks) {
       super(dataSource, knownTasks);
@@ -106,7 +109,7 @@ public class TestHelper {
           waiter,
           heartbeatInterval,
           enableImmediateExecution,
-          List.of(new StatsRegistryAdapter(statsRegistry)),
+          schedulerListeners,
           Optional.ofNullable(pollingStrategyConfig).orElse(PollingStrategyConfig.DEFAULT_FETCH),
           deleteUnresolvedAfter,
           LogLevel.DEBUG,

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
@@ -49,7 +49,8 @@ public class TestHelper {
   public static class ManualSchedulerBuilder extends SchedulerBuilder {
     private SettableClock clock;
 
-    protected List<SchedulerListener> schedulerListeners = List.of(new StatsRegistryAdapter(statsRegistry));
+    protected List<SchedulerListener> schedulerListeners =
+        List.of(new StatsRegistryAdapter(statsRegistry));
 
     public ManualSchedulerBuilder(DataSource dataSource, List<Task<?>> knownTasks) {
       super(dataSource, knownTasks);
@@ -76,9 +77,9 @@ public class TestHelper {
     }
 
     public ManualSchedulerBuilder addSchedulerListener(SchedulerListener schedulerListener) {
-      schedulerListeners = Stream
-        .concat(schedulerListeners.stream(), Stream.of(schedulerListener))
-        .collect(Collectors.toList());
+      schedulerListeners =
+          Stream.concat(schedulerListeners.stream(), Stream.of(schedulerListener))
+              .collect(Collectors.toList());
       return this;
     }
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/event/SchedulerListenersTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/event/SchedulerListenersTest.java
@@ -1,0 +1,73 @@
+package com.github.kagkarlsson.scheduler.event;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.github.kagkarlsson.scheduler.CurrentlyExecuting;
+import com.github.kagkarlsson.scheduler.EmbeddedPostgresqlExtension;
+import com.github.kagkarlsson.scheduler.task.Execution;
+import com.github.kagkarlsson.scheduler.task.ExecutionComplete;
+import com.github.kagkarlsson.scheduler.task.TaskInstanceId;
+import com.github.kagkarlsson.scheduler.testhelper.ManualScheduler;
+import com.github.kagkarlsson.scheduler.testhelper.TestHelper;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SchedulerListenersTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SchedulerListenersTest.class);
+
+  @RegisterExtension
+  public EmbeddedPostgresqlExtension postgres = new EmbeddedPostgresqlExtension();
+
+  private final SchedulerListener listener = new SchedulerListener() {
+
+    @Override
+    public void onExecutionScheduled(TaskInstanceId taskInstanceId, Instant executionTime) {
+      LOG.info("onExecutionScheduled()");
+    }
+
+    @Override
+    public void onExecutionStart(CurrentlyExecuting currentlyExecuting) {
+      LOG.info("onExecutionStart()");
+    }
+
+    @Override
+    public void onExecutionComplete(ExecutionComplete executionComplete) {
+      LOG.info("onExecutionComplete()");
+    }
+
+    @Override
+    public void onExecutionDead(Execution execution) {
+      LOG.info("onExecutionDead()");
+    }
+
+    @Override
+    public void onExecutionFailedHeartbeat(CurrentlyExecuting currentlyExecuting) {
+      LOG.info("onExecutionFailedHeartbeat()");
+    }
+
+    @Override
+    public void onSchedulerEvent(SchedulerEventType type) {
+      LOG.info("onSchedulerEvent()");
+    }
+
+    @Override
+    public void onCandidateEvent(CandidateEventType type) {
+      LOG.info("onCandidateEvent()");
+    }
+  };
+
+  @Test
+  public void register_scheduler_listener() {
+    LOG.info("register_scheduler_listener()");
+
+    ManualScheduler scheduler = TestHelper.createManualScheduler(postgres.getDataSource()).build();
+
+    assertDoesNotThrow(() -> scheduler.registerSchedulerListener(listener));
+
+  }
+
+}

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/event/SchedulerListenersTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/event/SchedulerListenersTest.java
@@ -22,43 +22,44 @@ public class SchedulerListenersTest {
   @RegisterExtension
   public EmbeddedPostgresqlExtension postgres = new EmbeddedPostgresqlExtension();
 
-  private final SchedulerListener listener = new SchedulerListener() {
+  private final SchedulerListener listener =
+      new SchedulerListener() {
 
-    @Override
-    public void onExecutionScheduled(TaskInstanceId taskInstanceId, Instant executionTime) {
-      LOG.info("onExecutionScheduled()");
-    }
+        @Override
+        public void onExecutionScheduled(TaskInstanceId taskInstanceId, Instant executionTime) {
+          LOG.info("onExecutionScheduled()");
+        }
 
-    @Override
-    public void onExecutionStart(CurrentlyExecuting currentlyExecuting) {
-      LOG.info("onExecutionStart()");
-    }
+        @Override
+        public void onExecutionStart(CurrentlyExecuting currentlyExecuting) {
+          LOG.info("onExecutionStart()");
+        }
 
-    @Override
-    public void onExecutionComplete(ExecutionComplete executionComplete) {
-      LOG.info("onExecutionComplete()");
-    }
+        @Override
+        public void onExecutionComplete(ExecutionComplete executionComplete) {
+          LOG.info("onExecutionComplete()");
+        }
 
-    @Override
-    public void onExecutionDead(Execution execution) {
-      LOG.info("onExecutionDead()");
-    }
+        @Override
+        public void onExecutionDead(Execution execution) {
+          LOG.info("onExecutionDead()");
+        }
 
-    @Override
-    public void onExecutionFailedHeartbeat(CurrentlyExecuting currentlyExecuting) {
-      LOG.info("onExecutionFailedHeartbeat()");
-    }
+        @Override
+        public void onExecutionFailedHeartbeat(CurrentlyExecuting currentlyExecuting) {
+          LOG.info("onExecutionFailedHeartbeat()");
+        }
 
-    @Override
-    public void onSchedulerEvent(SchedulerEventType type) {
-      LOG.info("onSchedulerEvent()");
-    }
+        @Override
+        public void onSchedulerEvent(SchedulerEventType type) {
+          LOG.info("onSchedulerEvent()");
+        }
 
-    @Override
-    public void onCandidateEvent(CandidateEventType type) {
-      LOG.info("onCandidateEvent()");
-    }
-  };
+        @Override
+        public void onCandidateEvent(CandidateEventType type) {
+          LOG.info("onCandidateEvent()");
+        }
+      };
 
   @Test
   public void register_scheduler_listener() {
@@ -67,7 +68,5 @@ public class SchedulerListenersTest {
     ManualScheduler scheduler = TestHelper.createManualScheduler(postgres.getDataSource()).build();
 
     assertDoesNotThrow(() -> scheduler.registerSchedulerListener(listener));
-
   }
-
 }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/testhelper/ManualSchedulerTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/testhelper/ManualSchedulerTest.java
@@ -1,0 +1,78 @@
+package com.github.kagkarlsson.scheduler.testhelper;
+
+import static org.testcontainers.shaded.org.hamcrest.MatcherAssert.assertThat;
+import static org.testcontainers.shaded.org.hamcrest.Matchers.hasItem;
+
+import com.github.kagkarlsson.scheduler.CurrentlyExecuting;
+import com.github.kagkarlsson.scheduler.EmbeddedPostgresqlExtension;
+import com.github.kagkarlsson.scheduler.event.SchedulerListener;
+import com.github.kagkarlsson.scheduler.task.Execution;
+import com.github.kagkarlsson.scheduler.task.ExecutionComplete;
+import com.github.kagkarlsson.scheduler.task.TaskInstanceId;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ManualSchedulerTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ManualSchedulerTest.class);
+
+  @RegisterExtension
+  public EmbeddedPostgresqlExtension postgres = new EmbeddedPostgresqlExtension();
+
+  private final SchedulerListener listener = new SchedulerListener() {
+
+    @Override
+    public void onExecutionScheduled(TaskInstanceId taskInstanceId, Instant executionTime) {
+      LOG.info("onExecutionScheduled()");
+    }
+
+    @Override
+    public void onExecutionStart(CurrentlyExecuting currentlyExecuting) {
+      LOG.info("onExecutionStart()");
+    }
+
+    @Override
+    public void onExecutionComplete(ExecutionComplete executionComplete) {
+      LOG.info("onExecutionComplete()");
+    }
+
+    @Override
+    public void onExecutionDead(Execution execution) {
+      LOG.info("onExecutionDead()");
+    }
+
+    @Override
+    public void onExecutionFailedHeartbeat(CurrentlyExecuting currentlyExecuting) {
+      LOG.info("onExecutionFailedHeartbeat()");
+    }
+
+    @Override
+    public void onSchedulerEvent(SchedulerEventType type) {
+      LOG.info("onSchedulerEvent()");
+    }
+
+    @Override
+    public void onCandidateEvent(CandidateEventType type) {
+      LOG.info("onCandidateEvent()");
+    }
+  };
+
+  @Test
+  public void manual_scheduler_listener() {
+    LOG.info("manual_scheduler_add_listener()");
+
+    ManualScheduler scheduler = TestHelper
+      .createManualScheduler(postgres.getDataSource())
+      .addSchedulerListener(listener)
+      .build();
+
+    assertThat(
+      scheduler.getSchedulerListeners().getSchedulerListeners(),
+      hasItem(listener)
+    );
+  }
+
+}

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/testhelper/ManualSchedulerTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/testhelper/ManualSchedulerTest.java
@@ -22,52 +22,54 @@ public class ManualSchedulerTest {
   @RegisterExtension
   public EmbeddedPostgresqlExtension postgres = new EmbeddedPostgresqlExtension();
 
-  private final SchedulerListener listener = new SchedulerListener() {
+  private final SchedulerListener listener =
+      new SchedulerListener() {
 
-    @Override
-    public void onExecutionScheduled(TaskInstanceId taskInstanceId, Instant executionTime) {
-      LOG.info("onExecutionScheduled()");
-    }
+        @Override
+        public void onExecutionScheduled(TaskInstanceId taskInstanceId, Instant executionTime) {
+          LOG.info("onExecutionScheduled()");
+        }
 
-    @Override
-    public void onExecutionStart(CurrentlyExecuting currentlyExecuting) {
-      LOG.info("onExecutionStart()");
-    }
+        @Override
+        public void onExecutionStart(CurrentlyExecuting currentlyExecuting) {
+          LOG.info("onExecutionStart()");
+        }
 
-    @Override
-    public void onExecutionComplete(ExecutionComplete executionComplete) {
-      LOG.info("onExecutionComplete()");
-    }
+        @Override
+        public void onExecutionComplete(ExecutionComplete executionComplete) {
+          LOG.info("onExecutionComplete()");
+        }
 
-    @Override
-    public void onExecutionDead(Execution execution) {
-      LOG.info("onExecutionDead()");
-    }
+        @Override
+        public void onExecutionDead(Execution execution) {
+          LOG.info("onExecutionDead()");
+        }
 
-    @Override
-    public void onExecutionFailedHeartbeat(CurrentlyExecuting currentlyExecuting) {
-      LOG.info("onExecutionFailedHeartbeat()");
-    }
+        @Override
+        public void onExecutionFailedHeartbeat(CurrentlyExecuting currentlyExecuting) {
+          LOG.info("onExecutionFailedHeartbeat()");
+        }
 
-    @Override
-    public void onSchedulerEvent(SchedulerEventType type) {
-      LOG.info("onSchedulerEvent()");
-    }
+        @Override
+        public void onSchedulerEvent(SchedulerEventType type) {
+          LOG.info("onSchedulerEvent()");
+        }
 
-    @Override
-    public void onCandidateEvent(CandidateEventType type) {
-      LOG.info("onCandidateEvent()");
-    }
-  };
+        @Override
+        public void onCandidateEvent(CandidateEventType type) {
+          LOG.info("onCandidateEvent()");
+        }
+      };
 
   @Test
   public void manual_scheduler_listener() {
     LOG.info("manual_scheduler_add_listener()");
 
-    ManualScheduler scheduler = TestHelper.createManualScheduler(postgres.getDataSource())
-      .addSchedulerListener(listener).build();
+    ManualScheduler scheduler =
+        TestHelper.createManualScheduler(postgres.getDataSource())
+            .addSchedulerListener(listener)
+            .build();
 
     assertThat(scheduler.getSchedulerListeners().getSchedulerListeners(), hasItem(listener));
   }
-
 }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/testhelper/ManualSchedulerTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/testhelper/ManualSchedulerTest.java
@@ -64,15 +64,10 @@ public class ManualSchedulerTest {
   public void manual_scheduler_listener() {
     LOG.info("manual_scheduler_add_listener()");
 
-    ManualScheduler scheduler = TestHelper
-      .createManualScheduler(postgres.getDataSource())
-      .addSchedulerListener(listener)
-      .build();
+    ManualScheduler scheduler = TestHelper.createManualScheduler(postgres.getDataSource())
+      .addSchedulerListener(listener).build();
 
-    assertThat(
-      scheduler.getSchedulerListeners().getSchedulerListeners(),
-      hasItem(listener)
-    );
+    assertThat(scheduler.getSchedulerListeners().getSchedulerListeners(), hasItem(listener));
   }
 
 }


### PR DESCRIPTION
## Brief, plain english overview of your changes here
Made ManualSchedulerBuilder use provided SchedulerListeners instead of a hard coded list. Also fixed `ManualScheduler.registerSchedulerListener()` throwing an unsupported operation exception.

## Fixes
[#532](https://github.com/kagkarlsson/db-scheduler/issues/532)


## Reminders
- [x ] Added/ran automated tests
- [x ] Update README and/or examples
- [x ] Ran `mvn spotless:apply`

---
cc @kagkarlsson
