### PR TITLE
629: update Spring Boot configuration docs for polling strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,9 @@ Configuration is mainly done via `application.properties`. Configuration of sche
 db-scheduler.enabled=true
 db-scheduler.heartbeat-interval=5m
 db-scheduler.polling-interval=10s
-db-scheduler.polling-limit=
+db-scheduler.polling-strategy=fetch
+db-scheduler.polling-strategy-lower-limit-fraction-of-threads=0.5
+db-scheduler.polling-strategy-upper-limit-fraction-of-threads=3.0
 db-scheduler.table-name=scheduled_tasks
 db-scheduler.immediate-execution-enabled=false
 db-scheduler.scheduler-name=


### PR DESCRIPTION
## Brief, plain english overview of your changes here

Fixes the Spring Boot configuration docs in the `README` for polling strategy to reflect updated properties.

## Fixes

Closes #629.


## Reminders
- [x] Added/ran automated tests
- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`

---
cc @kagkarlsson
