### PR TITLE
633: expose `missedHeartbeatsLimit` config through Spring Boot properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ The number of executions fetched each time is equal to `(upperLimitFractionOfThr
 Fetched executions are already locked/picked for this scheduler-instance thus saving one `UPDATE` statement.
 <br/>For normal usage, set to for example `0.5, 1.0`.
 <br/>For high throughput
-(i.e. keep threads busy), set to for example `1.0, 4.0`. Currently hearbeats are not updated for picked executions
+(i.e. keep threads busy), set to for example `1.0, 4.0`. Currently heartbeats are not updated for picked executions
 in queue (applicable if `upperLimitFractionOfThreads > 1.0`). If they stay there for more than
 `4 * heartbeat-interval` (default `20m`), not starting execution, they will be detected as _dead_ and likely be
 unlocked again (determined by `DeadExecutionHandler`).  Currently supported by PostgreSQL, SQL Server, MySQL v8+.
@@ -333,7 +333,7 @@ but db-scheduler also bundles a `GsonSerializer` and `JacksonSerializer`. See ex
 See also additional documentation under [Serializers](#Serializers).
 
 :gear: `.executorService(ExecutorService)`<br/>
-If specified, use this externally managed executor service to run executions. Ideally the number of threads it
+If specified, use this externally managed executor service to run executions. Ideally, the number of threads it
 will use should still be supplied (for scheduler polling optimizations). Default `null`.
 
 :gear: `.deleteUnresolvedAfter(Duration)`<br/>
@@ -395,7 +395,7 @@ and it will remove any existing executions for that task.
 ### Serializers
 
 A task-instance may have some associated data in the field `task_data`. The scheduler uses a `Serializer` to read and write this
-data to the database. By default, standard Java serialization is used, but a number of options is provided:
+data to the database. By default, standard Java serialization is used, but a number of options are provided:
 
 * `GsonSerializer`
 * `JacksonSerializer`
@@ -453,6 +453,7 @@ Configuration is mainly done via `application.properties`. Configuration of sche
 
 db-scheduler.enabled=true
 db-scheduler.heartbeat-interval=5m
+db-scheduler.missed-heartbeats-limit=6
 db-scheduler.polling-interval=10s
 db-scheduler.polling-strategy=fetch
 db-scheduler.polling-strategy-lower-limit-fraction-of-threads=0.5
@@ -553,7 +554,7 @@ Use-cases might be:
 
 During execution, the scheduler regularly updates a heartbeat-time for the task-execution.
 If an execution is marked as executing, but is not receiving updates to the heartbeat-time,
-it will be considered a _dead execution_ after time X. That may for example happen if the
+it will be considered a _dead execution_ after time X. That may, for example, happen if the
 JVM running the scheduler suddenly exits.
 
 When a dead execution is found, the `Task`is consulted to see what should be done. A dead
@@ -580,9 +581,9 @@ In v10, a new polling strategy (`lock-and-fetch`) was added. It utilizes the fac
 Using such a strategy, it is possible to fetch executions pre-locked, and thus getting one statement less:
 
 1. `select for update .. skip locked` a batch of due executions. These will already be picked by the scheduler-instance.
-3. When execution is done, `update` or `delete` the record according to handlers.
+2. When execution is done, `update` or `delete` the record according to handlers.
 
-In sum per batch: 1 select-and-update, 1 * batch-size updates   (no misses)
+In sum per batch: 1 select-and-update, 1 * batch-size updates (no misses)
 
 
 ### Benchmark test

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
@@ -141,6 +141,8 @@ public class DbSchedulerAutoConfiguration {
 
     builder.heartbeatInterval(config.getHeartbeatInterval());
 
+    builder.missedHeartbeatsLimit(config.getMissedHeartbeatsLimit());
+
     // Use scheduler name implementation from customizer if available, otherwise use
     // configured scheduler name (String). If both is absent, use the library default
     if (customizer.schedulerName().isPresent()) {

--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
@@ -38,6 +38,13 @@ public class DbSchedulerProperties {
   private Duration heartbeatInterval = SchedulerBuilder.DEFAULT_HEARTBEAT_INTERVAL;
 
   /**
+   * How many heart beats can be missed before an execution is considered dead.
+   *
+   * <p>Must be greater than 4
+   */
+  private int missedHeartbeatsLimit = SchedulerBuilder.DEFAULT_MISSED_HEARTBEATS_LIMIT;
+
+  /**
    * Name of this scheduler-instance. The name is stored in the database when an execution is picked
    * by a scheduler.
    *
@@ -139,6 +146,14 @@ public class DbSchedulerProperties {
 
   public void setHeartbeatInterval(final Duration heartbeatInterval) {
     this.heartbeatInterval = heartbeatInterval;
+  }
+
+  public int getMissedHeartbeatsLimit() {
+    return missedHeartbeatsLimit;
+  }
+
+  public void setMissedHeartbeatsLimit(final int missedHeartbeatsLimit) {
+    this.missedHeartbeatsLimit = missedHeartbeatsLimit;
   }
 
   public String getSchedulerName() {


### PR DESCRIPTION
## Brief, plain english overview of your changes here

Exposes the `missedHeartbeatsLimit` configuration added in #432 through the Spring Boot `DbSchedulerProperties`.

## Fixes

Closes #633.

## Reminders
- [ ] Added/ran automated tests
- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`

---
cc @kagkarlsson
