### PR TITLE
fix: Daily Schedule should add day on LocalDate before setting the LocalTi…

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/Daily.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/Daily.java
@@ -51,7 +51,7 @@ public class Daily implements Schedule, Serializable {
 
   public Daily(ZoneId zone, List<LocalTime> times) {
     this.zone = Objects.requireNonNull(zone, "zone cannot be null");
-    if (times.size() < 1) {
+    if (times.isEmpty()) {
       throw new IllegalArgumentException("times cannot be empty");
     }
     this.times = times.stream().sorted().collect(Collectors.toList());
@@ -69,7 +69,7 @@ public class Daily implements Schedule, Serializable {
       }
     }
 
-    return ZonedDateTime.of(doneDate, times.get(0), zone).plusDays(1).toInstant();
+    return ZonedDateTime.of(doneDate.plusDays(1), times.get(0), zone).toInstant();
   }
 
   @Override


### PR DESCRIPTION
When using a daily schedule with a time like 01:30 in the Europe/London timezone, the DST transition on March 30, 2025 causes an issue. That day the schedule triggers at 02:30, since 01:30 does not exist on that day due to the clock jumping forward. This is a reasonable behavior (inherited ZonedDateTime#of method behavior). However, the bug arises in the next scheduled iteration, which also returns 02:30 instead of reverting to the correct 01:30.

## Fixes
Fixes #662 

## Reminders
- [x] Added/ran automated tests
- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`

---
cc @kagkarlsson
