### PR TITLE
fix: Upgrade Sql Server image used in tests

### DIFF
--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/MssqlCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/MssqlCompatibilityTest.java
@@ -31,7 +31,7 @@ public class MssqlCompatibilityTest extends CompatibilityTest {
   @Container
   private static final MSSQLServerContainer MSSQL =
       new MSSQLServerContainer<>(
-          DockerImageName.parse("mcr.microsoft.com/mssql/server:2019-latest"));
+          DockerImageName.parse("mcr.microsoft.com/mssql/server:2022-latest"));
 
   private static DataSource pooledDatasource;
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/MssqlCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/MssqlCompatibilityTest.java
@@ -28,9 +28,11 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers
 public class MssqlCompatibilityTest extends CompatibilityTest {
 
-  @Container private static final MSSQLServerContainer MSSQL = new MSSQLServerContainer<>(
-    DockerImageName.parse("mcr.microsoft.com/mssql/server:2019-latest")
-  );
+  @Container
+  private static final MSSQLServerContainer MSSQL =
+      new MSSQLServerContainer<>(
+          DockerImageName.parse("mcr.microsoft.com/mssql/server:2019-latest"));
+
   private static DataSource pooledDatasource;
 
   public MssqlCompatibilityTest() {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/MssqlCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/MssqlCompatibilityTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Tag;
 import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 /**
  * To test manually, disable testcontainers stuff and use Azure SQL Edge
@@ -27,7 +28,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 public class MssqlCompatibilityTest extends CompatibilityTest {
 
-  @Container private static final MSSQLServerContainer MSSQL = new MSSQLServerContainer();
+  @Container private static final MSSQLServerContainer MSSQL = new MSSQLServerContainer<>(
+    DockerImageName.parse("mcr.microsoft.com/mssql/server:2019-latest")
+  );
   private static DataSource pooledDatasource;
 
   public MssqlCompatibilityTest() {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/concurrent/MssqlClusterTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/concurrent/MssqlClusterTest.java
@@ -44,7 +44,7 @@ public class MssqlClusterTest {
   @Container
   private static final MSSQLServerContainer MSSQL =
       new MSSQLServerContainer<>(
-          DockerImageName.parse("mcr.microsoft.com/mssql/server:2019-latest"));
+          DockerImageName.parse("mcr.microsoft.com/mssql/server:2022-latest"));
 
   private static DataSource pooledDatasource;
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/concurrent/MssqlClusterTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/concurrent/MssqlClusterTest.java
@@ -22,9 +22,11 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
 @Tag("compatibility-cluster")
+@SuppressWarnings("rawtypes")
 public class MssqlClusterTest {
   public static final int NUMBER_OF_THREADS = 10;
   private static final Logger DEBUG_LOG = LoggerFactory.getLogger(MssqlClusterTest.class);
@@ -39,7 +41,9 @@ public class MssqlClusterTest {
   //        new LogLevelOverride("com.github.kagkarlsson.scheduler.FetchCandidates", Level.DEBUG)
   //    );
 
-  @Container private static final MSSQLServerContainer MSSQL = new MSSQLServerContainer();
+  @Container private static final MSSQLServerContainer MSSQL = new MSSQLServerContainer<>(
+    DockerImageName.parse("mcr.microsoft.com/mssql/server:2019-latest")
+  );
   private static DataSource pooledDatasource;
 
   @BeforeAll

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/concurrent/MssqlClusterTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/concurrent/MssqlClusterTest.java
@@ -41,9 +41,11 @@ public class MssqlClusterTest {
   //        new LogLevelOverride("com.github.kagkarlsson.scheduler.FetchCandidates", Level.DEBUG)
   //    );
 
-  @Container private static final MSSQLServerContainer MSSQL = new MSSQLServerContainer<>(
-    DockerImageName.parse("mcr.microsoft.com/mssql/server:2019-latest")
-  );
+  @Container
+  private static final MSSQLServerContainer MSSQL =
+      new MSSQLServerContainer<>(
+          DockerImageName.parse("mcr.microsoft.com/mssql/server:2019-latest"));
+
   private static DataSource pooledDatasource;
 
   @BeforeAll

--- a/db-scheduler/src/test/resources/container-license-acceptance.txt
+++ b/db-scheduler/src/test/resources/container-license-acceptance.txt
@@ -1,2 +1,2 @@
-mcr.microsoft.com/mssql/server:2017-CU12
+mcr.microsoft.com/mssql/server:2022-latest
 


### PR DESCRIPTION
Fix build-errors caused by docker-image not starting on newer Ubuntu-images for github runners



## Reminders
- [x] Added/ran automated tests
- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`

