### PR TITLE
fix: Reduce log-level to DEBUG when missing a single heartbeat update

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
@@ -647,7 +647,7 @@ public class JdbcTaskRepository implements TaskRepository {
     if (updated == 0) {
       // There is a race-condition: Executions are not removed from currently-executing until after
       // the execution has been updated in the database, so this might happen.
-      LOG.warn(
+      LOG.debug(
           "Did not update heartbeat. Execution must have been removed or rescheduled"
               + "(i.e. CompletionHandler ran and finished just before heartbeat-update). "
               + "This is a race-condition that may occur, but is very unlikely. "


### PR DESCRIPTION
See issue #654. This fix reduces that logging from WARN to DEBUG. If there are consecutive failures for heartbeats, there will still be a WARN (handled on the outside)

## Fixes
Fixes #654


## Reminders
- [ ] Added/ran automated tests
- [ ] Update README and/or examples
- [ ] Ran `mvn spotless:apply`
