### PR TITLE
fix: Fix getExecutionsFailingLongerThan to not return executions that have previously failed but are now running ok

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
@@ -673,12 +673,12 @@ public class JdbcTaskRepository implements TaskRepository {
         "select * from "
             + tableName
             + " where "
-            + "    ((last_success is null and last_failure is not null)"
-            + "    or (last_failure is not null and last_success < ?)) "
+            + "    consecutive_failures > 0 "
+            + "    and (last_success is null or last_success < ?) "
             + unresolvedFilter.andCondition(),
         (PreparedStatement p) -> {
           int index = 1;
-          jdbcCustomization.setInstant(p, index++, Instant.now().minus(interval));
+          jdbcCustomization.setInstant(p, index++, clock.now().minus(interval));
           unresolvedFilter.setParameters(p, index);
         },
         new ExecutionResultSetMapper(false, false));

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
@@ -364,15 +364,15 @@ public class JdbcTaskRepositoryTest {
     assertThat(taskRepository.getExecutionsFailingLongerThan(ofMinutes(1)), hasSize(1));
     assertThat(taskRepository.getExecutionsFailingLongerThan(ofDays(1)), hasSize(1));
 
-    taskRepository.reschedule(
-        getSingleDueExecution(), now, now.minus(ofMinutes(1)), now, 1);
+    taskRepository.reschedule(getSingleDueExecution(), now, now.minus(ofMinutes(1)), now, 1);
     assertThat(taskRepository.getExecutionsFailingLongerThan(Duration.ZERO), hasSize(1));
     assertThat(taskRepository.getExecutionsFailingLongerThan(Duration.ofSeconds(1)), hasSize(1));
     assertThat(taskRepository.getExecutionsFailingLongerThan(Duration.ofHours(1)), hasSize(0));
   }
 
   @Test
-  public void get_failing_executions_should_not_return_previously_failed_but_currently_successful() {
+  public void
+      get_failing_executions_should_not_return_previously_failed_but_currently_successful() {
     Instant third = TimeHelper.truncatedInstantNow();
     Instant second = third.minus(ofMinutes(1));
     Instant first = second.minus(ofMinutes(1));
@@ -398,8 +398,7 @@ public class JdbcTaskRepositoryTest {
     assertThat(taskRepository.getExecutionsFailingLongerThan(Duration.ZERO), hasSize(0));
   }
 
-
-    @Test
+  @Test
   public void get_scheduled_executions() {
     Instant now = TimeHelper.truncatedInstantNow();
     IntStream.range(0, 100)

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/helper/TimeHelper.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/helper/TimeHelper.java
@@ -13,6 +13,10 @@ public final class TimeHelper {
    * @see <a href="https://bugs.openjdk.java.net/browse/JDK-8068730">JDK-8068730</a>
    */
   public static Instant truncatedInstantNow() {
-    return Instant.now().truncatedTo(MILLIS);
+    return truncated(Instant.now());
+  }
+
+  private static Instant truncated(Instant instant) {
+    return instant.truncatedTo(MILLIS);
   }
 }


### PR DESCRIPTION
getExecutionsFailingLongerThan is not working as expected. Returns execution forever if it has failed once..

## Fixes
#563


## Reminders
- [ ] Added/ran automated tests
- [ ] Update README and/or examples
- [ ] Ran `mvn spotless:apply`
