### PR TITLE
feat: Provide onDeadExecution method for RecurringTaskWithPersistentScheduleBuilder

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTaskWithPersistentSchedule.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTaskWithPersistentSchedule.java
@@ -36,12 +36,21 @@ public abstract class RecurringTaskWithPersistentSchedule<T extends ScheduleAndD
 
   public RecurringTaskWithPersistentSchedule(
       String name, Class<T> dataClass, FailureHandler<T> onFailure, int defaultPriority) {
-    super(
+    this(
         name,
         dataClass,
         onFailure,
         new DeadExecutionHandler.ReviveDeadExecution<>(),
         defaultPriority);
+  }
+
+  public RecurringTaskWithPersistentSchedule(
+      String name,
+      Class<T> dataClass,
+      FailureHandler<T> onFailure,
+      DeadExecutionHandler<T> deadExecutionHandler,
+      int defaultPriority) {
+    super(name, dataClass, onFailure, deadExecutionHandler, defaultPriority);
   }
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/Tasks.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/Tasks.java
@@ -186,6 +186,8 @@ public class Tasks {
     private final Class<T> dataClass;
     private FailureHandler<T> onFailure =
         new FailureHandler.OnFailureRescheduleUsingTaskDataSchedule<>();
+    private DeadExecutionHandler<T> onDeadExecution =
+        new DeadExecutionHandler.ReviveDeadExecution<>();
 
     private int defaultPriority = RecurringTaskWithPersistentSchedule.DEFAULT_PRIORITY;
 
@@ -205,10 +207,21 @@ public class Tasks {
       return this;
     }
 
+    public RecurringTaskWithPersistentScheduleBuilder<T> onDeadExecutionRevive() {
+      this.onDeadExecution = new DeadExecutionHandler.ReviveDeadExecution<>();
+      return this;
+    }
+
+    public RecurringTaskWithPersistentScheduleBuilder<T> onDeadExecution(
+        DeadExecutionHandler<T> deadExecutionHandler) {
+      this.onDeadExecution = deadExecutionHandler;
+      return this;
+    }
+
     public RecurringTaskWithPersistentSchedule<T> execute(
         VoidExecutionHandler<T> executionHandler) {
       return new RecurringTaskWithPersistentSchedule<>(
-          name, dataClass, onFailure, defaultPriority) {
+          name, dataClass, onFailure, onDeadExecution, defaultPriority) {
         @Override
         public CompletionHandler<T> execute(
             TaskInstance<T> taskInstance, ExecutionContext executionContext) {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTaskWithPersistentScheduleTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTaskWithPersistentScheduleTest.java
@@ -3,6 +3,7 @@ package com.github.kagkarlsson.scheduler.task.helper;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.github.kagkarlsson.scheduler.serializer.jackson.ScheduleAndDataForTest;
+import com.github.kagkarlsson.scheduler.task.DeadExecutionHandler;
 import com.github.kagkarlsson.scheduler.task.Priority;
 import org.junit.jupiter.api.Test;
 
@@ -26,5 +27,29 @@ class RecurringTaskWithPersistentScheduleTest {
             .execute((taskInstance, executionContext) -> new ScheduleAndDataForTest(null, null));
 
     assertEquals(Priority.LOW, recurringTask.getDefaultPriority());
+  }
+
+  @Test
+  public void should_have_ReviveDeadExecution_as_default_DeadExecutionHandler() {
+    RecurringTaskWithPersistentSchedule<ScheduleAndDataForTest> recurringTask =
+        Tasks.recurringWithPersistentSchedule("name", ScheduleAndDataForTest.class)
+            .execute((taskInstance, executionContext) -> new ScheduleAndDataForTest(null, null));
+
+    assertEquals(
+        DeadExecutionHandler.ReviveDeadExecution.class,
+        recurringTask.getDeadExecutionHandler().getClass());
+  }
+
+  @Test
+  public void should_overwrite_DeadExecutionHandler() {
+    DeadExecutionHandler<ScheduleAndDataForTest> deadExecutionHandler =
+        new DeadExecutionHandler.CancelDeadExecution<>();
+
+    RecurringTaskWithPersistentSchedule<ScheduleAndDataForTest> recurringTask =
+        Tasks.recurringWithPersistentSchedule("name", ScheduleAndDataForTest.class)
+            .onDeadExecution(deadExecutionHandler)
+            .execute((taskInstance, executionContext) -> new ScheduleAndDataForTest(null, null));
+
+    assertEquals(deadExecutionHandler, recurringTask.getDeadExecutionHandler());
   }
 }


### PR DESCRIPTION
## Extending the api of the RecurringTaskWithPersistentScheduleBuilder
After these changes, we match the capabilities of the RecurringTaskBuilder. 


## Fixes
#705 


## Reminders
- [X] Added/ran automated tests
- [X] Update README and/or examples
- [X] Ran `mvn spotless:apply`

---
cc @kagkarlsson
