### PR TITLE
feat: Expose Clock from builder and implement in Spring Boot AutoConfiguration

### DIFF
--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
@@ -117,7 +117,8 @@ public class DbSchedulerAutoConfiguration {
   @ConditionalOnMissingBean
   @DependsOnDatabaseInitialization
   @Bean(destroyMethod = "stop")
-  public Scheduler scheduler(DbSchedulerCustomizer customizer, StatsRegistry registry, Clock clock) {
+  public Scheduler scheduler(
+      DbSchedulerCustomizer customizer, StatsRegistry registry, Clock clock) {
     log.info("Creating db-scheduler using tasks from Spring context: {}", configuredTasks);
 
     // Ensure that we are using a transactional aware data source

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
@@ -301,7 +301,7 @@ public class SchedulerBuilder {
       addSchedulerListener(new StatsRegistryAdapter(statsRegistry));
     }
 
-    Waiter waiter = new Waiter(this.poolingInterval, clock);
+    Waiter waiter = buildWaiter();
 
     LOG.info(
         "Creating scheduler with configuration: threads={}, pollInterval={}s, heartbeat={}s, enable-immediate-execution={}, enable-priority={}, table-name={}, name={}",
@@ -351,5 +351,9 @@ public class SchedulerBuilder {
     }
 
     return scheduler;
+  }
+
+  protected Waiter buildWaiter() {
+    return new Waiter(poolingInterval, clock);
   }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
@@ -59,7 +59,7 @@ public class SchedulerBuilder {
   protected Clock clock = new SystemClock(); // if this is set, waiter-clocks must be updated
   protected SchedulerName schedulerName;
   protected int executorThreads = 10;
-  protected Waiter waiter = new Waiter(DEFAULT_POLLING_INTERVAL, clock);
+  protected Duration poolingInterval = DEFAULT_POLLING_INTERVAL;
   protected StatsRegistry statsRegistry = StatsRegistry.NOOP;
   protected Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
   protected Serializer serializer = Serializer.DEFAULT_JAVA_SERIALIZER;
@@ -99,7 +99,7 @@ public class SchedulerBuilder {
   }
 
   public SchedulerBuilder pollingInterval(Duration pollingInterval) {
-    waiter = new Waiter(pollingInterval, clock);
+    this.poolingInterval = pollingInterval;
     return this;
   }
 
@@ -237,6 +237,11 @@ public class SchedulerBuilder {
     return this;
   }
 
+  public SchedulerBuilder clock(Clock clock) {
+    this.clock = clock;
+    return this;
+  }
+
   public Scheduler build() {
     if (schedulerName == null) {
       schedulerName = new SchedulerName.Hostname();
@@ -295,6 +300,8 @@ public class SchedulerBuilder {
     if (statsRegistry != null) {
       addSchedulerListener(new StatsRegistryAdapter(statsRegistry));
     }
+
+    Waiter waiter = new Waiter(this.poolingInterval, clock);
 
     LOG.info(
         "Creating scheduler with configuration: threads={}, pollInterval={}s, heartbeat={}s, enable-immediate-execution={}, enable-priority={}, table-name={}, name={}",

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
@@ -17,6 +17,7 @@ import com.github.kagkarlsson.scheduler.PollingStrategyConfig;
 import com.github.kagkarlsson.scheduler.SchedulerBuilder;
 import com.github.kagkarlsson.scheduler.SchedulerName;
 import com.github.kagkarlsson.scheduler.TaskResolver;
+import com.github.kagkarlsson.scheduler.Waiter;
 import com.github.kagkarlsson.scheduler.event.SchedulerListener;
 import com.github.kagkarlsson.scheduler.event.SchedulerListeners;
 import com.github.kagkarlsson.scheduler.jdbc.DefaultJdbcCustomization;
@@ -103,6 +104,8 @@ public class TestHelper {
               serializer,
               enablePriority,
               clock);
+
+      Waiter waiter = buildWaiter();
 
       return new ManualScheduler(
           clock,


### PR DESCRIPTION
## Brief, plain english overview of your changes here
- Added clock(Clock) method to SchedulerBuilder so users can provide their own clock for Scheduler
- In order not to have to think about Waiter caching old Clock I moved Waiter creation to build method, so it always uses latest Clock from builder field
- Had to build Waiter manually in TestHelper for ManualScheduler.

Note: This changes current behavior, but I think it's a bug. 
Currently Waiter in ManualScheduler is using SystemClock instead of newly set clock, I changed that because Waiter is now created in the end so it will always use up-to date Clock instance, in case this is desired behavior for some reason, let me know and I will fix it. 


## Reminders
- [x] Added/ran automated tests
- [ ] Update README and/or examples
- [x] Ran `mvn spotless:apply`

---
cc @kagkarlsson
