### PR TITLE
build(deps): Use Spring Boot v3.5.5 as default (from 3.4.5)

### DIFF
--- a/db-scheduler-boot-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
+++ b/db-scheduler-boot-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
@@ -235,11 +235,18 @@ public class DbSchedulerAutoConfigurationTest {
 
   @Test
   public void it_should_provide_noop_registry_if_actuator_not_present() {
-    ctxRunner
-        .withUserConfiguration(SingleTaskConfiguration.class)
-        .with(
-            classesRemovedFromClasspath(
-                MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class))
+    new ApplicationContextRunner()
+        .withPropertyValues(
+            "spring.application.name=db-scheduler-boot-starter-test",
+            "spring.profiles.active=integration-test")
+        .withConfiguration(
+            AutoConfigurations.of(
+                DataSourceAutoConfiguration.class,
+                SqlInitializationAutoConfiguration.class,
+                HealthContributorAutoConfiguration.class,
+                DbSchedulerMetricsAutoConfiguration.class,
+                DbSchedulerActuatorAutoConfiguration.class,
+                DbSchedulerAutoConfiguration.class))
         .run(
             (AssertableApplicationContext ctx) -> {
               assertThat(ctx).hasSingleBean(DefaultStatsRegistry.class);

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 		<!-- Dependency versions -->
 		<slf4j.version>1.7.36</slf4j.version>
 		<logback.version>1.2.13</logback.version>
-		<spring-boot.version>3.4.5</spring-boot.version>
+		<spring-boot.version>3.5.5</spring-boot.version>
 		<micrometer.version>1.15.3</micrometer.version>
 		<gson.version>2.11.0</gson.version>
 		<jackson.version>2.18.3</jackson.version>


### PR DESCRIPTION
## Brief, plain english overview of your changes here
Upgrade support to Spring Boot 3.5.5.

## Fixes
<!--- Which issue # does this fix? --->
#735 

## Reminders
- [x] Added/ran automated tests
- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`

---
cc @kagkarlsson
