### PR TITLE
fix: Rename clock bean to not clash with user clock bean

### DIFF
--- a/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
+++ b/db-scheduler-boot-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
@@ -108,7 +108,7 @@ public class DbSchedulerAutoConfiguration {
   }
 
   @ConditionalOnMissingBean
-  @Bean
+  @Bean("dbSchedulerClock")
   public Clock clock() {
     return new SystemClock();
   }


### PR DESCRIPTION
## Brief, plain english overview of your changes here

Rename the `Clock` bean so it doesn't clash with Clock beans in applications using db-scheduler. This was reported in #720  after merging.

## Reminders
- [ ] Added/ran automated tests
- [ ] Update README and/or examples
- [ ] Ran `mvn spotless:apply`

---
cc @kagkarlsson
