### PR TITLE
feat: Use execution-time when calculating age of execution with unresolved task

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -49,7 +49,7 @@
       </option>
       <option name="IMPORT_LAYOUT_TABLE">
         <value>
-          <package name="" withSubpackages="true" static="false" module="true" />
+          <package name="" withSubpackages="true" static="false" />
           <package name="" withSubpackages="true" static="true" />
           <emptyLine />
           <package name="" withSubpackages="true" static="false" />

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ExecutePicked.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ExecutePicked.java
@@ -93,7 +93,7 @@ class ExecutePicked implements Runnable {
   }
 
   private void executePickedExecution(Execution execution, CurrentlyExecuting currentlyExecuting) {
-    final Optional<Task> task = taskResolver.resolve(execution.taskInstance.getTaskName());
+    final Optional<Task> task = taskResolver.resolve(execution);
     if (task.isEmpty()) {
       LOG.error(
           "Failed to find implementation for task with name '{}'. Should have been excluded in JdbcRepository.",

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Resolvable.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Resolvable.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) Gustav Karlsson
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.kagkarlsson.scheduler;
+
+import com.github.kagkarlsson.scheduler.task.HasTaskName;
+import java.time.Instant;
+
+public interface Resolvable extends HasTaskName {
+
+  Instant getExecutionTime();
+
+  static Resolvable of(String taskName, Instant executionTime) {
+    return new SimpleResolvable(taskName, executionTime);
+  }
+
+  record SimpleResolvable(String taskName, Instant executionTime) implements Resolvable {
+
+    @Override
+    public Instant getExecutionTime() {
+      return executionTime;
+    }
+
+    @Override
+    public String getTaskName() {
+      return taskName;
+    }
+  }
+}

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -386,7 +386,7 @@ public class Scheduler implements SchedulerClient {
             LOG.info("Found dead execution. Delegating handling to task. Execution: " + execution);
             try {
 
-              Optional<Task> task = taskResolver.resolve(execution.taskInstance.getTaskName());
+              Optional<Task> task = taskResolver.resolve(execution);
               if (task.isPresent()) {
                 schedulerListeners.onSchedulerEvent(SchedulerEventType.DEAD_EXECUTION);
                 schedulerListeners.onExecutionDead(execution);

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskResolver.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskResolver.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("rawtypes")
 public class TaskResolver {
+
   private static final Logger LOG = LoggerFactory.getLogger(TaskResolver.class);
   private final SchedulerListeners schedulerListeners;
   private final Clock clock;
@@ -44,14 +45,16 @@ public class TaskResolver {
     this.taskMap = knownTasks.stream().collect(Collectors.toMap(Task::getName, identity()));
   }
 
-  public Optional<Task> resolve(String taskName) {
-    return resolve(taskName, true);
+  public Optional<Task> resolve(Resolvable resolvable) {
+    return resolve(resolvable, true);
   }
 
-  public Optional<Task> resolve(String taskName, boolean addUnresolvedToExclusionFilter) {
+  public Optional<Task> resolve(Resolvable resolvable, boolean addUnresolvedToExclusionFilter) {
+    String taskName = resolvable.getTaskName();
+
     Task task = taskMap.get(taskName);
     if (task == null && addUnresolvedToExclusionFilter) {
-      addUnresolved(taskName);
+      addUnresolved(taskName, resolvable.getExecutionTime());
       schedulerListeners.onSchedulerEvent(SchedulerEventType.UNRESOLVED_TASK);
       LOG.info(
           "Found execution with unknown task-name '{}'. Adding it to the list of known unresolved task-names.",
@@ -60,8 +63,8 @@ public class TaskResolver {
     return Optional.ofNullable(task);
   }
 
-  private void addUnresolved(String taskName) {
-    unresolvedTasks.putIfAbsent(taskName, new UnresolvedTask(taskName));
+  private void addUnresolved(String taskName, Instant executionTime) {
+    unresolvedTasks.putIfAbsent(taskName, new UnresolvedTask(taskName, executionTime));
   }
 
   public void addTask(Task task) {
@@ -87,12 +90,13 @@ public class TaskResolver {
   }
 
   public class UnresolvedTask {
+
     private final String taskName;
     private final Instant firstUnresolved;
 
-    public UnresolvedTask(String taskName) {
+    public UnresolvedTask(String taskName, Instant executionTime) {
       this.taskName = taskName;
-      firstUnresolved = clock.now();
+      firstUnresolved = executionTime;
     }
 
     public String getTaskName() {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
@@ -23,6 +23,7 @@ import com.github.kagkarlsson.jdbc.ResultSetMapper;
 import com.github.kagkarlsson.jdbc.SQLRuntimeException;
 import com.github.kagkarlsson.scheduler.Clock;
 import com.github.kagkarlsson.scheduler.ExecutionTimeAndId;
+import com.github.kagkarlsson.scheduler.Resolvable;
 import com.github.kagkarlsson.scheduler.ScheduledExecutionsFilter;
 import com.github.kagkarlsson.scheduler.SchedulerName;
 import com.github.kagkarlsson.scheduler.TaskRepository;
@@ -799,7 +800,10 @@ public class JdbcTaskRepository implements TaskRepository {
 
       while (rs.next()) {
         String taskName = rs.getString("task_name");
-        Optional<Task> task = taskResolver.resolve(taskName, addUnresolvedToExclusionFilter);
+        Instant executionTime = jdbcCustomization.getInstant(rs, "execution_time");
+        Optional<Task> task =
+            taskResolver.resolve(
+                Resolvable.of(taskName, executionTime), addUnresolvedToExclusionFilter);
 
         if (task.isEmpty() && !includeUnresolved) {
           if (addUnresolvedToExclusionFilter) {
@@ -814,8 +818,6 @@ public class JdbcTaskRepository implements TaskRepository {
 
         String instanceId = rs.getString("task_instance");
         byte[] data = jdbcCustomization.getTaskData(rs, "task_data");
-
-        Instant executionTime = jdbcCustomization.getInstant(rs, "execution_time");
 
         boolean picked = rs.getBoolean("picked");
         final String pickedBy = rs.getString("picked_by");
@@ -878,6 +880,7 @@ public class JdbcTaskRepository implements TaskRepository {
   }
 
   private static class NewData {
+
     private final Object data;
 
     NewData(Object data) {
@@ -886,6 +889,7 @@ public class JdbcTaskRepository implements TaskRepository {
   }
 
   static class UnresolvedFilter implements AndCondition {
+
     private final List<UnresolvedTask> unresolved;
 
     public UnresolvedFilter(List<UnresolvedTask> unresolved) {
@@ -917,6 +921,7 @@ public class JdbcTaskRepository implements TaskRepository {
   }
 
   private static class PickedCondition implements AndCondition {
+
     private final boolean value;
 
     public PickedCondition(boolean value) {
@@ -936,6 +941,7 @@ public class JdbcTaskRepository implements TaskRepository {
   }
 
   private static class TaskCondition implements AndCondition {
+
     private final String value;
 
     public TaskCondition(String value) {
@@ -955,6 +961,7 @@ public class JdbcTaskRepository implements TaskRepository {
   }
 
   private class ExecutionTimeAfterCondition implements AndCondition {
+
     private final ExecutionTimeAndId execution;
 
     public ExecutionTimeAfterCondition(ExecutionTimeAndId execution) {
@@ -976,6 +983,7 @@ public class JdbcTaskRepository implements TaskRepository {
   }
 
   private class ExecutionTimeBeforeCondition implements AndCondition {
+
     private final ExecutionTimeAndId execution;
 
     public ExecutionTimeBeforeCondition(ExecutionTimeAndId execution) {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/Execution.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/Execution.java
@@ -13,11 +13,12 @@
  */
 package com.github.kagkarlsson.scheduler.task;
 
+import com.github.kagkarlsson.scheduler.Resolvable;
 import java.time.Instant;
 import java.util.Objects;
 
 @SuppressWarnings("rawtypes")
-public final class Execution implements TaskInstanceId {
+public final class Execution implements TaskInstanceId, Resolvable {
   public final TaskInstance taskInstance;
   public final Instant executionTime;
   public final boolean picked;
@@ -53,6 +54,7 @@ public final class Execution implements TaskInstanceId {
     this.version = version;
   }
 
+  @Override
   public Instant getExecutionTime() {
     return executionTime;
   }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/TaskResolverTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/TaskResolverTest.java
@@ -6,6 +6,9 @@ import static org.mockito.Mockito.verify;
 import com.github.kagkarlsson.scheduler.event.SchedulerListener;
 import com.github.kagkarlsson.scheduler.event.SchedulerListener.SchedulerEventType;
 import com.github.kagkarlsson.scheduler.event.SchedulerListeners;
+import com.github.kagkarlsson.scheduler.task.Execution;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,7 +26,7 @@ class TaskResolverTest {
         new TaskResolver(
             new SchedulerListeners(mockScheduleListener), new SystemClock(), List.of());
 
-    taskResolver.resolve("unknown-task");
+    taskResolver.resolve(new Execution(Instant.now(), new TaskInstance<Void>("unresolved", "id1")));
 
     verify(mockScheduleListener, times(1)).onSchedulerEvent(SchedulerEventType.UNRESOLVED_TASK);
   }


### PR DESCRIPTION
Use execution-time when calculating age of execution with unresolved task. Previously age was calculated based on the first time it was detected as unresolved after startup.

## Reminders
- [x] Added/ran automated tests
- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`
