### PR TITLE
fix: Add default value for execution time column

### DIFF
--- a/db-scheduler/src/test/resources/mariadb_tables.sql
+++ b/db-scheduler/src/test/resources/mariadb_tables.sql
@@ -3,7 +3,7 @@ create table test.scheduled_tasks (
   task_name varchar(100) not null,
   task_instance varchar(100) not null,
   task_data blob,
-  execution_time timestamp(6) not null,
+  execution_time timestamp(6) not null default current_timestamp(6),
   picked BOOLEAN not null,
   picked_by varchar(50),
   last_success timestamp(6) null,

--- a/db-scheduler/src/test/resources/mysql_tables.sql
+++ b/db-scheduler/src/test/resources/mysql_tables.sql
@@ -2,7 +2,7 @@ create table test.scheduled_tasks (
   task_name varchar(100) not null,
   task_instance varchar(100) not null,
   task_data blob,
-  execution_time timestamp(6) not null,
+  execution_time timestamp(6) not null default current_timestamp(6),,
   picked BOOLEAN not null,
   picked_by varchar(50),
   last_success timestamp(6) null,


### PR DESCRIPTION
Add default value for execution time column, to prevent mysql/mariadb from automatically adding ON UPDATE CURRENT_TIMESTAMP. This strange quirk is explained, for example, in this stackoverflow: https://stackoverflow.com/questions/34355965/mysql-timestamp-column-is-auto-updated-why

I'm not sure if the auto updating of the execution time breaks anything, but it definitely is confusing behavior when using mysql/mariadb.

I  don't think running the tests etc. really does anything in this case.

---
cc @kagkarlsson
