### PR TITLE
fix: generate properties metadata for spring boot starter

### DIFF
--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/pom.xml
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/pom.xml
@@ -61,4 +61,21 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <parameters>true</parameters>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.springframework.boot</groupId>
+              <artifactId>spring-boot-configuration-processor</artifactId>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
Fix generation of spring configuration-properties metadata for boot3 and 4 starters

## Fixes
#778 


## Reminders
- [x] Added/ran automated tests
- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`
