### PR TITLE
fix: Add ManualSchedulerBuilder overrides for tableName and alwaysPersistTimestampInUTC

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
@@ -82,6 +82,16 @@ public class TestHelper {
       return this;
     }
 
+    public ManualSchedulerBuilder tableName(String tableName) {
+      super.tableName = tableName;
+      return this;
+    }
+
+    public ManualSchedulerBuilder alwaysPersistTimestampInUTC() {
+      super.alwaysPersistTimestampInUTC = true;
+      return this;
+    }
+
     public ManualScheduler build() {
       final TaskResolver taskResolver =
           new TaskResolver(new SchedulerListeners(schedulerListeners), clock, knownTasks);


### PR DESCRIPTION
## Brief, plain english overview of your changes here
I just added a few more overrides in the ManualSchedulerBuilder that are missing for my use case.

## Fixes
This fixes the ManualSchedulerBuilder needing to be recast to a ManualSchedulerBuilder  after calling .tableName / .alwaysPersistTimestampInUTC


## Reminders
- [ ] Added/ran automated tests
- [ ] Update README and/or examples
- [ ] Ran `mvn spotless:apply`

---
cc @kagkarlsson
