### PR TITLE
refactor: Use JsonMapper instead of ObjectMapper in Jackson3Serializer

### DIFF
--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot4-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/Jackson3Serializer.java
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot4-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/Jackson3Serializer.java
@@ -25,28 +25,27 @@ import java.util.function.Consumer;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.Version;
 import tools.jackson.databind.MapperFeature;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.module.SimpleModule;
 
 public class Jackson3Serializer implements Serializer {
-  private final ObjectMapper objectMapper;
+  private final JsonMapper jsonMapper;
 
   public Jackson3Serializer() {
-    this(getDefaultObjectMapper());
+    this(getDefaultJsonMapper());
   }
 
-  public Jackson3Serializer(ObjectMapper objectMapper) {
-    this.objectMapper = objectMapper;
+  public Jackson3Serializer(JsonMapper jsonMapper) {
+    this.jsonMapper = jsonMapper;
   }
 
-  public Jackson3Serializer(Consumer<ObjectMapper> objectMapperCustomizer) {
-    ObjectMapper defaultObjectMapper = getDefaultObjectMapper();
-    objectMapperCustomizer.accept(defaultObjectMapper);
-    this.objectMapper = defaultObjectMapper;
+  public Jackson3Serializer(Consumer<JsonMapper> jsonMapperCustomizer) {
+    JsonMapper defaultJsonMapper = getDefaultJsonMapper();
+    jsonMapperCustomizer.accept(defaultJsonMapper);
+    this.jsonMapper = defaultJsonMapper;
   }
 
-  public static ObjectMapper getDefaultObjectMapper() {
+  public static JsonMapper getDefaultJsonMapper() {
     SimpleModule module = new SimpleModule("CustomInstantModule", Version.unknownVersion());
     module.addSerializer(Instant.class, new InstantSerializer());
     module.addDeserializer(Instant.class, new InstantDeserializer());
@@ -62,7 +61,7 @@ public class Jackson3Serializer implements Serializer {
   @Override
   public byte[] serialize(Object object) {
     try {
-      return objectMapper.writeValueAsBytes(object);
+      return jsonMapper.writeValueAsBytes(object);
     } catch (JacksonException e) {
       throw new SerializationException("Failed to serialize object.", e);
     }
@@ -71,7 +70,7 @@ public class Jackson3Serializer implements Serializer {
   @Override
   public <T> T deserialize(Class<T> clazz, byte[] serializedData) {
     try {
-      return objectMapper.readValue(serializedData, clazz);
+      return jsonMapper.readValue(serializedData, clazz);
     } catch (JacksonException e) {
       throw new SerializationException("Failed to deserialize object.", e);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
     <!-- Dependency versions -->
     <slf4j.version>1.7.36</slf4j.version>
     <logback.version>1.2.13</logback.version>
-    <spring-boot.version>3.5.5</spring-boot.version>
-    <spring-boot-4.version>4.0.1</spring-boot-4.version>
+    <spring-boot.version>3.5.10</spring-boot.version>
+    <spring-boot-4.version>4.0.2</spring-boot-4.version>
     <micrometer.version>1.15.3</micrometer.version>
     <gson.version>2.13.2</gson.version>
     <jackson.version>2.20.0</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
     <!-- Dependency versions -->
     <slf4j.version>1.7.36</slf4j.version>
     <logback.version>1.2.13</logback.version>
-    <spring-boot.version>3.5.10</spring-boot.version>
-    <spring-boot-4.version>4.0.2</spring-boot-4.version>
+    <spring-boot.version>3.5.11</spring-boot.version>
+    <spring-boot-4.version>4.0.3</spring-boot-4.version>
     <micrometer.version>1.15.3</micrometer.version>
     <gson.version>2.13.2</gson.version>
     <jackson.version>2.20.0</jackson.version>


### PR DESCRIPTION
Jackson 3.x recommends using JsonMapper over ObjectMapper. Updated Jackson3Serializer in the Spring Boot 4 starter accordingly.

**Official migration guide**: https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md