### PR TITLE
fix: cronStyle getter is added to CronSchedule

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/CronSchedule.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/schedule/CronSchedule.java
@@ -164,6 +164,10 @@ public class CronSchedule implements Schedule, Serializable {
     return zoneId;
   }
 
+  public CronStyle getCronStyle() {
+    return cronStyle;
+  }
+
   private static class DisabledScheduleExecutionTime implements ExecutionTime {
     @Override
     public Optional<ZonedDateTime> nextExecution(ZonedDateTime date) {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/serializer/jackson/JacksonSerializerTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/serializer/jackson/JacksonSerializerTest.java
@@ -1,16 +1,24 @@
 package com.github.kagkarlsson.scheduler.serializer.jackson;
 
+import static com.github.kagkarlsson.scheduler.serializer.JacksonSerializer.getDefaultObjectMapper;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.kagkarlsson.scheduler.serializer.JacksonSerializer;
+import com.github.kagkarlsson.scheduler.task.ExecutionComplete;
 import com.github.kagkarlsson.scheduler.task.helper.PlainScheduleAndData;
 import com.github.kagkarlsson.scheduler.task.schedule.CronSchedule;
+import com.github.kagkarlsson.scheduler.task.schedule.CronStyle;
 import com.github.kagkarlsson.scheduler.task.schedule.Daily;
 import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay;
 import com.github.kagkarlsson.scheduler.task.schedule.Schedules;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -88,5 +96,28 @@ public class JacksonSerializerTest {
         scheduleAndData.getSchedule().getInitialExecutionTime(now),
         deserialized.getSchedule().getInitialExecutionTime(now));
     assertEquals(50, deserialized.getData());
+  }
+
+  @Test
+  public void serialize_cron_schedule_with_unix_cron_style_and_custom_object_mapper() {
+    Instant now = Instant.now();
+    ObjectMapper objectMapper =
+        getDefaultObjectMapper().setVisibility(PropertyAccessor.FIELD, Visibility.NONE);
+    serializer = new JacksonSerializer(objectMapper);
+
+    ExecutionComplete successExecution = ExecutionComplete.success(null, now.minusSeconds(1), now);
+    CronSchedule cronSchedule = new CronSchedule("* * * * *", ZoneId.of("UTC"), CronStyle.UNIX);
+
+    ScheduleAndDataForTest scheduleAndData = new ScheduleAndDataForTest(cronSchedule, 50L);
+    ScheduleAndDataForTest deserialized =
+        serializer.deserialize(ScheduleAndDataForTest.class, serializer.serialize(scheduleAndData));
+
+    CronSchedule deserializedSchedule = deserialized.getSchedule();
+
+    assertDoesNotThrow(() -> deserializedSchedule.getNextExecutionTime(successExecution));
+    assertEquals(CronStyle.UNIX, deserializedSchedule.getCronStyle());
+    assertEquals(
+        scheduleAndData.getSchedule().getInitialExecutionTime(now),
+        deserializedSchedule.getInitialExecutionTime(now));
   }
 }


### PR DESCRIPTION
## Fix CronSchedule deserialization with custom JacksonSerializer

The CronSchedule class lacked getter for cronStyle fields, causing deserialization failures when using custom ObjectMapper configurations that serialize only by getters. This affected RecurringTaskWithPersistentSchedule tasks, which would become dead in non spring cron type case and be rescheduled indefinitely.

## Fixes
https://github.com/kagkarlsson/db-scheduler/issues/792

## Reminders

- [x] Added/ran automated tests
- [x] Ran `mvn spotless:apply`

---

cc @kagkarlsson
