### PR TITLE
fix: Update schema and jdbc-customizaztion to fix MS SQL task_data corruption for odd-length byte arrays

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MssqlJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/MssqlJdbcCustomization.java
@@ -15,6 +15,8 @@ package com.github.kagkarlsson.scheduler.jdbc;
 
 import static com.github.kagkarlsson.scheduler.jdbc.Queries.selectForUpdate;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +35,11 @@ public class MssqlJdbcCustomization extends DefaultJdbcCustomization {
               + "Persisting timestamp with undefined timezone is not recommended and will likely cause issues",
           getClass().getName());
     }
+  }
+
+  @Override
+  public void setTaskData(PreparedStatement p, int index, byte[] value) throws SQLException {
+    p.setBytes(index, value);
   }
 
   @Override

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/MssqlCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/MssqlCompatibilityTest.java
@@ -1,13 +1,36 @@
 package com.github.kagkarlsson.scheduler.compatibility;
 
+import static com.github.kagkarlsson.scheduler.helper.TimeHelper.truncatedInstantNow;
+import static com.github.kagkarlsson.scheduler.jdbc.JdbcTaskRepository.DEFAULT_TABLE_NAME;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
 import com.github.kagkarlsson.scheduler.DbUtils;
+import com.github.kagkarlsson.scheduler.SchedulerName;
+import com.github.kagkarlsson.scheduler.SystemClock;
+import com.github.kagkarlsson.scheduler.TaskResolver;
+import com.github.kagkarlsson.scheduler.TestTasks;
+import com.github.kagkarlsson.scheduler.event.SchedulerListeners;
+import com.github.kagkarlsson.scheduler.jdbc.JdbcTaskRepository;
+import com.github.kagkarlsson.scheduler.jdbc.MssqlJdbcCustomization;
+import com.github.kagkarlsson.scheduler.serializer.JacksonSerializer;
+import com.github.kagkarlsson.scheduler.task.SchedulableTaskInstance;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.util.DriverDataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
 import java.util.Properties;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -80,5 +103,79 @@ public class MssqlCompatibilityTest extends CompatibilityTest {
   @Override
   public boolean commitWhenAutocommitDisabled() {
     return false;
+  }
+
+  /**
+   * Verifies that task_data byte[] roundtrips correctly through MSSQL, including odd-length
+   * payloads. This failed when task_data was defined as nvarchar(max) because the MSSQL JDBC driver
+   * reinterpreted raw bytes as UTF-16LE characters, null-padding odd-length arrays. Fixed by
+   * changing the column type to varbinary(max).
+   */
+  @Test
+  void test_task_data_byte_array_roundtrip_with_odd_length() {
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(20),
+        () -> {
+          JacksonSerializer serializer = new JacksonSerializer();
+          MssqlJdbcCustomization jdbcCustomization = new MssqlJdbcCustomization();
+          SystemClock clock = new SystemClock();
+
+          OneTimeTask<String> task =
+              TestTasks.oneTimeWithType("byte-roundtrip-task", String.class, (ti, ctx) -> {});
+
+          TaskResolver taskResolver =
+              new TaskResolver(SchedulerListeners.NOOP, clock, List.of(task));
+
+          JdbcTaskRepository repository =
+              new JdbcTaskRepository(
+                  getDataSource(),
+                  commitWhenAutocommitDisabled(),
+                  jdbcCustomization,
+                  DEFAULT_TABLE_NAME,
+                  taskResolver,
+                  new SchedulerName.Fixed("scheduler1"),
+                  serializer,
+                  false,
+                  clock);
+
+          // "odd" serializes to odd-length JSON
+          String taskData = "odd";
+          byte[] serializedBytes = serializer.serialize(taskData);
+          // Ensure we're actually testing an odd-length payload
+          if (serializedBytes.length % 2 == 0) {
+            taskData = "odd!";
+            serializedBytes = serializer.serialize(taskData);
+          }
+
+          final Instant now = truncatedInstantNow();
+
+          TaskInstance<String> taskInstance = task.instance("roundtrip-1", taskData);
+          final SchedulableTaskInstance<String> newExecution =
+              new SchedulableTaskInstance<>(taskInstance, now);
+          repository.createIfNotExists(newExecution);
+
+          // Read raw bytes back from DB and verify they match exactly
+          try (Connection conn = getDataSource().getConnection();
+              PreparedStatement ps =
+                  conn.prepareStatement(
+                      "SELECT task_data FROM scheduled_tasks"
+                          + " WHERE task_name = ? AND task_instance = ?")) {
+            ps.setString(1, "byte-roundtrip-task");
+            ps.setString(2, "roundtrip-1");
+            try (ResultSet rs = ps.executeQuery()) {
+              rs.next();
+              byte[] storedBytes = rs.getBytes("task_data");
+
+              assertArrayEquals(
+                  serializedBytes,
+                  storedBytes,
+                  "task_data byte[] roundtrip should be lossless (expected "
+                      + serializedBytes.length
+                      + " bytes, got "
+                      + storedBytes.length
+                      + ")");
+            }
+          }
+        });
   }
 }

--- a/db-scheduler/src/test/resources/mssql_tables.sql
+++ b/db-scheduler/src/test/resources/mssql_tables.sql
@@ -2,7 +2,7 @@ create table scheduled_tasks
 (
   task_name            varchar(250)   not null,
   task_instance        varchar(250)   not null,
-  task_data            nvarchar(max),
+  task_data            varbinary(max),
   execution_time       datetimeoffset not null,
   picked               bit,
   picked_by            varchar(50),


### PR DESCRIPTION
## Brief, plain english overview of your changes here

Fixes data corruption when storing task_data in MSSQL. The MSSQL schema defined task_data as nvarchar(max) (UTF-16LE, 2 bytes per character), but the JDBC layer writes/reads raw byte[]. When the serialized payload has an odd number of bytes, SQL Server null-pads the last byte to form a complete UTF-16LE  character pair, silently corrupting the stored data.

This is currently masked by Jackson 2.x's readValue(byte[]) which is lenient and ignores trailing null bytes. However, Jackson 3 enables FAIL_ON_TRAILING_TOKENS by default, which will cause deserialization failures on the trailing 0x00.

This is how we noticed the bug.

All other initialization scripts use blob format, while SQL Server script uses a stringy column.

## Fixes
None

## Reminders

- Not sure if some migration notes are needed? 

---

cc @kagkarlsson
