### PR TITLE
refactor: ‎pollUsingFetchAndLockOnExecute strategy is renamed and ‎README is refactored

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # db-scheduler
 
 ![build status](https://github.com/kagkarlsson/db-scheduler/workflows/build/badge.svg)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.kagkarlsson/db-scheduler/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.kagkarlsson/db-scheduler)
+[![Maven Central](https://img.shields.io/maven-central/v/com.github.kagkarlsson/db-scheduler)](https://central.sonatype.com/artifact/com.github.kagkarlsson/db-scheduler)
 [![License](http://img.shields.io/:license-apache-brightgreen.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 
 Task-scheduler for Java that was inspired by the need for a clustered `java.util.concurrent.ScheduledExecutorService` simpler than Quartz.
@@ -276,7 +276,7 @@ as they do not support descending indexes.
 #### Polling strategy
 
 If you are running >1000 executions/s you might want to use the `lock-and-fetch` polling-strategy for lower overhead
-and higher throughput ([read more](#polling-strategy-lock-and-fetch)). If not, the default `fetch-and-lock-on-execute` will be fine.
+and higher throughput ([read more](#polling-strategy-lock-and-fetch)). If not, the default `fetch-and-lock-on-execute` (configured as `fetch` in Fluent API and Spring Boot) will be fine.
 
 :gear: `.pollUsingFetchAndLockOnExecute(double, double)`<br/>
 Use default polling strategy `fetch-and-lock-on-execute`.<br/>
@@ -452,9 +452,6 @@ db-scheduler.enabled=true
 db-scheduler.heartbeat-interval=5m
 db-scheduler.missed-heartbeats-limit=6
 db-scheduler.polling-interval=10s
-db-scheduler.polling-strategy=fetch
-db-scheduler.polling-strategy-lower-limit-fraction-of-threads=0.5
-db-scheduler.polling-strategy-upper-limit-fraction-of-threads=3.0
 db-scheduler.table-name=scheduled_tasks
 db-scheduler.immediate-execution-enabled=false
 db-scheduler.scheduler-name=
@@ -464,7 +461,7 @@ db-scheduler.priority-enabled=false
 # Ignored if a custom DbSchedulerStarter bean is defined
 db-scheduler.delay-startup-until-context-ready=false
 
-db-scheduler.polling-strategy=fetch
+db-scheduler.polling-strategy=fetch # fetch-and-lock-on-execute (default)
 db-scheduler.polling-strategy-lower-limit-fraction-of-threads=0.5
 db-scheduler.polling-strategy-upper-limit-fraction-of-threads=3.0
 
@@ -605,7 +602,7 @@ Observations for these tests:
   * seem to consistently handle 10k executions/s for these configurations
   * throughput did not scale with postgres instance-size (4-8 core), so bottleneck is somewhere else
 
-Currently, polling strategy `lock-and-fetch` is implemented only for Postgres. Contributions adding support for more databases are welcome.
+Currently, polling strategy `lock-and-fetch` is implemented only for Postgres (single statement mode), SQL Server and MySQL v8+ (generic mode). Contributions adding support for more databases are welcome.
 
 ### User testimonial
 

--- a/README.md
+++ b/README.md
@@ -279,10 +279,10 @@ as they do not support descending indexes.
 #### Polling strategy
 
 If you are running >1000 executions/s you might want to use the `lock-and-fetch` polling-strategy for lower overhead
-and higher throughput ([read more](#polling-strategy-lock-and-fetch)). If not, the default `fetch-and-lock-on-execute` (configured as `fetch` in Fluent API and Spring Boot) will be fine.
+and higher throughput ([read more](#polling-strategy-lock-and-fetch)). If not, the default `fetch` will be fine.
 
-:gear: `.pollUsingFetchAndLockOnExecute(double, double)`<br/>
-Use default polling strategy `fetch-and-lock-on-execute`.<br/>
+:gear: `.pollUsingFetch(double, double)`<br/>
+Use default polling strategy `fetch`.<br/>
 If the last fetch from the database was a full batch (`executionsPerBatchFractionOfThreads`), a new fetch will be triggered
 when the number of executions left are less than or equal to `lowerLimitFractionOfThreads * nr-of-threads`.
 Fetched executions are not locked/picked, so the scheduler will compete with other instances for the lock
@@ -464,7 +464,7 @@ db-scheduler.priority-enabled=false
 # Ignored if a custom DbSchedulerStarter bean is defined
 db-scheduler.delay-startup-until-context-ready=false
 
-db-scheduler.polling-strategy=fetch # fetch-and-lock-on-execute (default)
+db-scheduler.polling-strategy=fetch
 db-scheduler.polling-strategy-lower-limit-fraction-of-threads=0.5
 db-scheduler.polling-strategy-upper-limit-fraction-of-threads=3.0
 
@@ -560,9 +560,9 @@ While db-scheduler initially was targeted at low-to-medium throughput use-cases,
 due to the fact that its data-model is very simple, consisting of a single table of executions.
 To understand how it will perform, it is useful to consider the SQL statements it runs per batch of executions.
 
-### Polling strategy fetch-and-lock-on-execute
+### Polling strategy fetch
 
-The original and default polling strategy, `fetch-and-lock-on-execute`, will do the following:
+The original and default polling strategy, `fetch`, will do the following:
 1. `select` a batch of due executions
 2. For every execution, on execute, try to `update` the execution to `picked=true` for this scheduler-instance. May miss due to competing schedulers.
 3. If execution was picked, when execution is done, `update` or `delete` the record according to handlers.
@@ -597,7 +597,7 @@ TPS is the approx. transactions per second as shown in GCP.
 
 Observations for these tests:
 
-* For `fetch-and-lock-on-execute`
+* For `fetch`
   * TPS ≈ 4-5 * execution-throughput. A bit higher than the best-case 2 * execution-throughput, likely due the inefficiency of missed executions.
   * throughput did scale with postgres instance-size, from 2000 executions/s on 4core to 4000 executions/s on 8core
 * For `lock-and-fetch`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # db-scheduler
 
 ![build status](https://github.com/kagkarlsson/db-scheduler/workflows/build/badge.svg)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.kagkarlsson/db-scheduler/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.kagkarlsson/db-scheduler)
+[![Maven Central](https://img.shields.io/maven-central/v/com.github.kagkarlsson/db-scheduler)](https://central.sonatype.com/artifact/com.github.kagkarlsson/db-scheduler)
 [![License](http://img.shields.io/:license-apache-brightgreen.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 
 Task-scheduler for Java that was inspired by the need for a clustered `java.util.concurrent.ScheduledExecutorService` simpler than Quartz.
@@ -279,7 +279,7 @@ as they do not support descending indexes.
 #### Polling strategy
 
 If you are running >1000 executions/s you might want to use the `lock-and-fetch` polling-strategy for lower overhead
-and higher throughput ([read more](#polling-strategy-lock-and-fetch)). If not, the default `fetch-and-lock-on-execute` will be fine.
+and higher throughput ([read more](#polling-strategy-lock-and-fetch)). If not, the default `fetch-and-lock-on-execute` (configured as `fetch` in Fluent API and Spring Boot) will be fine.
 
 :gear: `.pollUsingFetchAndLockOnExecute(double, double)`<br/>
 Use default polling strategy `fetch-and-lock-on-execute`.<br/>
@@ -455,9 +455,6 @@ db-scheduler.enabled=true
 db-scheduler.heartbeat-interval=5m
 db-scheduler.missed-heartbeats-limit=6
 db-scheduler.polling-interval=10s
-db-scheduler.polling-strategy=fetch
-db-scheduler.polling-strategy-lower-limit-fraction-of-threads=0.5
-db-scheduler.polling-strategy-upper-limit-fraction-of-threads=3.0
 db-scheduler.table-name=scheduled_tasks
 db-scheduler.immediate-execution-enabled=false
 db-scheduler.scheduler-name=
@@ -467,7 +464,7 @@ db-scheduler.priority-enabled=false
 # Ignored if a custom DbSchedulerStarter bean is defined
 db-scheduler.delay-startup-until-context-ready=false
 
-db-scheduler.polling-strategy=fetch
+db-scheduler.polling-strategy=fetch # fetch-and-lock-on-execute (default)
 db-scheduler.polling-strategy-lower-limit-fraction-of-threads=0.5
 db-scheduler.polling-strategy-upper-limit-fraction-of-threads=3.0
 
@@ -608,7 +605,7 @@ Observations for these tests:
   * seem to consistently handle 10k executions/s for these configurations
   * throughput did not scale with postgres instance-size (4-8 core), so bottleneck is somewhere else
 
-Currently, polling strategy `lock-and-fetch` is implemented only for Postgres. Contributions adding support for more databases are welcome.
+Currently, polling strategy `lock-and-fetch` is implemented only for Postgres (single statement mode), SQL Server and MySQL v8+ (generic mode). Contributions adding support for more databases are welcome.
 
 ### User testimonial
 

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerConfigurationSupport.java
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerConfigurationSupport.java
@@ -78,7 +78,7 @@ public final class DbSchedulerConfigurationSupport {
     builder.pollingInterval(config.getPollingInterval());
 
     if (config.getPollingStrategy() == PollingStrategyConfig.Type.FETCH) {
-      builder.pollUsingFetchAndLockOnExecute(
+      builder.pollUsingFetch(
           config.getPollingStrategyLowerLimitFractionOfThreads(),
           config.getPollingStrategyUpperLimitFractionOfThreads());
     } else if (config.getPollingStrategy() == PollingStrategyConfig.Type.LOCK_AND_FETCH) {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
@@ -198,7 +198,16 @@ public class SchedulerBuilder {
     return this;
   }
 
+  /**
+   * @deprecated use {@link SchedulerBuilder#pollUsingFetch} instead.
+   */
+  @Deprecated
   public SchedulerBuilder pollUsingFetchAndLockOnExecute(
+      double lowerLimitFractionOfThreads, double executionsPerBatchFractionOfThreads) {
+    return pollUsingFetch(lowerLimitFractionOfThreads, executionsPerBatchFractionOfThreads);
+  }
+
+  public SchedulerBuilder pollUsingFetch(
       double lowerLimitFractionOfThreads, double executionsPerBatchFractionOfThreads) {
     this.pollingStrategyConfig =
         new PollingStrategyConfig(

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/CompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/CompatibilityTest.java
@@ -142,7 +142,7 @@ public abstract class CompatibilityTest {
     SchedulerBuilder builder =
         Scheduler.create(getDataSource(), Lists.newArrayList(oneTime, recurring))
             .pollingInterval(Duration.ofMillis(10))
-            .pollUsingFetchAndLockOnExecute(0, UPPER_LIMIT_FRACTION_OF_THREADS_FOR_FETCH)
+            .pollUsingFetch(0, UPPER_LIMIT_FRACTION_OF_THREADS_FOR_FETCH)
             .heartbeatInterval(Duration.ofMillis(100))
             .schedulerName(new SchedulerName.Fixed("test"))
             .addSchedulerListener(testableListener)

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/PostgresqlGenericLockAndFetchCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/PostgresqlGenericLockAndFetchCompatibilityTest.java
@@ -7,12 +7,12 @@ import java.util.Optional;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class PostgresqlGenericFetchAndLockCompatibilityTest extends CompatibilityTest {
+public class PostgresqlGenericLockAndFetchCompatibilityTest extends CompatibilityTest {
 
   @RegisterExtension
   public EmbeddedPostgresqlExtension postgres = new EmbeddedPostgresqlExtension();
 
-  public PostgresqlGenericFetchAndLockCompatibilityTest() {
+  public PostgresqlGenericLockAndFetchCompatibilityTest() {
     super(true, true);
   }
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/concurrent/MssqlClusterTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/concurrent/MssqlClusterTest.java
@@ -78,7 +78,7 @@ public class MssqlClusterTest {
           ClusterTests.testConcurrencyForPollingStrategy(
               pooledDatasource,
               (SchedulerBuilder b) -> {
-                b.pollUsingFetchAndLockOnExecute(0, NUMBER_OF_THREADS * 3);
+                b.pollUsingFetch(0, NUMBER_OF_THREADS * 3);
                 b.jdbcCustomization(new MssqlJdbcCustomization());
               },
               stopScheduler);

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/concurrent/PostgresClusterTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/concurrent/PostgresClusterTest.java
@@ -36,7 +36,7 @@ public class PostgresClusterTest {
     DEBUG_LOG.info("Starting test_concurrency_optimistic_locking");
     testConcurrencyForPollingStrategy(
         DB.getDataSource(),
-        (SchedulerBuilder b) -> b.pollUsingFetchAndLockOnExecute(0, NUMBER_OF_THREADS * 3),
+        (SchedulerBuilder b) -> b.pollUsingFetch(0, NUMBER_OF_THREADS * 3),
         stopScheduler);
   }
 

--- a/test/benchmark/src/main/java/com/github/kagkarlsson/App.java
+++ b/test/benchmark/src/main/java/com/github/kagkarlsson/App.java
@@ -46,8 +46,8 @@ public class App {
 
         Scheduler scheduler = Scheduler.create(ds, task1)
             .pollUsingLockAndFetch(0.5, 4.0)
-//            .pollUsingFetchAndLockOnExecute(6, 40.0)
-//            .pollUsingFetchAndLockOnExecute(0.5, 4.0)
+//            .pollUsingFetch(6, 40.0)
+//            .pollUsingFetch(0.5, 4.0)
             .statsRegistry(new BenchmarkStatsRegistry(metrics))
             .threads(50)
             .build();


### PR DESCRIPTION
## Clarify polling strategy naming between documentation and Spring Boot config and additional readme refactoring
The polling strategy is referred to as `fetch-and-lock-on-execute` in the main documentation, but configured as `fetch` in Fluent API and Spring Boot application.properties. 
Specifying `fetch-and-lock-on-execute` in Spring configuration results in startup failure cause the enum expects `FETCH` or `LOCK_AND_FETCH`:
```
***************************
APPLICATION FAILED TO START
***************************

Description:

Failed to bind properties under 'db-scheduler.polling-strategy' to com.github.kagkarlsson.scheduler.PollingStrategyConfig$Type:

    Property: db-scheduler.polling-strategy
    Value: "fetch-and-lock-on-execute"
    Origin: class path resource [application.properties] - 26:31
    Reason: failed to convert java.lang.String to com.github.kagkarlsson.scheduler.PollingStrategyConfig$Type (caused by java.lang.IllegalArgumentException: No enum constant com.github.kagkarlsson.scheduler.PollingStrategyConfig.Type.fetch-and-lock-on-execute)

Action:

Update your application's configuration. The following values are valid:

    FETCH
    LOCK_AND_FETCH
```
This inconsistency can be confusing for users. Changing the property name from `fetch` to `fetch-and-lock-on-execute` would constitute a breaking change for existing users.  Therefore, renaming `fetch-and-lock-on-execute` to `fetch` is the optimal variant  solution — it requires only documentation updates and the deprecation of one scheduler method.

## Fixes

This PR establishes clear consistency between the two:
- Renames polling strategy `fetch-and-lock-on-execute` to `fetch` in `‎README.md` and scheduler builder. For backward compatibility `builder.pollUsingFetchAndLockOnExecute` method is marked as deprecated 
- Adds "SQL Server, MySQL v8+" to the lock-and-fetch description in the Benchmark test. In the pollUsingLockAndFetch config description, these databases are already listed.

Also additional refactoring:
- Removes duplicate polling strategy properties in Spring Boot example
- Replaces corrupted herokuapp Maven Central badge with modern Shields.io badge. Update link to point to central.sonatype.com

Documentation is updated to clarify the mapping, helping users avoid this error.

## Reminders

- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`

---

cc @kagkarlsson
