### PR TITLE
fix: custom deadExecution applying is fixed in builder executeStateful

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/Tasks.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/Tasks.java
@@ -239,7 +239,7 @@ public class Tasks {
     public RecurringTaskWithPersistentSchedule<T> executeStateful(
         StateReturningExecutionHandler<T> executionHandler) {
       return new RecurringTaskWithPersistentSchedule<>(
-          name, dataClass, onFailure, defaultPriority) {
+          name, dataClass, onFailure, onDeadExecution, defaultPriority) {
 
         @Override
         public CompletionHandler<T> execute(

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTaskWithPersistentScheduleTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/task/helper/RecurringTaskWithPersistentScheduleTest.java
@@ -5,7 +5,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.github.kagkarlsson.scheduler.serializer.jackson.ScheduleAndDataForTest;
 import com.github.kagkarlsson.scheduler.task.DeadExecutionHandler;
 import com.github.kagkarlsson.scheduler.task.Priority;
+import com.github.kagkarlsson.scheduler.task.helper.Tasks.RecurringTaskWithPersistentScheduleBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class RecurringTaskWithPersistentScheduleTest {
 
@@ -29,27 +32,43 @@ class RecurringTaskWithPersistentScheduleTest {
     assertEquals(Priority.LOW, recurringTask.getDefaultPriority());
   }
 
-  @Test
-  public void should_have_ReviveDeadExecution_as_default_DeadExecutionHandler() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void should_have_ReviveDeadExecution_as_default_DeadExecutionHandler(
+      boolean statefulExecution) {
+    var recurringTaskBuilder =
+        Tasks.recurringWithPersistentSchedule("name", ScheduleAndDataForTest.class);
     RecurringTaskWithPersistentSchedule<ScheduleAndDataForTest> recurringTask =
-        Tasks.recurringWithPersistentSchedule("name", ScheduleAndDataForTest.class)
-            .execute((taskInstance, executionContext) -> new ScheduleAndDataForTest(null, null));
+        getRecurringTask(statefulExecution, recurringTaskBuilder);
 
     assertEquals(
         DeadExecutionHandler.ReviveDeadExecution.class,
         recurringTask.getDeadExecutionHandler().getClass());
   }
 
-  @Test
-  public void should_overwrite_DeadExecutionHandler() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void should_overwrite_DeadExecutionHandler(boolean statefulExecution) {
     DeadExecutionHandler<ScheduleAndDataForTest> deadExecutionHandler =
         new DeadExecutionHandler.CancelDeadExecution<>();
 
-    RecurringTaskWithPersistentSchedule<ScheduleAndDataForTest> recurringTask =
+    var recurringTaskBuilder =
         Tasks.recurringWithPersistentSchedule("name", ScheduleAndDataForTest.class)
-            .onDeadExecution(deadExecutionHandler)
-            .execute((taskInstance, executionContext) -> new ScheduleAndDataForTest(null, null));
+            .onDeadExecution(deadExecutionHandler);
+    RecurringTaskWithPersistentSchedule<ScheduleAndDataForTest> recurringTask =
+        getRecurringTask(statefulExecution, recurringTaskBuilder);
 
     assertEquals(deadExecutionHandler, recurringTask.getDeadExecutionHandler());
+  }
+
+  private static RecurringTaskWithPersistentSchedule<ScheduleAndDataForTest> getRecurringTask(
+      boolean statefulExecution,
+      RecurringTaskWithPersistentScheduleBuilder<ScheduleAndDataForTest> recurringTaskBuilder) {
+    if (statefulExecution) {
+      return recurringTaskBuilder.executeStateful(
+          (taskInstance, executionContext) -> new ScheduleAndDataForTest(null, null));
+    }
+    return recurringTaskBuilder.execute(
+        (taskInstance, executionContext) -> new ScheduleAndDataForTest(null, null));
   }
 }


### PR DESCRIPTION
## Custom `DeadExecutionHandler` is not applied in executeStateful
Custom DeadExecutionHandler is not applied in `executeStateful`, which leads to unpredictable behavior when the builder is configured with a custom `DeadExecutionHandler`, but the default handler is applied during housekeeping. This appears to have been overlooked in the recent changes [here](https://github.com/kagkarlsson/db-scheduler/pull/713).

## Fixes

#790 

## Reminders

- [x] Added/ran automated tests
- [x] Ran `mvn spotless:apply`

---

cc @kagkarlsson
