### PR TITLE
refactor: helper for updating rows (executions)

### DIFF
--- a/db-scheduler/pom.xml
+++ b/db-scheduler/pom.xml
@@ -24,6 +24,7 @@
     <bytebuddy.version>1.17.8</bytebuddy.version>
     <zonky-pg-embedded.version>2.1.1</zonky-pg-embedded.version>
     <slf4j.version>1.7.36</slf4j.version>
+    <assertj.version>3.27.6</assertj.version>
     <test.excludedTags>compatibility,compatibility-cluster</test.excludedTags>
   </properties>
 
@@ -78,6 +79,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
     </dependency>
     <!-- Shaded -->
     <dependency>
@@ -165,6 +170,12 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
@@ -25,6 +25,7 @@ import com.github.kagkarlsson.scheduler.jdbc.JdbcCustomization;
 import com.github.kagkarlsson.scheduler.jdbc.JdbcTaskRepository;
 import com.github.kagkarlsson.scheduler.serializer.Serializer;
 import com.github.kagkarlsson.scheduler.task.Execution;
+import com.github.kagkarlsson.scheduler.task.RescheduleUpdate;
 import com.github.kagkarlsson.scheduler.task.SchedulableInstance;
 import com.github.kagkarlsson.scheduler.task.ScheduledTaskInstance;
 import com.github.kagkarlsson.scheduler.task.Task;
@@ -554,12 +555,17 @@ public interface SchedulerClient {
         throw new TaskInstanceCurrentlyExecutingException(taskName, instanceId);
       }
 
-      boolean success;
-      if (newData == null) {
-        success = taskRepository.reschedule(execution, newExecutionTime, null, null, 0);
-      } else {
-        success = taskRepository.reschedule(execution, newExecutionTime, newData, null, null, 0);
+      RescheduleUpdate.Builder rescheduleUpdate =
+          RescheduleUpdate.toExecutionTime(newExecutionTime)
+              .lastSuccess(null)
+              .lastFailure(null)
+              .consecutiveFailures(0);
+
+      if (newData != null) {
+        rescheduleUpdate.data(newData);
       }
+
+      boolean success = taskRepository.reschedule(execution, rescheduleUpdate.build());
 
       if (success) {
         schedulerListeners.onExecutionScheduled(taskInstanceId, newExecutionTime);

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
@@ -14,6 +14,7 @@
 package com.github.kagkarlsson.scheduler;
 
 import com.github.kagkarlsson.scheduler.task.Execution;
+import com.github.kagkarlsson.scheduler.task.RescheduleUpdate;
 import com.github.kagkarlsson.scheduler.task.SchedulableInstance;
 import com.github.kagkarlsson.scheduler.task.ScheduledTaskInstance;
 import com.github.kagkarlsson.scheduler.task.TaskInstanceId;
@@ -65,6 +66,8 @@ public interface TaskRepository {
   List<Execution> lockAndGetDue(Instant now, int limit);
 
   void remove(Execution execution);
+
+  boolean reschedule(Execution execution, RescheduleUpdate rescheduleUpdate);
 
   boolean reschedule(
       Execution execution,

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/exceptions/ExecutionException.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/exceptions/ExecutionException.java
@@ -25,8 +25,7 @@ public class ExecutionException extends TaskInstanceException {
     this.version = execution.version;
   }
 
-  public ExecutionException(
-      String message, String taskName, String instanceId, long version) {
+  public ExecutionException(String message, String taskName, String instanceId, long version) {
     super(message, taskName, instanceId);
     this.version = version;
   }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/exceptions/ExecutionException.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/exceptions/ExecutionException.java
@@ -25,6 +25,12 @@ public class ExecutionException extends TaskInstanceException {
     this.version = execution.version;
   }
 
+  public ExecutionException(
+      String message, String taskName, String instanceId, long version) {
+    super(message, taskName, instanceId);
+    this.version = version;
+  }
+
   public ExecutionException(String message, Execution execution, Throwable ex) {
     super(message, execution.taskInstance.getTaskName(), execution.taskInstance.getId(), ex);
     this.version = execution.version;

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/ExecutionUpdate.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/ExecutionUpdate.java
@@ -15,8 +15,7 @@ package com.github.kagkarlsson.scheduler.jdbc;
 
 import static java.util.stream.Collectors.joining;
 
-import com.github.kagkarlsson.jdbc.PreparedStatementSetter;
-import com.github.kagkarlsson.scheduler.exceptions.TaskInstanceException;
+import com.github.kagkarlsson.scheduler.exceptions.ExecutionException;
 import com.github.kagkarlsson.scheduler.task.Execution;
 import com.github.kagkarlsson.scheduler.task.TaskInstanceId;
 import java.sql.PreparedStatement;
@@ -96,64 +95,28 @@ class ExecutionUpdate {
   }
 
   void updateSingle(JdbcConfig jdbcConfig) {
-    var setColumns = new ArrayList<String>();
-    var setValues = new ArrayList<PreparedStatementParameterSetter>();
+    var updates = new ArrayList<ColumnUpdate>();
 
-    if (executionTime != null) {
-      setColumns.add("execution_time");
-      setValues.add(
-          (ps, index) -> {
-            jdbcConfig.customization().setInstant(ps, index, executionTime.value);
-          });
-    }
+    addIfSet(executionTime, "execution_time", updates,
+        (ps, index) -> jdbcConfig.customization().setInstant(ps, index, executionTime.value));
+    addIfSet(taskData, "task_data", updates,
+        (ps, index) -> jdbcConfig.customization().setTaskData(ps, index, taskData.value));
+    addIfSet(picked, "picked", updates,
+        (ps, index) -> ps.setBoolean(index, toPrimitive(picked.value)));
+    addIfSet(pickedBy, "picked_by", updates,
+        (ps, index) -> ps.setString(index, pickedBy.value));
+    addIfSet(lastSuccess, "last_success", updates,
+        (ps, index) -> jdbcConfig.customization().setInstant(ps, index, lastSuccess.value));
+    addIfSet(lastFailure, "last_failure", updates,
+        (ps, index) -> jdbcConfig.customization().setInstant(ps, index, lastFailure.value));
+    addIfSet(consecutiveFailures, "consecutive_failures", updates,
+        (ps, index) -> ps.setInt(index, zeroIfNull(consecutiveFailures.value)));
+    addIfSet(lastHeartbeat, "last_heartbeat", updates,
+        (ps, index) -> jdbcConfig.customization().setInstant(ps, index, lastHeartbeat.value));
+    addIfSet(version, "version", updates,
+        (ps, index) -> ps.setLong(index, throwIfNull(version.value)));
 
-    if (taskData != null) {
-      setColumns.add("task_data");
-      setValues.add(
-          (ps, index) -> jdbcConfig.customization().setTaskData(ps, index, taskData.value));
-    }
-
-    if (picked != null) {
-      setColumns.add("picked");
-      setValues.add((ps, index) -> ps.setBoolean(index, toPrimitive(picked.value)));
-    }
-
-    if (pickedBy != null) {
-      setColumns.add("picked_by");
-      setValues.add((ps, index) -> ps.setString(index, pickedBy.value));
-    }
-
-    if (lastSuccess != null) {
-      setColumns.add("last_success");
-      setValues.add(
-          (ps, index) -> {
-            jdbcConfig.customization().setInstant(ps, index, lastSuccess.value);
-          });
-    }
-
-    if (lastFailure != null) {
-      setColumns.add("last_failure");
-      setValues.add(
-          (ps, index) -> jdbcConfig.customization().setInstant(ps, index, lastFailure.value));
-    }
-
-    if (consecutiveFailures != null) {
-      setColumns.add("consecutive_failures");
-      setValues.add((ps, index) -> ps.setInt(index, zeroIfNull(consecutiveFailures.value)));
-    }
-
-    if (lastHeartbeat != null) {
-      setColumns.add("last_heartbeat");
-      setValues.add(
-          (ps, index) -> jdbcConfig.customization().setInstant(ps, index, lastHeartbeat.value));
-    }
-
-    if (version != null) {
-      setColumns.add("version");
-      setValues.add((ps, index) -> ps.setLong(index, throwIfNull(version.value)));
-    }
-
-    if (setColumns.isEmpty()) {
+    if (updates.isEmpty()) {
       return;
     }
 
@@ -161,19 +124,36 @@ class ExecutionUpdate {
         "UPDATE "
             + jdbcConfig.tableName()
             + " SET "
-            + setColumns.stream().map(name -> name + " = ?").collect(joining(", "))
+            + updates.stream().map(u -> u.column + " = ?").collect(joining(", "))
             + " WHERE task_name = ? AND task_instance = ? AND version = ?";
-    setValues.add((ps, index) -> ps.setString(index, taskInstance.getTaskName()));
-    setValues.add((ps, index) -> ps.setString(index, taskInstance.getId()));
-    setValues.add((ps, index) -> ps.setLong(index, versionToUpdate));
 
     LOG.debug("ExecutionUpdate query: {}", query);
-    int updatedRows = jdbcConfig.runner().execute(query, toPreparedStatementSetter(setValues));
+    int updatedRows =
+        jdbcConfig.runner().execute(query, ps -> {
+          int index = 1;
+          for (ColumnUpdate update : updates) {
+            update.setter.setParameter(ps, index++);
+          }
+          ps.setString(index++, taskInstance.getTaskName());
+          ps.setString(index++, taskInstance.getId());
+          ps.setLong(index, versionToUpdate);
+        });
     if (updatedRows != 1) {
-      throw new TaskInstanceException(
+      throw new ExecutionException(
           "Expected one execution to be updated, but updated " + updatedRows + ". Indicates a bug.",
           taskInstance.getTaskName(),
-          taskInstance.getId());
+          taskInstance.getId(),
+          versionToUpdate);
+    }
+  }
+
+  private void addIfSet(
+      @Nullable NewValue<?> field,
+      String column,
+      List<ColumnUpdate> updates,
+      PreparedStatementParameterSetter setter) {
+    if (field != null) {
+      updates.add(new ColumnUpdate(column, setter));
     }
   }
 
@@ -196,15 +176,7 @@ class ExecutionUpdate {
     return value != null ? value : 0;
   }
 
-  private PreparedStatementSetter toPreparedStatementSetter(
-      List<PreparedStatementParameterSetter> setters) {
-    return preparedStatement -> {
-      int index = 1;
-      for (PreparedStatementParameterSetter setValue : setters) {
-        setValue.setParameter(preparedStatement, index++);
-      }
-    };
-  }
+  record ColumnUpdate(String column, PreparedStatementParameterSetter setter) {}
 
   interface PreparedStatementParameterSetter {
     void setParameter(PreparedStatement preparedStatement, int index) throws SQLException;

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/ExecutionUpdate.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/ExecutionUpdate.java
@@ -97,24 +97,41 @@ class ExecutionUpdate {
   void updateSingle(JdbcConfig jdbcConfig) {
     var updates = new ArrayList<ColumnUpdate>();
 
-    addIfSet(executionTime, "execution_time", updates,
+    addIfSet(
+        executionTime,
+        "execution_time",
+        updates,
         (ps, index) -> jdbcConfig.customization().setInstant(ps, index, executionTime.value));
-    addIfSet(taskData, "task_data", updates,
+    addIfSet(
+        taskData,
+        "task_data",
+        updates,
         (ps, index) -> jdbcConfig.customization().setTaskData(ps, index, taskData.value));
-    addIfSet(picked, "picked", updates,
-        (ps, index) -> ps.setBoolean(index, toPrimitive(picked.value)));
-    addIfSet(pickedBy, "picked_by", updates,
-        (ps, index) -> ps.setString(index, pickedBy.value));
-    addIfSet(lastSuccess, "last_success", updates,
+    addIfSet(
+        picked, "picked", updates, (ps, index) -> ps.setBoolean(index, toPrimitive(picked.value)));
+    addIfSet(pickedBy, "picked_by", updates, (ps, index) -> ps.setString(index, pickedBy.value));
+    addIfSet(
+        lastSuccess,
+        "last_success",
+        updates,
         (ps, index) -> jdbcConfig.customization().setInstant(ps, index, lastSuccess.value));
-    addIfSet(lastFailure, "last_failure", updates,
+    addIfSet(
+        lastFailure,
+        "last_failure",
+        updates,
         (ps, index) -> jdbcConfig.customization().setInstant(ps, index, lastFailure.value));
-    addIfSet(consecutiveFailures, "consecutive_failures", updates,
+    addIfSet(
+        consecutiveFailures,
+        "consecutive_failures",
+        updates,
         (ps, index) -> ps.setInt(index, zeroIfNull(consecutiveFailures.value)));
-    addIfSet(lastHeartbeat, "last_heartbeat", updates,
+    addIfSet(
+        lastHeartbeat,
+        "last_heartbeat",
+        updates,
         (ps, index) -> jdbcConfig.customization().setInstant(ps, index, lastHeartbeat.value));
-    addIfSet(version, "version", updates,
-        (ps, index) -> ps.setLong(index, throwIfNull(version.value)));
+    addIfSet(
+        version, "version", updates, (ps, index) -> ps.setLong(index, throwIfNull(version.value)));
 
     if (updates.isEmpty()) {
       return;
@@ -129,15 +146,19 @@ class ExecutionUpdate {
 
     LOG.debug("ExecutionUpdate query: {}", query);
     int updatedRows =
-        jdbcConfig.runner().execute(query, ps -> {
-          int index = 1;
-          for (ColumnUpdate update : updates) {
-            update.setter.setParameter(ps, index++);
-          }
-          ps.setString(index++, taskInstance.getTaskName());
-          ps.setString(index++, taskInstance.getId());
-          ps.setLong(index, versionToUpdate);
-        });
+        jdbcConfig
+            .runner()
+            .execute(
+                query,
+                ps -> {
+                  int index = 1;
+                  for (ColumnUpdate update : updates) {
+                    update.setter.setParameter(ps, index++);
+                  }
+                  ps.setString(index++, taskInstance.getTaskName());
+                  ps.setString(index++, taskInstance.getId());
+                  ps.setLong(index, versionToUpdate);
+                });
     if (updatedRows != 1) {
       throw new ExecutionException(
           "Expected one execution to be updated, but updated " + updatedRows + ". Indicates a bug.",

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/ExecutionUpdate.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/ExecutionUpdate.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) Gustav Karlsson
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.kagkarlsson.scheduler.jdbc;
+
+import static java.util.stream.Collectors.joining;
+
+import com.github.kagkarlsson.jdbc.PreparedStatementSetter;
+import com.github.kagkarlsson.scheduler.exceptions.TaskInstanceException;
+import com.github.kagkarlsson.scheduler.task.Execution;
+import com.github.kagkarlsson.scheduler.task.TaskInstanceId;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@NullMarked
+class ExecutionUpdate {
+  private static final Logger LOG = LoggerFactory.getLogger(ExecutionUpdate.class);
+
+  private final Long versionToUpdate;
+  private final TaskInstanceId taskInstance;
+  @Nullable private NewValue<byte[]> taskData;
+  @Nullable private NewValue<Instant> executionTime;
+  @Nullable private NewValue<Boolean> picked;
+  @Nullable private NewValue<String> pickedBy;
+  @Nullable private NewValue<Instant> lastSuccess;
+  @Nullable private NewValue<Instant> lastFailure;
+  @Nullable private NewValue<Integer> consecutiveFailures;
+  @Nullable private NewValue<Instant> lastHeartbeat;
+  @Nullable private final NewValue<Long> version;
+
+  ExecutionUpdate(TaskInstanceId taskInstance, Long versionToUpdate) {
+    this.taskInstance = taskInstance;
+    this.versionToUpdate = versionToUpdate;
+    this.version = new NewValue<>(versionToUpdate + 1);
+  }
+
+  static ExecutionUpdate forExecution(Execution execution) {
+    return new ExecutionUpdate(execution.taskInstance, execution.version);
+  }
+
+  ExecutionUpdate executionTime(@Nullable Instant executionTime) {
+    this.executionTime = new NewValue<>(executionTime);
+    return this;
+  }
+
+  ExecutionUpdate taskData(byte[] taskData) {
+    this.taskData = new NewValue<>(taskData);
+    return this;
+  }
+
+  ExecutionUpdate picked(boolean picked) {
+    this.picked = new NewValue<>(picked);
+    return this;
+  }
+
+  ExecutionUpdate pickedBy(@Nullable String pickedBy) {
+    this.pickedBy = new NewValue<>(pickedBy);
+    return this;
+  }
+
+  ExecutionUpdate lastSuccess(@Nullable Instant lastSuccess) {
+    this.lastSuccess = new NewValue<>(lastSuccess);
+    return this;
+  }
+
+  ExecutionUpdate lastFailure(@Nullable Instant lastFailure) {
+    this.lastFailure = new NewValue<>(lastFailure);
+    return this;
+  }
+
+  ExecutionUpdate consecutiveFailures(@Nullable Integer consecutiveFailures) {
+    this.consecutiveFailures = new NewValue<>(consecutiveFailures);
+    return this;
+  }
+
+  ExecutionUpdate lastHeartbeat(@Nullable Instant lastHeartbeat) {
+    this.lastHeartbeat = new NewValue<>(lastHeartbeat);
+    return this;
+  }
+
+  void updateSingle(JdbcConfig jdbcConfig) {
+    var setColumns = new ArrayList<String>();
+    var setValues = new ArrayList<PreparedStatementParameterSetter>();
+
+    if (executionTime != null) {
+      setColumns.add("execution_time");
+      setValues.add(
+          (ps, index) -> {
+            jdbcConfig.customization().setInstant(ps, index, executionTime.value);
+          });
+    }
+
+    if (taskData != null) {
+      setColumns.add("task_data");
+      setValues.add(
+          (ps, index) -> jdbcConfig.customization().setTaskData(ps, index, taskData.value));
+    }
+
+    if (picked != null) {
+      setColumns.add("picked");
+      setValues.add((ps, index) -> ps.setBoolean(index, toPrimitive(picked.value)));
+    }
+
+    if (pickedBy != null) {
+      setColumns.add("picked_by");
+      setValues.add((ps, index) -> ps.setString(index, pickedBy.value));
+    }
+
+    if (lastSuccess != null) {
+      setColumns.add("last_success");
+      setValues.add(
+          (ps, index) -> {
+            jdbcConfig.customization().setInstant(ps, index, lastSuccess.value);
+          });
+    }
+
+    if (lastFailure != null) {
+      setColumns.add("last_failure");
+      setValues.add(
+          (ps, index) -> jdbcConfig.customization().setInstant(ps, index, lastFailure.value));
+    }
+
+    if (consecutiveFailures != null) {
+      setColumns.add("consecutive_failures");
+      setValues.add((ps, index) -> ps.setInt(index, zeroIfNull(consecutiveFailures.value)));
+    }
+
+    if (lastHeartbeat != null) {
+      setColumns.add("last_heartbeat");
+      setValues.add(
+          (ps, index) -> jdbcConfig.customization().setInstant(ps, index, lastHeartbeat.value));
+    }
+
+    if (version != null) {
+      setColumns.add("version");
+      setValues.add((ps, index) -> ps.setLong(index, throwIfNull(version.value)));
+    }
+
+    if (setColumns.isEmpty()) {
+      return;
+    }
+
+    String query =
+        "UPDATE "
+            + jdbcConfig.tableName()
+            + " SET "
+            + setColumns.stream().map(name -> name + " = ?").collect(joining(", "))
+            + " WHERE task_name = ? AND task_instance = ? AND version = ?";
+    setValues.add((ps, index) -> ps.setString(index, taskInstance.getTaskName()));
+    setValues.add((ps, index) -> ps.setString(index, taskInstance.getId()));
+    setValues.add((ps, index) -> ps.setLong(index, versionToUpdate));
+
+    LOG.debug("ExecutionUpdate query: {}", query);
+    int updatedRows = jdbcConfig.runner().execute(query, toPreparedStatementSetter(setValues));
+    if (updatedRows != 1) {
+      throw new TaskInstanceException(
+          "Expected one execution to be updated, but updated " + updatedRows + ". Indicates a bug.",
+          taskInstance.getTaskName(),
+          taskInstance.getId());
+    }
+  }
+
+  private boolean toPrimitive(@Nullable Boolean value) {
+    if (value == null) {
+      throw new IllegalArgumentException("Value should never be null");
+    }
+    return value;
+  }
+
+  private long throwIfNull(@Nullable Long value) {
+    if (value != null) {
+      return value;
+    } else {
+      throw new IllegalArgumentException("value cannot be null");
+    }
+  }
+
+  private int zeroIfNull(@Nullable Integer value) {
+    return value != null ? value : 0;
+  }
+
+  private PreparedStatementSetter toPreparedStatementSetter(
+      List<PreparedStatementParameterSetter> setters) {
+    return preparedStatement -> {
+      int index = 1;
+      for (PreparedStatementParameterSetter setValue : setters) {
+        setValue.setParameter(preparedStatement, index++);
+      }
+    };
+  }
+
+  interface PreparedStatementParameterSetter {
+    void setParameter(PreparedStatement preparedStatement, int index) throws SQLException;
+  }
+
+  record NewValue<T>(@Nullable T value) {
+
+    public static <T> NewValue<T> of(T value) {
+      return new NewValue<>(value);
+    }
+  }
+}

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcConfig.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcConfig.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) Gustav Karlsson
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.kagkarlsson.scheduler.jdbc;
+
+import com.github.kagkarlsson.jdbc.JdbcRunner;
+
+record JdbcConfig(String tableName, JdbcRunner runner, JdbcCustomization customization) {}

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
@@ -537,8 +537,6 @@ public class JdbcTaskRepository implements TaskRepository {
     return true;
   }
 
-
-
   @Override
   public Optional<Execution> pick(Execution e, Instant timePicked) {
     final int updated =

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
@@ -66,6 +66,7 @@ public class JdbcTaskRepository implements TaskRepository {
   private final Serializer serializer;
   private final String tableName;
   private final JdbcCustomization jdbcCustomization;
+  private final JdbcConfig jdbcConfig;
   private final boolean orderByPriority;
   private final Clock clock;
 
@@ -146,6 +147,7 @@ public class JdbcTaskRepository implements TaskRepository {
     this.jdbcRunner = jdbcRunner;
     this.serializer = serializer;
     this.jdbcCustomization = jdbcCustomization;
+    this.jdbcConfig = new JdbcConfig(tableName, jdbcRunner, jdbcCustomization);
     this.orderByPriority = orderByPriority;
     this.clock = clock;
     this.insertQuery = getInsertQuery(tableName);
@@ -481,8 +483,16 @@ public class JdbcTaskRepository implements TaskRepository {
       Instant lastSuccess,
       Instant lastFailure,
       int consecutiveFailures) {
-    return rescheduleInternal(
-        execution, nextExecutionTime, null, lastSuccess, lastFailure, consecutiveFailures);
+    ExecutionUpdate update = ExecutionUpdate.forExecution(execution);
+    update.picked(false);
+    update.pickedBy(null);
+    update.lastHeartbeat(null);
+    update.executionTime(nextExecutionTime);
+    update.lastSuccess(lastSuccess);
+    update.lastFailure(lastFailure);
+    update.consecutiveFailures(consecutiveFailures);
+    update.updateSingle(jdbcConfig);
+    return true;
   }
 
   @Override
@@ -493,63 +503,16 @@ public class JdbcTaskRepository implements TaskRepository {
       Instant lastSuccess,
       Instant lastFailure,
       int consecutiveFailures) {
-    return rescheduleInternal(
-        execution,
-        nextExecutionTime,
-        new NewData(newData),
-        lastSuccess,
-        lastFailure,
-        consecutiveFailures);
-  }
-
-  private boolean rescheduleInternal(
-      Execution execution,
-      Instant nextExecutionTime,
-      NewData newData,
-      Instant lastSuccess,
-      Instant lastFailure,
-      int consecutiveFailures) {
-    final int updated =
-        jdbcRunner.execute(
-            "update "
-                + tableName
-                + " set "
-                + "picked = ?, "
-                + "picked_by = ?, "
-                + "last_heartbeat = ?, "
-                + "last_success = ?, "
-                + "last_failure = ?, "
-                + "consecutive_failures = ?, "
-                + "execution_time = ?, "
-                + (newData != null ? "task_data = ?, " : "")
-                + "version = version + 1 "
-                + "where task_name = ? "
-                + "and task_instance = ? "
-                + "and version = ?",
-            ps -> {
-              int index = 1;
-              ps.setBoolean(index++, false);
-              ps.setString(index++, null);
-              jdbcCustomization.setInstant(ps, index++, null);
-              jdbcCustomization.setInstant(ps, index++, lastSuccess);
-              jdbcCustomization.setInstant(ps, index++, lastFailure);
-              ps.setInt(index++, consecutiveFailures);
-              jdbcCustomization.setInstant(ps, index++, nextExecutionTime);
-              if (newData != null) {
-                // may cause datbase-specific problems, might have to use setNull instead
-                // FIXLATER: optionally support bypassing serializer if byte[] already
-                jdbcCustomization.setTaskData(ps, index++, serializer.serialize(newData.data));
-              }
-              ps.setString(index++, execution.taskInstance.getTaskName());
-              ps.setString(index++, execution.taskInstance.getId());
-              ps.setLong(index, execution.version);
-            });
-
-    if (updated != 1) {
-      throw new ExecutionException(
-          "Expected one execution to be updated, but updated " + updated + ". Indicates a bug.",
-          execution);
-    }
+    ExecutionUpdate update = ExecutionUpdate.forExecution(execution);
+    update.picked(false);
+    update.pickedBy(null);
+    update.lastHeartbeat(null);
+    update.executionTime(nextExecutionTime);
+    update.lastSuccess(lastSuccess);
+    update.lastFailure(lastFailure);
+    update.consecutiveFailures(consecutiveFailures);
+    update.taskData(serializer.serialize(newData));
+    update.updateSingle(jdbcConfig);
     return true;
   }
 
@@ -877,15 +840,6 @@ public class JdbcTaskRepository implements TaskRepository {
 
       Supplier<T> delegate = this::firstTime;
     };
-  }
-
-  private static class NewData {
-
-    private final Object data;
-
-    NewData(Object data) {
-      this.data = data;
-    }
   }
 
   static class UnresolvedFilter implements AndCondition {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
@@ -34,6 +34,7 @@ import com.github.kagkarlsson.scheduler.exceptions.FailedToScheduleBatchExceptio
 import com.github.kagkarlsson.scheduler.exceptions.TaskInstanceException;
 import com.github.kagkarlsson.scheduler.serializer.Serializer;
 import com.github.kagkarlsson.scheduler.task.Execution;
+import com.github.kagkarlsson.scheduler.task.RescheduleUpdate;
 import com.github.kagkarlsson.scheduler.task.SchedulableInstance;
 import com.github.kagkarlsson.scheduler.task.ScheduledTaskInstance;
 import com.github.kagkarlsson.scheduler.task.Task;
@@ -477,22 +478,45 @@ public class JdbcTaskRepository implements TaskRepository {
   }
 
   @Override
+  public boolean reschedule(Execution execution, RescheduleUpdate rescheduleUpdate) {
+    ExecutionUpdate update = ExecutionUpdate.forExecution(execution);
+
+    update.picked(false);
+    update.pickedBy(null);
+    update.lastHeartbeat(null);
+    update.executionTime(rescheduleUpdate.executionTime());
+
+    if (rescheduleUpdate.lastSuccess() != null) {
+      update.lastSuccess(rescheduleUpdate.lastSuccess().value());
+    }
+    if (rescheduleUpdate.lastFailure() != null) {
+      update.lastFailure(rescheduleUpdate.lastFailure().value());
+    }
+    if (rescheduleUpdate.consecutiveFailures() != null) {
+      update.consecutiveFailures(rescheduleUpdate.consecutiveFailures().value());
+    }
+    if (rescheduleUpdate.data() != null) {
+      update.taskData(serializer.serialize(rescheduleUpdate.data().value()));
+    }
+
+    update.updateSingle(jdbcConfig);
+    return true;
+  }
+
+  @Override
   public boolean reschedule(
       Execution execution,
       Instant nextExecutionTime,
       Instant lastSuccess,
       Instant lastFailure,
       int consecutiveFailures) {
-    ExecutionUpdate update = ExecutionUpdate.forExecution(execution);
-    update.picked(false);
-    update.pickedBy(null);
-    update.lastHeartbeat(null);
-    update.executionTime(nextExecutionTime);
-    update.lastSuccess(lastSuccess);
-    update.lastFailure(lastFailure);
-    update.consecutiveFailures(consecutiveFailures);
-    update.updateSingle(jdbcConfig);
-    return true;
+    return reschedule(
+        execution,
+        RescheduleUpdate.toExecutionTime(nextExecutionTime)
+            .lastSuccess(lastSuccess)
+            .lastFailure(lastFailure)
+            .consecutiveFailures(consecutiveFailures)
+            .build());
   }
 
   @Override
@@ -503,17 +527,14 @@ public class JdbcTaskRepository implements TaskRepository {
       Instant lastSuccess,
       Instant lastFailure,
       int consecutiveFailures) {
-    ExecutionUpdate update = ExecutionUpdate.forExecution(execution);
-    update.picked(false);
-    update.pickedBy(null);
-    update.lastHeartbeat(null);
-    update.executionTime(nextExecutionTime);
-    update.lastSuccess(lastSuccess);
-    update.lastFailure(lastFailure);
-    update.consecutiveFailures(consecutiveFailures);
-    update.taskData(serializer.serialize(newData));
-    update.updateSingle(jdbcConfig);
-    return true;
+    return reschedule(
+        execution,
+        RescheduleUpdate.toExecutionTime(nextExecutionTime)
+            .data(newData)
+            .lastSuccess(lastSuccess)
+            .lastFailure(lastFailure)
+            .consecutiveFailures(consecutiveFailures)
+            .build());
   }
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
@@ -478,32 +478,6 @@ public class JdbcTaskRepository implements TaskRepository {
   }
 
   @Override
-  public boolean reschedule(Execution execution, RescheduleUpdate rescheduleUpdate) {
-    ExecutionUpdate update = ExecutionUpdate.forExecution(execution);
-
-    update.picked(false);
-    update.pickedBy(null);
-    update.lastHeartbeat(null);
-    update.executionTime(rescheduleUpdate.executionTime());
-
-    if (rescheduleUpdate.lastSuccess() != null) {
-      update.lastSuccess(rescheduleUpdate.lastSuccess().value());
-    }
-    if (rescheduleUpdate.lastFailure() != null) {
-      update.lastFailure(rescheduleUpdate.lastFailure().value());
-    }
-    if (rescheduleUpdate.consecutiveFailures() != null) {
-      update.consecutiveFailures(rescheduleUpdate.consecutiveFailures().value());
-    }
-    if (rescheduleUpdate.data() != null) {
-      update.taskData(serializer.serialize(rescheduleUpdate.data().value()));
-    }
-
-    update.updateSingle(jdbcConfig);
-    return true;
-  }
-
-  @Override
   public boolean reschedule(
       Execution execution,
       Instant nextExecutionTime,
@@ -536,6 +510,34 @@ public class JdbcTaskRepository implements TaskRepository {
             .consecutiveFailures(consecutiveFailures)
             .build());
   }
+
+  @Override
+  public boolean reschedule(Execution execution, RescheduleUpdate rescheduleUpdate) {
+    ExecutionUpdate update = ExecutionUpdate.forExecution(execution);
+
+    update.picked(false);
+    update.pickedBy(null);
+    update.lastHeartbeat(null);
+    update.executionTime(rescheduleUpdate.executionTime());
+
+    if (rescheduleUpdate.lastSuccess() != null) {
+      update.lastSuccess(rescheduleUpdate.lastSuccess().value());
+    }
+    if (rescheduleUpdate.lastFailure() != null) {
+      update.lastFailure(rescheduleUpdate.lastFailure().value());
+    }
+    if (rescheduleUpdate.consecutiveFailures() != null) {
+      update.consecutiveFailures(rescheduleUpdate.consecutiveFailures().value());
+    }
+    if (rescheduleUpdate.data() != null) {
+      update.taskData(serializer.serialize(rescheduleUpdate.data().value()));
+    }
+
+    update.updateSingle(jdbcConfig);
+    return true;
+  }
+
+
 
   @Override
   public Optional<Execution> pick(Execution e, Instant timePicked) {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/NewValue.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/NewValue.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) Gustav Karlsson
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.kagkarlsson.scheduler.task;
+
+import org.jspecify.annotations.Nullable;
+
+public record NewValue<T>(@Nullable T value) {}

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/RescheduleUpdate.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/RescheduleUpdate.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) Gustav Karlsson
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.kagkarlsson.scheduler.task;
+
+import java.time.Instant;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+public record RescheduleUpdate(
+    Instant executionTime,
+    @Nullable NewValue<Object> data,
+    @Nullable NewValue<Instant> lastSuccess,
+    @Nullable NewValue<Instant> lastFailure,
+    @Nullable NewValue<Integer> consecutiveFailures) {
+
+  public static Builder toExecutionTime(Instant executionTime) {
+    return new Builder(executionTime);
+  }
+
+  public static class Builder {
+    private final Instant executionTime;
+    @Nullable private NewValue<Object> data;
+    @Nullable private NewValue<Instant> lastSuccess;
+    @Nullable private NewValue<Instant> lastFailure;
+    @Nullable private NewValue<Integer> consecutiveFailures;
+
+    public Builder(Instant executionTime) {
+      this.executionTime = executionTime;
+    }
+
+    public Builder data(@Nullable Object data) {
+      this.data = new NewValue<>(data);
+      return this;
+    }
+
+    public Builder lastSuccess(@Nullable Instant lastSuccess) {
+      this.lastSuccess = new NewValue<>(lastSuccess);
+      return this;
+    }
+
+    public Builder lastFailure(@Nullable Instant lastFailure) {
+      this.lastFailure = new NewValue<>(lastFailure);
+      return this;
+    }
+
+    public Builder consecutiveFailures(int count) {
+      this.consecutiveFailures = new NewValue<>(count);
+      return this;
+    }
+
+    /** Convenience method for resetting to not-failing */
+    public Builder resetFailures() {
+      this.consecutiveFailures = new NewValue<>(0);
+      this.lastFailure = new NewValue<>(null);
+      return this;
+    }
+
+    public RescheduleUpdate build() {
+      return new RescheduleUpdate(
+          executionTime, data, lastSuccess, lastFailure, consecutiveFailures);
+    }
+  }
+}

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/jdbc/ExecutionUpdateTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/jdbc/ExecutionUpdateTest.java
@@ -1,0 +1,142 @@
+package com.github.kagkarlsson.scheduler.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.kagkarlsson.jdbc.JdbcRunner;
+import com.github.kagkarlsson.scheduler.EmbeddedPostgresqlExtension;
+import com.github.kagkarlsson.scheduler.SchedulerName.Fixed;
+import com.github.kagkarlsson.scheduler.SystemClock;
+import com.github.kagkarlsson.scheduler.TaskResolver;
+import com.github.kagkarlsson.scheduler.event.SchedulerListeners;
+import com.github.kagkarlsson.scheduler.serializer.JavaSerializer;
+import com.github.kagkarlsson.scheduler.task.Execution;
+import com.github.kagkarlsson.scheduler.task.ExecutionContext;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import com.github.kagkarlsson.scheduler.task.TaskInstanceId;
+import com.github.kagkarlsson.scheduler.task.helper.OneTimeTask;
+import com.github.kagkarlsson.scheduler.task.helper.Tasks;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class ExecutionUpdateTest {
+
+  private static final String TABLE = JdbcTaskRepository.DEFAULT_TABLE_NAME;
+  private static final String TASK_ID = "id-1";
+  private static final Instant AN_INSTANT = Instant.parse("2020-01-01T12:00:00.00Z");
+  private static final Instant ANOTHER_INSTANT = Instant.parse("2022-01-01T12:00:00.00Z");
+
+  private static final OneTimeTask<Void> ONETIME_TASK =
+      Tasks.oneTime("task-onetime")
+          .execute((TaskInstance<Void> taskInstance, ExecutionContext ctx) -> {});
+
+  private static final OneTimeTask<String> STRING_TASK =
+      Tasks.oneTime("string-tas", String.class)
+          .execute((TaskInstance<String> taskInstance, ExecutionContext ctx) -> {});
+
+  @RegisterExtension
+  public EmbeddedPostgresqlExtension postgres = new EmbeddedPostgresqlExtension();
+
+  private JdbcConfig jdbcConfig;
+  private JdbcTaskRepository repository;
+
+  @BeforeEach
+  public void setup() {
+    jdbcConfig =
+        new JdbcConfig(
+            TABLE,
+            new JdbcRunner(postgres.getDataSource()),
+            new PostgreSqlJdbcCustomization(true, false));
+    repository =
+        new JdbcTaskRepository(
+            postgres.getDataSource(),
+            false,
+            TABLE,
+            new TaskResolver(
+                new SchedulerListeners(), new SystemClock(), List.of(ONETIME_TASK, STRING_TASK)),
+            new Fixed("test"),
+            false,
+            new SystemClock());
+  }
+
+  @Test
+  void should_update_execution_time() {
+    Execution execution = insert(AN_INSTANT);
+    ExecutionUpdate.forExecution(execution).executionTime(ANOTHER_INSTANT).updateSingle(jdbcConfig);
+
+    assertThat(getExecution(execution).executionTime).isEqualTo(ANOTHER_INSTANT);
+  }
+
+  @Test
+  void should_update_last_success() {
+    Execution execution = insert(AN_INSTANT);
+    ExecutionUpdate.forExecution(execution).lastSuccess(ANOTHER_INSTANT).updateSingle(jdbcConfig);
+
+    assertThat(getExecution(execution).lastSuccess).isEqualTo(ANOTHER_INSTANT);
+  }
+
+  @Test
+  void should_update_last_failed() {
+    Execution execution = insert(AN_INSTANT);
+    ExecutionUpdate.forExecution(execution).lastFailure(ANOTHER_INSTANT).updateSingle(jdbcConfig);
+
+    assertThat(getExecution(execution).lastFailure).isEqualTo(ANOTHER_INSTANT);
+  }
+
+  @Test
+  void should_update_picked() {
+    Execution execution = insert(AN_INSTANT);
+    ExecutionUpdate.forExecution(execution).picked(true).updateSingle(jdbcConfig);
+
+    assertThat(getExecution(execution).picked).isTrue();
+  }
+
+  @Test
+  void should_update_picked_by() {
+    Execution execution = insert(AN_INSTANT);
+    ExecutionUpdate.forExecution(execution).pickedBy("scheduler-1").updateSingle(jdbcConfig);
+
+    assertThat(getExecution(execution).pickedBy).isEqualTo("scheduler-1");
+  }
+
+  @Test
+  void should_update_consecutive_failures() {
+    Execution execution = insert(AN_INSTANT);
+    ExecutionUpdate.forExecution(execution).consecutiveFailures(3).updateSingle(jdbcConfig);
+
+    assertThat(getExecution(execution).consecutiveFailures).isEqualTo(3);
+  }
+
+  @Test
+  void should_update_last_heartbeat() {
+    Execution execution = insert(AN_INSTANT);
+    ExecutionUpdate.forExecution(execution).lastHeartbeat(ANOTHER_INSTANT).updateSingle(jdbcConfig);
+
+    assertThat(getExecution(execution).lastHeartbeat).isEqualTo(ANOTHER_INSTANT);
+  }
+
+  @Test
+  void should_update_task_data() {
+    var instance =
+        STRING_TASK.instanceBuilder(TASK_ID).data("initial-data").scheduledTo(AN_INSTANT);
+    repository.createIfNotExists(instance);
+    Execution execution = repository.getExecution(instance).orElseThrow();
+
+    byte[] serializedData = new JavaSerializer().serialize("new-data");
+    ExecutionUpdate.forExecution(execution).taskData(serializedData).updateSingle(jdbcConfig);
+
+    assertThat(getExecution(execution).taskInstance.getData()).isEqualTo("new-data");
+  }
+
+  private Execution insert(Instant executionTime) {
+    var instance = ONETIME_TASK.instanceBuilder(TASK_ID).scheduledTo(executionTime);
+    repository.createIfNotExists(instance);
+    return getExecution(instance);
+  }
+
+  private Execution getExecution(TaskInstanceId instance) {
+    return repository.getExecution(instance).orElseThrow();
+  }
+}

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepositoryExceptionsTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepositoryExceptionsTest.java
@@ -14,6 +14,7 @@ import com.github.kagkarlsson.jdbc.SQLRuntimeException;
 import com.github.kagkarlsson.scheduler.SystemClock;
 import com.github.kagkarlsson.scheduler.exceptions.ExecutionException;
 import com.github.kagkarlsson.scheduler.exceptions.TaskInstanceException;
+import com.github.kagkarlsson.scheduler.serializer.Serializer;
 import com.github.kagkarlsson.scheduler.task.Execution;
 import com.github.kagkarlsson.scheduler.task.SchedulableTaskInstance;
 import com.github.kagkarlsson.scheduler.task.TaskInstance;
@@ -42,7 +43,14 @@ public class JdbcTaskRepositoryExceptionsTest {
     expectedTableName = randomAlphanumeric(5);
     jdbcTaskRepository =
         new JdbcTaskRepository(
-            null, expectedTableName, null, null, null, mockJdbcRunner, false, new SystemClock());
+            new DefaultJdbcCustomization(false),
+            expectedTableName,
+            null,
+            null,
+            Serializer.DEFAULT_JAVA_SERIALIZER,
+            mockJdbcRunner,
+            false,
+            new SystemClock());
   }
 
   @Test
@@ -153,30 +161,16 @@ public class JdbcTaskRepositoryExceptionsTest {
   @ValueSource(ints = {0, 2})
   public void rescheduleUpdatesUnexpectedNumberOfRowsWithoutNewData(int updateCount) {
     when(mockJdbcRunner.execute(
-            ArgumentMatchers.eq(
-                "update "
-                    + expectedTableName
-                    + " set "
-                    + "picked = ?, "
-                    + "picked_by = ?, "
-                    + "last_heartbeat = ?, "
-                    + "last_success = ?, "
-                    + "last_failure = ?, "
-                    + "consecutive_failures = ?, "
-                    + "execution_time = ?, "
-                    + "version = version + 1 "
-                    + "where task_name = ? "
-                    + "and task_instance = ? "
-                    + "and version = ?"),
+            ArgumentMatchers.startsWith("UPDATE " + expectedTableName + " SET "),
             any(PreparedStatementSetter.class)))
         .thenReturn(updateCount);
 
     TaskInstance<Void> taskInstance =
         new TaskInstance<>(randomAlphanumeric(10), randomAlphanumeric(10));
     Execution execution = new Execution(Instant.now(), taskInstance);
-    ExecutionException actualException =
+    TaskInstanceException actualException =
         assertThrows(
-            ExecutionException.class,
+            TaskInstanceException.class,
             () -> {
               jdbcTaskRepository.reschedule(execution, Instant.now(), null, null, 0);
             });
@@ -189,7 +183,6 @@ public class JdbcTaskRepositoryExceptionsTest {
             + taskInstance.getId()
             + ")",
         actualException.getMessage());
-    assertEquals(execution.version, actualException.getVersion());
     assertEquals(execution.taskInstance.getTaskName(), actualException.getTaskName());
     assertEquals(execution.taskInstance.getId(), actualException.getInstanceId());
   }
@@ -198,31 +191,16 @@ public class JdbcTaskRepositoryExceptionsTest {
   @ValueSource(ints = {0, 2})
   public void rescheduleUpdatesUnexpectedNumberOfRowsWithNewData(int updateCount) {
     when(mockJdbcRunner.execute(
-            ArgumentMatchers.eq(
-                "update "
-                    + expectedTableName
-                    + " set "
-                    + "picked = ?, "
-                    + "picked_by = ?, "
-                    + "last_heartbeat = ?, "
-                    + "last_success = ?, "
-                    + "last_failure = ?, "
-                    + "consecutive_failures = ?, "
-                    + "execution_time = ?, "
-                    + "task_data = ?, "
-                    + "version = version + 1 "
-                    + "where task_name = ? "
-                    + "and task_instance = ? "
-                    + "and version = ?"),
+            ArgumentMatchers.startsWith("UPDATE " + expectedTableName + " SET "),
             any(PreparedStatementSetter.class)))
         .thenReturn(updateCount);
 
     TaskInstance<Void> taskInstance =
         new TaskInstance<>(randomAlphanumeric(10), randomAlphanumeric(10));
     Execution execution = new Execution(Instant.now(), taskInstance);
-    ExecutionException actualException =
+    TaskInstanceException actualException =
         assertThrows(
-            ExecutionException.class,
+            TaskInstanceException.class,
             () -> {
               jdbcTaskRepository.reschedule(execution, Instant.now(), "", null, null, 0);
             });
@@ -235,7 +213,6 @@ public class JdbcTaskRepositoryExceptionsTest {
             + taskInstance.getId()
             + ")",
         actualException.getMessage());
-    assertEquals(execution.version, actualException.getVersion());
     assertEquals(execution.taskInstance.getTaskName(), actualException.getTaskName());
     assertEquals(execution.taskInstance.getId(), actualException.getInstanceId());
   }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepositoryExceptionsTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepositoryExceptionsTest.java
@@ -168,9 +168,9 @@ public class JdbcTaskRepositoryExceptionsTest {
     TaskInstance<Void> taskInstance =
         new TaskInstance<>(randomAlphanumeric(10), randomAlphanumeric(10));
     Execution execution = new Execution(Instant.now(), taskInstance);
-    TaskInstanceException actualException =
+    ExecutionException actualException =
         assertThrows(
-            TaskInstanceException.class,
+            ExecutionException.class,
             () -> {
               jdbcTaskRepository.reschedule(execution, Instant.now(), null, null, 0);
             });
@@ -183,6 +183,7 @@ public class JdbcTaskRepositoryExceptionsTest {
             + taskInstance.getId()
             + ")",
         actualException.getMessage());
+    assertEquals(execution.version, actualException.getVersion());
     assertEquals(execution.taskInstance.getTaskName(), actualException.getTaskName());
     assertEquals(execution.taskInstance.getId(), actualException.getInstanceId());
   }
@@ -198,9 +199,9 @@ public class JdbcTaskRepositoryExceptionsTest {
     TaskInstance<Void> taskInstance =
         new TaskInstance<>(randomAlphanumeric(10), randomAlphanumeric(10));
     Execution execution = new Execution(Instant.now(), taskInstance);
-    TaskInstanceException actualException =
+    ExecutionException actualException =
         assertThrows(
-            TaskInstanceException.class,
+            ExecutionException.class,
             () -> {
               jdbcTaskRepository.reschedule(execution, Instant.now(), "", null, null, 0);
             });
@@ -213,6 +214,7 @@ public class JdbcTaskRepositoryExceptionsTest {
             + taskInstance.getId()
             + ")",
         actualException.getMessage());
+    assertEquals(execution.version, actualException.getVersion());
     assertEquals(execution.taskInstance.getTaskName(), actualException.getTaskName());
     assertEquals(execution.taskInstance.getId(), actualException.getInstanceId());
   }

--- a/pom.xml
+++ b/pom.xml
@@ -99,11 +99,11 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-        <dependency>
-            <groupId>org.jspecify</groupId>
-            <artifactId>jspecify</artifactId>
-            <version>1.0.0</version>
-        </dependency>
+      <dependency>
+        <groupId>org.jspecify</groupId>
+        <artifactId>jspecify</artifactId>
+        <version>1.0.0</version>
+      </dependency>
       <!-- Override to make testcontainers work on M1 -->
       <dependency>
         <groupId>net.java.dev.jna</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <version>1.0.0</version>
+        </dependency>
       <!-- Override to make testcontainers work on M1 -->
       <dependency>
         <groupId>net.java.dev.jna</groupId>


### PR DESCRIPTION
Introduces `ExecutionUpdate` to make updates to executions a bit less messy and easier to mix and match fields to update.