### PR TITLE
fix: lock-and-fetch unresolved first task picked state is fixed

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
@@ -17,6 +17,7 @@ import static com.github.kagkarlsson.scheduler.ExecutorUtils.defaultThreadFactor
 import static com.github.kagkarlsson.scheduler.Scheduler.THREAD_PREFIX;
 import static java.util.Optional.ofNullable;
 
+import com.github.kagkarlsson.scheduler.PollingStrategyConfig.Type;
 import com.github.kagkarlsson.scheduler.event.ExecutionInterceptor;
 import com.github.kagkarlsson.scheduler.event.SchedulerListener;
 import com.github.kagkarlsson.scheduler.event.SchedulerListeners;
@@ -299,6 +300,11 @@ public class SchedulerBuilder {
 
     if (statsRegistry != null) {
       addSchedulerListener(new StatsRegistryAdapter(statsRegistry));
+    }
+
+    if (pollingStrategyConfig.type == Type.LOCK_AND_FETCH) {
+      addSchedulerListener(
+          new UnresolvedTasksLockAndFetchListener(schedulerTaskRepository, taskResolver));
     }
 
     Waiter waiter = buildWaiter();

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
@@ -21,6 +21,7 @@ import com.github.kagkarlsson.scheduler.task.TaskInstanceId;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -85,6 +86,8 @@ public interface TaskRepository {
       int consecutiveFailures);
 
   Optional<Execution> pick(Execution e, Instant timePicked);
+
+  List<String> unpickUnresolved(Collection<String> unresolvedTaskNames);
 
   List<Execution> getDeadExecutions(Instant olderThan);
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskResolver.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskResolver.java
@@ -75,6 +75,10 @@ public class TaskResolver {
     return new ArrayList<>(unresolvedTasks.values());
   }
 
+  public boolean isUnresolved(String taskName) {
+    return unresolvedTasks.containsKey(taskName);
+  }
+
   public List<String> getUnresolvedTaskNames(Duration unresolvedFor) {
     return unresolvedTasks.values().stream()
         .filter(
@@ -89,7 +93,7 @@ public class TaskResolver {
     unresolvedTasks.remove(taskName);
   }
 
-  public class UnresolvedTask {
+  public static class UnresolvedTask {
 
     private final String taskName;
     private final Instant firstUnresolved;
@@ -101,6 +105,10 @@ public class TaskResolver {
 
     public String getTaskName() {
       return taskName;
+    }
+
+    public Instant getFirstUnresolved() {
+      return firstUnresolved;
     }
   }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/UnresolvedTasksLockAndFetchListener.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/UnresolvedTasksLockAndFetchListener.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) Gustav Karlsson
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.kagkarlsson.scheduler;
+
+import com.github.kagkarlsson.scheduler.TaskResolver.UnresolvedTask;
+import com.github.kagkarlsson.scheduler.event.AbstractSchedulerListener;
+import com.github.kagkarlsson.scheduler.jdbc.JdbcTaskRepository;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Scheduler listener that handles unresolved tasks during rolling updates in LOCK_AND_FETCH .
+ *
+ * <p>When a task type becomes unresolved (e.g., not registered in the current scheduler instance
+ * due to a rolling update where new versions don't have the task yet), this listener automatically
+ * releases (unpicks) those tasks so they can be processed by other scheduler instances that have
+ * the task type available (this behavior is already built-in for FETCH mode out of the box).
+ *
+ * @see com.github.kagkarlsson.scheduler.TaskResolver
+ * @see
+ *     com.github.kagkarlsson.scheduler.jdbc.JdbcTaskRepository#unpickUnresolved(java.util.Collection)
+ */
+class UnresolvedTasksLockAndFetchListener extends AbstractSchedulerListener {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(UnresolvedTasksLockAndFetchListener.class);
+  private final JdbcTaskRepository schedulerTaskRepository;
+  private final TaskResolver taskResolver;
+
+  private final List<String> refusedTasks = new CopyOnWriteArrayList<>();
+
+  public UnresolvedTasksLockAndFetchListener(
+      JdbcTaskRepository schedulerTaskRepository, TaskResolver taskResolver) {
+    this.schedulerTaskRepository = schedulerTaskRepository;
+    this.taskResolver = taskResolver;
+  }
+
+  @Override
+  public void onSchedulerEvent(SchedulerEventType type) {
+    if (type == SchedulerEventType.UNRESOLVED_TASK) {
+      final List<String> unresolvedTaskNames =
+          taskResolver.getUnresolved().stream()
+              .map(UnresolvedTask::getTaskName)
+              .filter(taskName -> !refusedTasks.contains(taskName))
+              .toList();
+      unpickUnresolvedTasks(unresolvedTaskNames);
+    }
+  }
+
+  private void unpickUnresolvedTasks(List<String> unresolvedTaskNames) {
+    if (unresolvedTaskNames.isEmpty()) {
+      LOG.debug("No new unresolved tasks to unpick");
+      return;
+    }
+
+    try {
+      final List<String> unpickedTaskNames =
+          schedulerTaskRepository.unpickUnresolved(unresolvedTaskNames);
+      refusedTasks.addAll(unpickedTaskNames);
+      LOG.debug("Unresolved tasks unpicked: {}", unpickedTaskNames);
+    } catch (Exception ex) {
+      LOG.error("Error occurred during task unpicking", ex);
+    }
+  }
+}

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
@@ -45,6 +45,7 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -576,6 +577,53 @@ public class JdbcTaskRepository implements TaskRepository {
           "Updated multiple rows when picking single execution. Should never happen since name and id is primary key. Execution: "
               + e);
     }
+  }
+
+  @Override
+  public List<String> unpickUnresolved(Collection<String> unresolvedTaskNames) {
+    final List<UnresolvedTask> unresolvedTasks =
+        taskResolver.getUnresolved().stream()
+            .filter(unresolvedTask -> unresolvedTaskNames.contains(unresolvedTask.getTaskName()))
+            .toList();
+
+    if (unresolvedTasks.isEmpty()) {
+      LOG.debug("No unresolved tasks to unpick");
+      return new ArrayList<>();
+    }
+
+    final int[] updated =
+        jdbcRunner.executeBatch(
+            "update "
+                + tableName
+                + " set picked = ?, version = version + 1 "
+                + "where picked = ? "
+                + "and task_name = ? "
+                + "and picked_by = ? "
+                + "and execution_time = ?",
+            unresolvedTasks,
+            (unresolvedTask, ps) -> {
+              int index = 1;
+              ps.setBoolean(index++, false);
+              ps.setBoolean(index++, true);
+              ps.setString(index++, unresolvedTask.getTaskName());
+              ps.setString(index++, truncate(schedulerSchedulerName.getName(), 50));
+              jdbcCustomization.setInstant(ps, index, unresolvedTask.getFirstUnresolved());
+            });
+
+    final List<String> taskNames = new ArrayList<>();
+    for (int i = 0; i < updated.length; i++) {
+      String taskName = unresolvedTasks.get(i).getTaskName();
+      if (updated[i] == 1) {
+        taskNames.add(taskName);
+      } else {
+        LOG.error(
+            "Error during unresolved task {} unpicking: expected 1 updated row but got {}",
+            taskName,
+            updated[i]);
+      }
+    }
+    LOG.info("Successfully unpicked unresolved tasks: {}", taskNames);
+    return taskNames;
   }
 
   @Override

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
@@ -7,8 +7,10 @@ import static java.time.Duration.ofDays;
 import static java.time.Duration.ofMinutes;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
@@ -30,6 +32,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -52,6 +55,8 @@ public class JdbcTaskRepositoryTest {
   private OneTimeTask<Void> oneTimeTask;
   private OneTimeTask<Void> alternativeOneTimeTask;
   private OneTimeTask<Integer> oneTimeTaskWithData;
+  private OneTimeTask<?> unknownOneTimeTask;
+  private OneTimeTask<?> unknownAlternativeOneTimeTask;
   private TaskResolver taskResolver;
   private TestableListener testableListener;
 
@@ -60,6 +65,9 @@ public class JdbcTaskRepositoryTest {
     oneTimeTask = TestTasks.oneTime("OneTime", Void.class, TestTasks.DO_NOTHING);
     alternativeOneTimeTask =
         TestTasks.oneTime("AlternativeOneTime", Void.class, TestTasks.DO_NOTHING);
+    unknownOneTimeTask = TestTasks.oneTime("UnknownOneTime", Void.class, TestTasks.DO_NOTHING);
+    unknownAlternativeOneTimeTask =
+        TestTasks.oneTime("UnknownAlternativeOneTime", Void.class, TestTasks.DO_NOTHING);
     oneTimeTaskWithData =
         TestTasks.oneTime("OneTimeWithData", Integer.class, new TestTasks.DoNothingHandler<>());
     List<Task<?>> knownTasks = new ArrayList<>();
@@ -536,6 +544,107 @@ public class JdbcTaskRepositoryTest {
     // should not be able to pick the same execution twice
     assertThat(taskRepository.lockAndFetchGeneric(now, POLLING_LIMIT), hasSize(0));
     assertThat(taskRepository.pick(picked.get(0), now), OptionalMatchers.empty());
+  }
+
+  @Test
+  public void unpickUnresolved_should_release_picked_tasks() {
+    Instant now = Instant.now();
+    TaskInstance<?> unknownOneTimeTaskInstance = unknownOneTimeTask.instance("task1");
+    TaskInstance<?> unknownAlternativeOneTimeTaskInstance =
+        unknownAlternativeOneTimeTask.instance("task2");
+
+    // Create unregistered (unknown) task instances
+    taskRepository.createIfNotExists(
+        new SchedulableTaskInstance<>(unknownOneTimeTaskInstance, now));
+    taskRepository.createIfNotExists(
+        new SchedulableTaskInstance<>(unknownAlternativeOneTimeTaskInstance, now));
+
+    // Try to pick the tasks (simulate adding to unresolved filter)
+    List<Execution> picked = taskRepository.lockAndGetDue(now, POLLING_LIMIT);
+    assertThat(picked, hasSize(0));
+    assertTrue(taskResolver.isUnresolved(unknownOneTimeTask.getName()));
+    assertTrue(taskResolver.isUnresolved(unknownAlternativeOneTimeTask.getName()));
+    assertTrue(taskRepository.getExecution(unknownOneTimeTaskInstance).orElseThrow().picked);
+    assertTrue(
+        taskRepository.getExecution(unknownAlternativeOneTimeTaskInstance).orElseThrow().picked);
+
+    List<String> unpicked =
+        taskRepository.unpickUnresolved(
+            Arrays.asList(unknownOneTimeTask.getName(), unknownAlternativeOneTimeTask.getName()));
+
+    assertThat(unpicked, hasSize(2));
+    assertThat(
+        unpicked,
+        containsInAnyOrder(unknownOneTimeTask.getName(), unknownAlternativeOneTimeTask.getName()));
+
+    assertFalse(taskRepository.getExecution(unknownOneTimeTaskInstance).orElseThrow().picked);
+    assertFalse(
+        taskRepository.getExecution(unknownAlternativeOneTimeTaskInstance).orElseThrow().picked);
+  }
+
+  @Test
+  public void unpickUnresolved_should_handle_single_task() {
+    Instant now = Instant.now();
+    TaskInstance<?> instance = unknownOneTimeTask.instance("id1");
+    taskRepository.createIfNotExists(new SchedulableTaskInstance<>(instance, now));
+
+    List<Execution> picked = taskRepository.lockAndGetDue(now, POLLING_LIMIT);
+    assertThat(picked, hasSize(0));
+    assertTrue(taskResolver.isUnresolved(unknownOneTimeTask.getName()));
+    assertTrue(taskRepository.getExecution(instance).orElseThrow().picked);
+
+    // Unpick single task
+    List<String> unpicked =
+        taskRepository.unpickUnresolved(Collections.singletonList(unknownOneTimeTask.getName()));
+
+    assertThat(unpicked, hasSize(1));
+    assertThat(unpicked, contains(unknownOneTimeTask.getName()));
+
+    assertFalse(taskRepository.getExecution(instance).orElseThrow().picked);
+  }
+
+  @Test
+  public void unpickUnresolved_should_return_empty_when_no_tasks_to_unpick() {
+    List<String> unpicked = taskRepository.unpickUnresolved(Collections.emptyList());
+    assertThat(unpicked, hasSize(0));
+  }
+
+  @Test
+  public void unpickUnresolved_should_ignore_existent_tasks() {
+    Instant now = Instant.now();
+    TaskInstance<Void> instance = oneTimeTask.instance("id1");
+
+    taskRepository.createIfNotExists(new SchedulableTaskInstance<>(instance, now));
+
+    List<Execution> picked = taskRepository.lockAndGetDue(now, POLLING_LIMIT);
+    assertThat(picked, hasSize(1));
+    assertTrue(taskRepository.getExecution(instance).orElseThrow().picked);
+
+    List<String> unpicked =
+        taskRepository.unpickUnresolved(Arrays.asList(oneTimeTask.getName(), "non_existent_task"));
+
+    assertThat(unpicked, hasSize(0));
+    assertThat(unpicked, not(contains(oneTimeTask.getName())));
+    assertTrue(taskRepository.getExecution(instance).orElseThrow().picked);
+  }
+
+  @Test
+  void unpickUnresolved_should_not_crash_when_unresolved_task_not_in_database() {
+    List<String> unpickedTasks =
+        taskRepository.unpickUnresolved(List.of("task-that-does-not-exist"));
+    assertThat(unpickedTasks, empty());
+  }
+
+  @Test
+  void unpickUnresolved_should_return_empty_list_when_no_unresolved_tasks_exist() {
+    List<String> unpickedTasks = taskRepository.unpickUnresolved(List.of("nonexistent-task"));
+    assertThat(unpickedTasks, empty());
+  }
+
+  @Test
+  void unpickUnresolved_should_handle_empty_collection_gracefully() {
+    List<String> unpickedTasks = taskRepository.unpickUnresolved(Collections.emptyList());
+    assertThat(unpickedTasks, empty());
   }
 
   private List<Execution> getScheduledExecutions(

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
@@ -1,11 +1,17 @@
 package com.github.kagkarlsson.scheduler;
 
-import static java.time.Duration.*;
+import static java.time.Duration.ZERO;
+import static java.time.Duration.between;
+import static java.time.Duration.ofHours;
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofMinutes;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import com.github.kagkarlsson.scheduler.SchedulerName.Fixed;
 import com.github.kagkarlsson.scheduler.task.ExecutionComplete;
 import com.github.kagkarlsson.scheduler.task.FailureHandler;
 import com.github.kagkarlsson.scheduler.task.Task;
@@ -337,5 +343,44 @@ public class SchedulerTest {
           lastScheduleTimeDifferenceFromFirstCall.getSeconds(),
           greaterThanOrEqualTo(expectedTimeDifferenceFromFirstCall.minusSeconds(1).getSeconds()));
     }
+  }
+
+  @Test
+  public void should_unpick_unresolved_tasks_during_rolling_update_in_lock_and_fetch() {
+    final TestTasks.CountingHandler<Void> knownTaskHandler = new TestTasks.CountingHandler<>();
+    final OneTimeTask<Void> knownTask =
+        TestTasks.oneTime("KnownTask", Void.class, knownTaskHandler);
+
+    final Scheduler scheduler =
+        Scheduler.create(postgres.getDataSource(), knownTask)
+            .threads(1)
+            .pollingInterval(ofMillis(100))
+            .schedulerName(new Fixed("rolling-update-test"))
+            .pollUsingLockAndFetch(1.0, 3.0)
+            .build();
+    stopScheduler.register(scheduler);
+
+    try {
+      executeKnownAndUnknownTasks(scheduler, knownTask); // first time picking
+      executeKnownAndUnknownTasks(scheduler, knownTask); // second time picking
+    } finally {
+      scheduler.stop();
+    }
+  }
+
+  private void executeKnownAndUnknownTasks(Scheduler scheduler, OneTimeTask<Void> knownTask) {
+    final TaskInstance<Void> unresolvedInstance1 =
+        new TaskInstance<>("UnresolvedTask1", "unresolved-1");
+    final TaskInstance<Void> unresolvedInstance2 =
+        new TaskInstance<>("UnresolvedTask2", "unresolved-2");
+
+    scheduler.schedule(knownTask.instance("known-1"), clock.now());
+    scheduler.schedule(unresolvedInstance1, clock.now());
+    scheduler.schedule(unresolvedInstance2, clock.now());
+
+    scheduler.executeDue();
+
+    assertFalse(scheduler.getScheduledExecution(unresolvedInstance1).orElseThrow().isPicked());
+    assertFalse(scheduler.getScheduledExecution(unresolvedInstance2).orElseThrow().isPicked());
   }
 }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/TaskResolverTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/TaskResolverTest.java
@@ -1,13 +1,20 @@
 package com.github.kagkarlsson.scheduler;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.github.kagkarlsson.scheduler.TaskResolver.UnresolvedTask;
 import com.github.kagkarlsson.scheduler.event.SchedulerListener;
 import com.github.kagkarlsson.scheduler.event.SchedulerListener.SchedulerEventType;
 import com.github.kagkarlsson.scheduler.event.SchedulerListeners;
 import com.github.kagkarlsson.scheduler.task.Execution;
 import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -29,5 +36,90 @@ class TaskResolverTest {
     taskResolver.resolve(new Execution(Instant.now(), new TaskInstance<Void>("unresolved", "id1")));
 
     verify(mockScheduleListener, times(1)).onSchedulerEvent(SchedulerEventType.UNRESOLVED_TASK);
+  }
+
+  @Test
+  void shouldReturnUnresolvedTasksWhenRequested() {
+    TaskResolver taskResolver =
+        new TaskResolver(
+            new SchedulerListeners(mockScheduleListener), new SystemClock(), List.of());
+
+    final Instant now = Instant.now();
+    taskResolver.resolve(new Execution(now, new TaskInstance<Void>("unresolved1", "id1")));
+    taskResolver.resolve(
+        new Execution(
+            now.plus(Duration.ofSeconds(10)), new TaskInstance<Void>("unresolved2", "id2")));
+
+    final List<UnresolvedTask> unresolved = taskResolver.getUnresolved();
+    assertThat(unresolved, hasSize(2));
+    assertThat(
+        unresolved.stream().map(TaskResolver.UnresolvedTask::getTaskName).toList(),
+        contains("unresolved1", "unresolved2"));
+  }
+
+  @Test
+  void shouldTrackFirstUnresolvedExecutionTime() {
+    TaskResolver taskResolver =
+        new TaskResolver(
+            new SchedulerListeners(mockScheduleListener), new SystemClock(), List.of());
+
+    final Instant firstTime = Instant.now();
+    final Instant secondTime = firstTime.plus(Duration.ofMinutes(5));
+
+    taskResolver.resolve(new Execution(firstTime, new TaskInstance<Void>("unresolved", "id1")));
+    taskResolver.resolve(new Execution(secondTime, new TaskInstance<Void>("unresolved", "id1")));
+
+    final List<UnresolvedTask> unresolved = taskResolver.getUnresolved();
+    assertThat(unresolved, hasSize(1));
+    assertThat(unresolved.get(0).getFirstUnresolved(), is(firstTime));
+  }
+
+  @Test
+  void shouldReturnUnresolvedTasksOlderThanSpecifiedDuration() {
+    TaskResolver taskResolver =
+        new TaskResolver(
+            new SchedulerListeners(mockScheduleListener), new SystemClock(), List.of());
+
+    final Instant now = Instant.now();
+    final Instant oldTime = now.minus(Duration.ofSeconds(20));
+    final Instant newTime = now.minus(Duration.ofSeconds(5));
+
+    taskResolver.resolve(new Execution(oldTime, new TaskInstance<Void>("old-unresolved", "id1")));
+    taskResolver.resolve(new Execution(newTime, new TaskInstance<Void>("new-unresolved", "id2")));
+
+    final List<String> oldUnresolvedNames =
+        taskResolver.getUnresolvedTaskNames(Duration.ofSeconds(10));
+    assertThat(oldUnresolvedNames, contains("old-unresolved"));
+  }
+
+  @Test
+  void shouldClearUnresolvedTaskWhenRequested() {
+    final TaskResolver taskResolver =
+        new TaskResolver(
+            new SchedulerListeners(mockScheduleListener), new SystemClock(), List.of());
+
+    final Instant now = Instant.now();
+    taskResolver.resolve(new Execution(now, new TaskInstance<Void>("unresolved", "id1")));
+    assertThat(taskResolver.getUnresolved(), hasSize(1));
+
+    taskResolver.clearUnresolved("unresolved");
+    assertThat(taskResolver.getUnresolved(), empty());
+  }
+
+  @Test
+  void shouldNotClearOtherUnresolvedTasksWhenClearingOne() {
+    final TaskResolver taskResolver =
+        new TaskResolver(
+            new SchedulerListeners(mockScheduleListener), new SystemClock(), List.of());
+
+    final Instant now = Instant.now();
+    taskResolver.resolve(new Execution(now, new TaskInstance<Void>("unresolved1", "id1")));
+    taskResolver.resolve(new Execution(now, new TaskInstance<Void>("unresolved2", "id2")));
+
+    taskResolver.clearUnresolved("unresolved1");
+
+    final List<UnresolvedTask> remaining = taskResolver.getUnresolved();
+    assertThat(remaining, hasSize(1));
+    assertThat(remaining.get(0).getTaskName(), is("unresolved2"));
   }
 }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/UnresolvedTasksLockAndFetchListenerTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/UnresolvedTasksLockAndFetchListenerTest.java
@@ -1,0 +1,153 @@
+package com.github.kagkarlsson.scheduler;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.kagkarlsson.scheduler.TaskResolver.UnresolvedTask;
+import com.github.kagkarlsson.scheduler.event.SchedulerListener.SchedulerEventType;
+import com.github.kagkarlsson.scheduler.jdbc.JdbcTaskRepository;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class UnresolvedTasksLockAndFetchListenerTest {
+
+  private final JdbcTaskRepository mockSchedulerTaskRepository = mock(JdbcTaskRepository.class);
+  private final TaskResolver mockTaskResolver = mock(TaskResolver.class);
+
+  private final UnresolvedTasksLockAndFetchListener listener =
+      new UnresolvedTasksLockAndFetchListener(mockSchedulerTaskRepository, mockTaskResolver);
+
+  @Test
+  void shouldNotCallRepositoryWhenEventTypeIsNotUNRESOLVED_TASK() {
+    when(mockTaskResolver.getUnresolved()).thenReturn(new ArrayList<>());
+
+    listener.onSchedulerEvent(SchedulerEventType.RAN_EXECUTE_DUE);
+
+    verify(mockSchedulerTaskRepository, never()).unpickUnresolved(anyCollection());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldCallUnpickUnresolvedWhenUNRESOLVED_TASKEventFired() {
+    List<UnresolvedTask> unresolvedTasks = List.of(new UnresolvedTask("Task1", Instant.now()));
+
+    when(mockTaskResolver.getUnresolved()).thenReturn(unresolvedTasks);
+    when(mockSchedulerTaskRepository.unpickUnresolved(anyCollection()))
+        .thenReturn(List.of("Task1"));
+
+    listener.onSchedulerEvent(SchedulerEventType.UNRESOLVED_TASK);
+
+    ArgumentCaptor<Collection<String>> captor = ArgumentCaptor.forClass(Collection.class);
+    verify(mockSchedulerTaskRepository).unpickUnresolved(captor.capture());
+
+    assertThat(captor.getValue(), contains("Task1"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldFilterOutRefusedTasksFromSecondCall() {
+    List<UnresolvedTask> unresolvedTasks = new ArrayList<>();
+    unresolvedTasks.add(new TaskResolver.UnresolvedTask("Task1", Instant.now()));
+    unresolvedTasks.add(new TaskResolver.UnresolvedTask("Task2", Instant.now()));
+
+    when(mockTaskResolver.getUnresolved()).thenReturn(unresolvedTasks);
+    when(mockSchedulerTaskRepository.unpickUnresolved(anyCollection()))
+        .thenReturn(List.of("Task1"));
+
+    // First call
+    listener.onSchedulerEvent(SchedulerEventType.UNRESOLVED_TASK);
+
+    verify(mockSchedulerTaskRepository).unpickUnresolved(anyCollection());
+
+    // Second call - Task1 should be filtered as refused
+    when(mockTaskResolver.getUnresolved()).thenReturn(unresolvedTasks);
+    when(mockSchedulerTaskRepository.unpickUnresolved(anyCollection())).thenReturn(List.of());
+
+    listener.onSchedulerEvent(SchedulerEventType.UNRESOLVED_TASK);
+
+    ArgumentCaptor<Collection<String>> captor = ArgumentCaptor.forClass(Collection.class);
+    verify(mockSchedulerTaskRepository, times(2)).unpickUnresolved(captor.capture());
+
+    // Second call should only have Task2
+    assertThat(captor.getValue(), contains("Task2"));
+  }
+
+  @Test
+  void shouldHandleEmptyUnresolvedListGracefully() {
+    when(mockTaskResolver.getUnresolved()).thenReturn(new ArrayList<>());
+
+    assertDoesNotThrow(() -> listener.onSchedulerEvent(SchedulerEventType.UNRESOLVED_TASK));
+
+    verify(mockSchedulerTaskRepository, never()).unpickUnresolved(anyCollection());
+  }
+
+  @Test
+  void shouldHandleRepositoryExceptionGracefully() {
+    List<UnresolvedTask> unresolvedTasks = new ArrayList<>();
+    unresolvedTasks.add(new TaskResolver.UnresolvedTask("Task1", Instant.now()));
+
+    when(mockTaskResolver.getUnresolved()).thenReturn(unresolvedTasks);
+    when(mockSchedulerTaskRepository.unpickUnresolved(anyCollection()))
+        .thenThrow(new RuntimeException("Database error"));
+
+    assertDoesNotThrow(() -> listener.onSchedulerEvent(SchedulerEventType.UNRESOLVED_TASK));
+
+    verify(mockSchedulerTaskRepository).unpickUnresolved(anyCollection());
+  }
+
+  @Test
+  void shouldNotRetryUnpickedTasksOnSubsequentEvents() {
+    List<UnresolvedTask> unresolvedTasks = new ArrayList<>();
+    unresolvedTasks.add(new TaskResolver.UnresolvedTask("Task1", Instant.now()));
+
+    when(mockTaskResolver.getUnresolved()).thenReturn(unresolvedTasks);
+    when(mockSchedulerTaskRepository.unpickUnresolved(anyCollection()))
+        .thenReturn(List.of("Task1"));
+
+    // First call - unpicks Task1
+    listener.onSchedulerEvent(SchedulerEventType.UNRESOLVED_TASK);
+
+    verify(mockSchedulerTaskRepository).unpickUnresolved(anyCollection());
+
+    // Second call with same unresolved task
+    when(mockTaskResolver.getUnresolved()).thenReturn(unresolvedTasks);
+    listener.onSchedulerEvent(SchedulerEventType.UNRESOLVED_TASK);
+
+    // Should not call repository again because Task1 is in refusedTasks
+    verify(mockSchedulerTaskRepository).unpickUnresolved(anyCollection());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldHandleMultipleUnresolvedTasksInSingleEvent() {
+    List<UnresolvedTask> unresolvedTasks =
+        List.of(
+            new TaskResolver.UnresolvedTask("Task1", Instant.now()),
+            new TaskResolver.UnresolvedTask("Task2", Instant.now()),
+            new TaskResolver.UnresolvedTask("Task3", Instant.now()));
+
+    when(mockTaskResolver.getUnresolved()).thenReturn(unresolvedTasks);
+    when(mockSchedulerTaskRepository.unpickUnresolved(anyCollection()))
+        .thenReturn(List.of("Task1", "Task2", "Task3"));
+
+    listener.onSchedulerEvent(SchedulerEventType.UNRESOLVED_TASK);
+
+    ArgumentCaptor<Collection<String>> captor = ArgumentCaptor.forClass(Collection.class);
+    verify(mockSchedulerTaskRepository).unpickUnresolved(captor.capture());
+
+    assertThat(captor.getValue(), hasSize(3));
+    assertThat(captor.getValue(), contains("Task1", "Task2", "Task3"));
+  }
+}


### PR DESCRIPTION
## Scheduler listener that handles unresolved tasks for LOCK_AND_FETCH mode is added
When a task type becomes unresolved (e.g., not registered in the current scheduler instance due to a rolling update where new versions don't have the task yet), this listener automatically releases (unpicks) those tasks so they can be processed by other scheduler instances that have the task type available (this behavior is already built-in 
for FETCH mode out of the box).

### Implementation Details

**Listener behavior:**
- Added to scheduler in builder only in LOCK_AND_FETCH mode
- Tracks previously unpicked task names to prevent duplicate queries
- Reduces unnecessary database operations

**Unpick operation:**
- Uses batch update to mark tasks as unpicked (picked=false with version increment)
- Records contain picker info (picked_by scheduler instance) and execution_time
- Allows other scheduler instances to pick up unresolved tasks

### Known Issue / Limitation

⚠️ **Current limitation:** If batch contains multiple unresolved **instances** of the same task, only the first instance is unpicked (cause only first unresolved task is recorded in TaskResolver as unresolved). TaskResolver needs to store all unresolved task instances (by taskName + executionTime), not just one per task name to unpick all possible unresolved tasks.

### Tests Added
Several additional tests are added to TaskResolverTest for better coverage.

## Fixes

https://github.com/kagkarlsson/db-scheduler/issues/804

## Reminders

- [x] Added/ran automated tests
- [x] Ran `mvn spotless:apply`

---

cc @kagkarlsson
