### PR TITLE
fix: remove duplicated "while" in heartbeat-failure log

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -456,7 +456,7 @@ public class Scheduler implements SchedulerClient {
       }
 
     } catch (Throwable ex) { // just-in-case to avoid any "poison-pills"
-      LOG.error("Unexpected failure while while updating heartbeat for execution {}.", e, ex);
+      LOG.error("Unexpected failure while updating heartbeat for execution {}.", e, ex);
       schedulerListeners.onSchedulerEvent(SchedulerEventType.FAILED_HEARTBEAT);
       schedulerListeners.onSchedulerEvent(SchedulerEventType.UNEXPECTED_ERROR);
       schedulerListeners.onExecutionFailedHeartbeat(currentlyExecuting);


### PR DESCRIPTION
## Brief, plain english overview of your changes here

Removes a duplicated "while" from the heartbeat-failure error log in `Scheduler.updateHeartbeatForExecution`. The message previously read "Unexpected failure while while updating heartbeat for execution ...".

The original `Unexpteced` → `Unexpected` typo flagged in the issue was already corrected in an earlier change; this PR addresses the remaining doubled word on the same line.

## Fixes

Closes #730

## Reminders

- [x] Added/ran automated tests (`mvn clean test` passes — no new tests needed for a log string fix)
- [ ] Update README and/or examples (N/A)
- [x] Ran `mvn spotless:apply`

---

cc @kagkarlsson