### PR TITLE
chore(deps): bump Spring Boot BOMs to pull in patched Jackson (fixes #805)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,11 +68,11 @@
     <!-- Dependency versions -->
     <slf4j.version>1.7.36</slf4j.version>
     <logback.version>1.2.13</logback.version>
-    <spring-boot.version>3.5.11</spring-boot.version>
-    <spring-boot-4.version>4.0.3</spring-boot-4.version>
+    <spring-boot.version>3.5.14</spring-boot.version>
+    <spring-boot-4.version>4.0.6</spring-boot-4.version>
     <micrometer.version>1.15.3</micrometer.version>
     <gson.version>2.13.2</gson.version>
-    <jackson.version>2.20.0</jackson.version>
+    <jackson.version>2.21.2</jackson.version>
     <postgresql.version>42.7.8</postgresql.version>
     <guava.version>33.5.0-jre</guava.version>
   </properties>


### PR DESCRIPTION
## Summary
- Bump `spring-boot-4.version` 4.0.3 → **4.0.6** (latest 4.0.x). Pulls `jackson-bom` 3.1.2, which is past the jackson-core 3.1.0 CVE fixed in 3.1.1 (FasterXML/jackson-core#1591).
- Bump `spring-boot.version` 3.5.11 → **3.5.14** (latest 3.5.x). Pulls `jackson-bom` 2.21.2.
- Bump `jackson.version` 2.20.0 → **2.21.2** in the core module so its directly-imported `jackson-bom` aligns with what the Spring Boot 3 starter resolves; avoids two competing Jackson 2.x versions on a consumer's classpath.

Pure version bumps — no source changes.

Closes #805.