### PR TITLE
build: disable JReleaser issue-marking on release

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -30,7 +30,10 @@ release:
         contributors:
           - 'GitHub'
     issues:
-      enabled: true
+      # Disabled: the conventional-commits preset extracts `#N` refs from
+      # dependabot commit bodies (upstream repos' release notes), so JReleaser
+      # ends up labelling/commenting on unrelated issues in this repo.
+      enabled: false
 
 signing:
   active: ALWAYS


### PR DESCRIPTION
The conventional-commits preset extracts `#N` refs from dependabot commit bodies (which paste upstream repos' release notes), so JReleaser labels and comments on unrelated issues in this repo. The v16.9.0 run touched 32 unrelated items and aborted with a 422 when one of them turned out to be a Discussion.

## Changes
- `jreleaser.yml`: set `release.github.issues.enabled: false` and add a comment explaining why.

---
This PR was prepared with Claude Code.