### PR TITLE
refactor: mdc logging interceptor is refactored in spring boot example

### DIFF
--- a/examples/spring-boot-example/src/main/java/com/github/kagkarlsson/examples/boot/config/SchedulerConfiguration.java
+++ b/examples/spring-boot-example/src/main/java/com/github/kagkarlsson/examples/boot/config/SchedulerConfiguration.java
@@ -13,14 +13,15 @@
  */
 package com.github.kagkarlsson.examples.boot.config;
 
+import com.github.kagkarlsson.scheduler.CurrentlyExecuting;
 import com.github.kagkarlsson.scheduler.SchedulerName;
 import com.github.kagkarlsson.scheduler.boot.autoconfigure.Jackson3Serializer;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerCustomizer;
 import com.github.kagkarlsson.scheduler.event.AbstractSchedulerListener;
-import com.github.kagkarlsson.scheduler.event.ExecutionInterceptor;
 import com.github.kagkarlsson.scheduler.event.SchedulerListener;
 import com.github.kagkarlsson.scheduler.serializer.Serializer;
 import com.github.kagkarlsson.scheduler.task.ExecutionComplete;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,8 +32,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SchedulerConfiguration {
 
-  public static final String MDC_TASKNAME = "task-name";
-  public static final String MDC_TASKINSTANCEID = "task-instance-id";
+  private static final String MDC_TASK_NAME = "task-name";
+  private static final String MDC_TASK_INSTANCE_ID = "task-instance-id";
   private static final Logger LOG = LoggerFactory.getLogger(SchedulerConfiguration.class);
 
   /** Bean defined when a configuration-property in DbSchedulerCustomizer needs to be overridden. */
@@ -52,30 +53,19 @@ public class SchedulerConfiguration {
   }
 
   @Bean
-  SchedulerListener schedulerListener() {
+  SchedulerListener mdcSchedulerListener() {
     return new AbstractSchedulerListener() {
+      @Override
+      public void onExecutionStart(CurrentlyExecuting executing) {
+        TaskInstance<?> taskInstance = executing.getTaskInstance();
+        MDC.put(MDC_TASK_NAME, taskInstance.getTaskName());
+        MDC.put(MDC_TASK_INSTANCE_ID, taskInstance.getId());
+      }
 
       @Override
       public void onExecutionComplete(ExecutionComplete executionComplete) {
-        LOG.info(
-            "SchedulerListener.onExecutionComplete. Result={}, took={}ms ",
-            executionComplete.getResult(),
-            executionComplete.getDuration().toMillis());
-      }
-    };
-  }
-
-  @Bean
-  ExecutionInterceptor mdcExecutionInterceptor() {
-    return (taskInstance, executionContext, chain) -> {
-      LOG.info("Setting MDC before execution");
-      MDC.put(MDC_TASKNAME, taskInstance.getTaskName());
-      MDC.put(MDC_TASKINSTANCEID, taskInstance.getId());
-      try {
-        return chain.proceed(taskInstance, executionContext);
-      } finally {
-        MDC.remove(MDC_TASKNAME);
-        MDC.remove(MDC_TASKINSTANCEID);
+        MDC.remove(MDC_TASK_NAME);
+        MDC.remove(MDC_TASK_INSTANCE_ID);
       }
     };
   }


### PR DESCRIPTION
## The current implementation of mdcExecutionInterceptor in the Spring examples contains issues

If we take the Spring example and copy `mdcExecutionInterceptor` to production, we lose `MDC` parameters in error and success handlers, which in a large number of logs leads to problems finding which job fails or what the problem is. Our and neighboring teams copied this interceptor from the examples and they had problems with error finding.

<img width="1055" height="397" alt="image" src="https://github.com/user-attachments/assets/d2fd012f-f231-4ba6-a34b-46ff5f9d14c2" />

In the image: **(1)** Task executes with MDC params, then they are cleared. **(2)** and **(3)** logs show no MDC parameters.

The changes in this MR show the correct `MDC` logging usage. The example will be clear for clients, and they will have no problems with `MDC` logging. 

The other solution could be changing or adding new interceptors, but this would require big architectural changes. The interceptor could be extended to wrap both execution and result handlers. This would be the best variant for cases where the task and its handlers need to be atomic in a single transaction (currently they run in two separate transactions).

## Problem example based on current implementation

If we upgrade `sampleOneTimeTask` in the Spring examples with retries and error results:

```java
/** Define a one-time task which has to be manually scheduled. */
@Bean
Task<Void> sampleOneTimeTask() {
  return Tasks.oneTime(BASIC_ONE_TIME_TASK)
    .onFailure(new OnFailureRetryLater<>(Duration.ZERO))
    .execute(
        (instance, ctx) -> {
          log.info("I am a one-time task!");
          throw new RuntimeException();
        });
}
```
and enable structured logging, we can see that `MDC` is cleared in retry logs:
```
{"version":"1.1","short_message":"I am a one-time task!","timestamp":1778960858.622,"level":6,"_level_name":"INFO","_process_pid":3128,"_process_thread_name":"db-scheduler-pool-2-thread-2","host":"spring-boot-example","_log_logger":"com.github.kagkarlsson.examples.boot.config.BasicExamplesConfiguration","_task-name":"sample-one-time-task","_task-instance-id":"command-line-runner"}
{"version":"1.1","short_message":"Unhandled exception RuntimeException during execution of task with name 'sample-one-time-task'. Treating as failure.","timestamp":1778960858.624,"level":4,"_level_name":"WARN","_process_pid":3128,"_process_thread_name":"db-scheduler-pool-2-thread-2","host":"spring-boot-example","_log_logger":"com.github.kagkarlsson.scheduler.Scheduler","full_message":"Unhandled exception RuntimeException during execution of task with name 'sample-one-time-task'. Treating as failure.\n\njava.lang.RuntimeException\r\n\tat com.github.kagkarlsson.examples.boot.config.BasicExamplesConfiguration.lambda$sampleOneTimeTask$0(BasicExamplesConfiguration.java:77)\r\n\tat com.github.kagkarlsson.scheduler.task.helper.Tasks$OneTimeTaskBuilder$1.executeOnce(Tasks.java:303)\r\n\tat com.github.kagkarlsson.scheduler.task.helper.OneTimeTask.execute(OneTimeTask.java:68)\r\n\tat com.github.kagkarlsson.scheduler.event.ExecutionChain.proceed(ExecutionChain.java:37)\r\n\tat com.github.kagkarlsson.examples.boot.config.SchedulerConfiguration.lambda$mdcExecutionInterceptor$0(SchedulerConfiguration.java:75)\r\n\tat com.github.kagkarlsson.scheduler.event.ExecutionChain.proceed(ExecutionChain.java:41)\r\n\tat com.github.kagkarlsson.scheduler.ExecutePicked.executePickedExecution(ExecutePicked.java:113)\r\n\tat com.github.kagkarlsson.scheduler.ExecutePicked.run(ExecutePicked.java:89)\r\n\tat com.github.kagkarlsson.scheduler.FetchCandidates.lambda$run$2(FetchCandidates.java:117)\r\n\tat java.base/java.util.Optional.ifPresent(Optional.java:178)\r\n\tat com.github.kagkarlsson.scheduler.FetchCandidates.lambda$run$1(FetchCandidates.java:103)\r\n\tat com.github.kagkarlsson.scheduler.Executor.lambda$addToQueue$0(Executor.java:53)\r\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095)\r\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619)\r\n\tat java.base/java.lang.Thread.run(Thread.java:1447)\r\n","_error_type":"java.lang.RuntimeException","_error_stack_trace":"java.lang.RuntimeException\r\n\tat com.github.kagkarlsson.examples.boot.config.BasicExamplesConfiguration.lambda$sampleOneTimeTask$0(BasicExamplesConfiguration.java:77)\r\n\tat com.github.kagkarlsson.scheduler.task.helper.Tasks$OneTimeTaskBuilder$1.executeOnce(Tasks.java:303)\r\n\tat com.github.kagkarlsson.scheduler.task.helper.OneTimeTask.execute(OneTimeTask.java:68)\r\n\tat com.github.kagkarlsson.scheduler.event.ExecutionChain.proceed(ExecutionChain.java:37)\r\n\tat com.github.kagkarlsson.examples.boot.config.SchedulerConfiguration.lambda$mdcExecutionInterceptor$0(SchedulerConfiguration.java:75)\r\n\tat com.github.kagkarlsson.scheduler.event.ExecutionChain.proceed(ExecutionChain.java:41)\r\n\tat com.github.kagkarlsson.scheduler.ExecutePicked.executePickedExecution(ExecutePicked.java:113)\r\n\tat com.github.kagkarlsson.scheduler.ExecutePicked.run(ExecutePicked.java:89)\r\n\tat com.github.kagkarlsson.scheduler.FetchCandidates.lambda$run$2(FetchCandidates.java:117)\r\n\tat java.base/java.util.Optional.ifPresent(Optional.java:178)\r\n\tat com.github.kagkarlsson.scheduler.FetchCandidates.lambda$run$1(FetchCandidates.java:103)\r\n\tat com.github.kagkarlsson.scheduler.Executor.lambda$addToQueue$0(Executor.java:53)\r\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095)\r\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619)\r\n\tat java.base/java.lang.Thread.run(Thread.java:1447)\r\n","_error_message":null}
{"version":"1.1","short_message":"Execution failed. Retrying task TaskInstance: task=sample-one-time-task, id=command-line-runner, priority=0 at 2026-05-16T19:47:38.626033500Z","timestamp":1778960858.626,"level":7,"_level_name":"DEBUG","_process_pid":3128,"_process_thread_name":"db-scheduler-pool-2-thread-2","host":"spring-boot-example","_log_logger":"com.github.kagkarlsson.scheduler.task.CompletionHandler$OnCompleteReschedule"}
```
`MDC` params `"_task-name":"sample-one-time-task","_task-instance-id":"command-line-runner"` are only in the first log of execution.
After the example fixes, `MDC` logs will appear in the error handler and completion handler logs:
```
{"version":"1.1","short_message":"I am a one-time task!","timestamp":1778960728.065,"level":6,"_level_name":"INFO","_process_pid":35320,"_process_thread_name":"db-scheduler-pool-2-thread-1","host":"spring-boot-example","_log_logger":"com.github.kagkarlsson.examples.boot.config.BasicExamplesConfiguration","_task-name":"sample-one-time-task","_task-instance-id":"command-line-runner"}
{"version":"1.1","short_message":"Unhandled exception RuntimeException during execution of task with name 'sample-one-time-task'. Treating as failure.","timestamp":1778960728.065,"level":4,"_level_name":"WARN","_process_pid":35320,"_process_thread_name":"db-scheduler-pool-2-thread-1","host":"spring-boot-example","_log_logger":"com.github.kagkarlsson.scheduler.Scheduler","_task-name":"sample-one-time-task","_task-instance-id":"command-line-runner","full_message":"Unhandled exception RuntimeException during execution of task with name 'sample-one-time-task'. Treating as failure.\n\njava.lang.RuntimeException\r\n\tat com.github.kagkarlsson.examples.boot.config.BasicExamplesConfiguration.lambda$sampleOneTimeTask$0(BasicExamplesConfiguration.java:77)\r\n\tat com.github.kagkarlsson.scheduler.task.helper.Tasks$OneTimeTaskBuilder$1.executeOnce(Tasks.java:303)\r\n\tat com.github.kagkarlsson.scheduler.task.helper.OneTimeTask.execute(OneTimeTask.java:68)\r\n\tat com.github.kagkarlsson.scheduler.event.ExecutionChain.proceed(ExecutionChain.java:37)\r\n\tat com.github.kagkarlsson.examples.boot.config.SchedulerConfiguration.lambda$mdcExecutionInterceptor$0(SchedulerConfiguration.java:60)\r\n\tat com.github.kagkarlsson.scheduler.event.ExecutionChain.proceed(ExecutionChain.java:41)\r\n\tat com.github.kagkarlsson.scheduler.ExecutePicked.executePickedExecution(ExecutePicked.java:113)\r\n\tat com.github.kagkarlsson.scheduler.ExecutePicked.run(ExecutePicked.java:89)\r\n\tat com.github.kagkarlsson.scheduler.FetchCandidates.lambda$run$2(FetchCandidates.java:117)\r\n\tat java.base/java.util.Optional.ifPresent(Optional.java:178)\r\n\tat com.github.kagkarlsson.scheduler.FetchCandidates.lambda$run$1(FetchCandidates.java:103)\r\n\tat com.github.kagkarlsson.scheduler.Executor.lambda$addToQueue$0(Executor.java:53)\r\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095)\r\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619)\r\n\tat java.base/java.lang.Thread.run(Thread.java:1447)\r\n","_error_type":"java.lang.RuntimeException","_error_stack_trace":"java.lang.RuntimeException\r\n\tat com.github.kagkarlsson.examples.boot.config.BasicExamplesConfiguration.lambda$sampleOneTimeTask$0(BasicExamplesConfiguration.java:77)\r\n\tat com.github.kagkarlsson.scheduler.task.helper.Tasks$OneTimeTaskBuilder$1.executeOnce(Tasks.java:303)\r\n\tat com.github.kagkarlsson.scheduler.task.helper.OneTimeTask.execute(OneTimeTask.java:68)\r\n\tat com.github.kagkarlsson.scheduler.event.ExecutionChain.proceed(ExecutionChain.java:37)\r\n\tat com.github.kagkarlsson.examples.boot.config.SchedulerConfiguration.lambda$mdcExecutionInterceptor$0(SchedulerConfiguration.java:60)\r\n\tat com.github.kagkarlsson.scheduler.event.ExecutionChain.proceed(ExecutionChain.java:41)\r\n\tat com.github.kagkarlsson.scheduler.ExecutePicked.executePickedExecution(ExecutePicked.java:113)\r\n\tat com.github.kagkarlsson.scheduler.ExecutePicked.run(ExecutePicked.java:89)\r\n\tat com.github.kagkarlsson.scheduler.FetchCandidates.lambda$run$2(FetchCandidates.java:117)\r\n\tat java.base/java.util.Optional.ifPresent(Optional.java:178)\r\n\tat com.github.kagkarlsson.scheduler.FetchCandidates.lambda$run$1(FetchCandidates.java:103)\r\n\tat com.github.kagkarlsson.scheduler.Executor.lambda$addToQueue$0(Executor.java:53)\r\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095)\r\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619)\r\n\tat java.base/java.lang.Thread.run(Thread.java:1447)\r\n","_error_message":null}
{"version":"1.1","short_message":"Execution failed. Retrying task TaskInstance: task=sample-one-time-task, id=command-line-runner, priority=0 at 2026-05-16T19:45:28.065922200Z","timestamp":1778960728.065,"level":7,"_level_name":"DEBUG","_process_pid":35320,"_process_thread_name":"db-scheduler-pool-2-thread-1","host":"spring-boot-example","_log_logger":"com.github.kagkarlsson.scheduler.task.CompletionHandler$OnCompleteReschedule","_task-name":"sample-one-time-task","_task-instance-id":"command-line-runner"}
```

## Fixes

For correct `MDC` handling, `MDC` filling is done in the interceptor and `MDC` clearing is done in the completion listener.

## Reminders

- [ ] Added/ran automated tests
- [ ] Update README and/or examples
- [x] Ran `mvn spotless:apply`

---

cc @kagkarlsson
