### PR TITLE
docs: Refactor ai-policy to separate AI_POLICY.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,13 @@
-## Brief, plain english overview of your changes here
+<Brief, plain english overview of your changes here>
 
-## Fixes
+Fixes #issue-nr (if applicable)
 
-<!--- Which issue # does this fix? --->
-
-## Reminders
+#### Reminders
 
 - [ ] Added/ran automated tests
 - [ ] Update README and/or examples
 - [ ] Ran `mvn spotless:apply`
+- [ ] If AI tools were used, disclosed per the [AI Contribution Policy](../AI_POLICY.md)
 
 ---
 

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,24 @@
+# AI Contribution Policy
+
+Contributions made with the assistance of AI tools are welcome, but contributors must use them responsibly and disclose that use clearly.
+
+## In general
+
+* **Don't paste unreviewed AI-generated text into issues, discussions, or PR comments**;
+  use your own words. AI may help you arrive at an answer,
+  but the message itself should reflect your analysis and understanding.
+
+* Contributors are responsible for ensuring that all submitted content complies with the project's license
+  and contribution standards, regardless of how it was produced.
+
+## Pull requests
+
+* If AI tools were used, **disclose** this in the PR description. Include what tools were used
+  and optionally what they were used for.
+
+* The contributor must **fully understand** all submitted changes and be able to explain and maintain them.
+
+* All AI-assisted code must always be **reviewed critically** prior to creating the PR.
+  This includes tests and generated boilerplate. Added code comes with a maintenance cost. AI tools
+  often create unnecessary abstraction, duplication, excessive test coverage, or too much boilerplate.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,9 @@
 
 ### AI Contribution Policy
 
-Contributions made with the assistance of AI tools are welcome, but contributors must use them responsibly and disclose that use clearly.
-
-* If AI tools were used, **disclose** in the PR-description what tool was used and the extent to which the work was AI-assisted.
-
-* The contributor must **fully understand** all the changes made and all the code supplied.
-
-* The supplied code must always be **reviewed critically** prior to creating the PR. This includes tests.
+Contributions made with the assistance of AI tools are welcome, but must follow the
+[AI Contribution Policy](AI_POLICY.md). In short: disclose AI use, fully understand the changes,
+and don't paste raw AI output into issues or discussions.
 
 ### Are you new and looking to dive in?
 


### PR DESCRIPTION
Extract AI contribution policy to separate top-level document for clarity and discoverability.