### PR TITLE
fix: infer fixed executor thread count

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,6 +60,7 @@ public class SchedulerBuilder {
   protected Clock clock = new SystemClock(); // if this is set, waiter-clocks must be updated
   protected SchedulerName schedulerName;
   protected int executorThreads = 10;
+  protected boolean executorThreadsConfigured = false;
   protected Duration poolingInterval = DEFAULT_POLLING_INTERVAL;
   protected StatsRegistry statsRegistry = StatsRegistry.NOOP;
   protected Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
@@ -118,6 +120,7 @@ public class SchedulerBuilder {
 
   public SchedulerBuilder threads(int numberOfThreads) {
     this.executorThreads = numberOfThreads;
+    this.executorThreadsConfigured = true;
     return this;
   }
 
@@ -291,6 +294,7 @@ public class SchedulerBuilder {
           Executors.newFixedThreadPool(
               executorThreads, defaultThreadFactoryWithPrefix(THREAD_PREFIX + "-"));
     }
+    int candidateExecutorThreads = resolveExecutorThreads(candidateExecutorService);
 
     ExecutorService candidateDueExecutor = dueExecutor;
     if (candidateDueExecutor == null) {
@@ -314,7 +318,7 @@ public class SchedulerBuilder {
 
     LOG.info(
         "Creating scheduler with configuration: threads={}, pollInterval={}s, heartbeat={}s, enable-immediate-execution={}, enable-priority={}, table-name={}, name={}",
-        executorThreads,
+        candidateExecutorThreads,
         waiter.getWaitDuration().getSeconds(),
         heartbeatInterval.getSeconds(),
         enableImmediateExecution,
@@ -328,7 +332,7 @@ public class SchedulerBuilder {
             schedulerTaskRepository,
             clientTaskRepository,
             taskResolver,
-            executorThreads,
+            candidateExecutorThreads,
             candidateExecutorService,
             schedulerName,
             waiter,
@@ -364,5 +368,20 @@ public class SchedulerBuilder {
 
   protected Waiter buildWaiter() {
     return new Waiter(poolingInterval, clock);
+  }
+
+  private int resolveExecutorThreads(ExecutorService candidateExecutorService) {
+    if (executorThreadsConfigured) {
+      return executorThreads;
+    }
+
+    if (candidateExecutorService instanceof ThreadPoolExecutor) {
+      ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) candidateExecutorService;
+      if (threadPoolExecutor.getCorePoolSize() == threadPoolExecutor.getMaximumPoolSize()) {
+        return threadPoolExecutor.getMaximumPoolSize();
+      }
+    }
+
+    return executorThreads;
   }
 }

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerBuilderTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerBuilderTest.java
@@ -1,0 +1,73 @@
+package com.github.kagkarlsson.scheduler;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.github.kagkarlsson.scheduler.jdbc.DefaultJdbcCustomization;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+public class SchedulerBuilderTest {
+
+  private final Logger logger = (Logger) LoggerFactory.getLogger(SchedulerBuilder.class);
+  private final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+
+  {
+    logger.setLevel(ch.qos.logback.classic.Level.ALL);
+    appender.start();
+  }
+
+  @BeforeEach
+  public void addAppender() {
+    logger.addAppender(appender);
+  }
+
+  @AfterEach
+  public void removeAppender() {
+    logger.detachAppender(appender);
+  }
+
+  @Test
+  public void should_use_fixed_executor_service_thread_count_when_threads_not_configured() {
+    ExecutorService executorService = Executors.newFixedThreadPool(3);
+
+    try {
+      Scheduler scheduler = schedulerBuilder().executorService(executorService).build();
+
+      assertThat(scheduler.threadpoolSize, is(3));
+      assertThat(appender.list.get(0).getFormattedMessage(), containsString("threads=3"));
+    } finally {
+      executorService.shutdownNow();
+    }
+  }
+
+  @Test
+  public void should_use_configured_threads_over_fixed_executor_service_thread_count() {
+    ExecutorService executorService = Executors.newFixedThreadPool(3);
+
+    try {
+      Scheduler scheduler = schedulerBuilder().executorService(executorService).threads(5).build();
+
+      assertThat(scheduler.threadpoolSize, is(5));
+      assertThat(appender.list.get(0).getFormattedMessage(), containsString("threads=5"));
+    } finally {
+      executorService.shutdownNow();
+    }
+  }
+
+  private SchedulerBuilder schedulerBuilder() {
+    return Scheduler.create(mock(DataSource.class))
+        .jdbcCustomization(new DefaultJdbcCustomization(false))
+        .schedulerName(new SchedulerName.Fixed("test"));
+  }
+}


### PR DESCRIPTION
## Summary
- infer the scheduler thread count from fixed-size `ThreadPoolExecutor` instances when `.threads(...)` was not explicitly configured
- keep explicit `.threads(...)` values taking precedence over executor introspection
- add regression coverage for the logged and stored scheduler thread count

Closes #517

## Verification
- `mvn -pl db-scheduler -Dtest=SchedulerBuilderTest test`
- `mvn -pl db-scheduler spotless:check`
- `git diff --check`

## AI assistance disclosure
I used OpenAI GPT-5 to inspect the issue context, implement the focused change, and run the verification commands above. I reviewed the code and test before submitting.
