### PR TITLE
feat: sqlite support is added

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See also [why not Quartz?](#why-db-scheduler-when-there-is-quartz)
 </dependency>
 ```
 
-2. Create the `scheduled_tasks` table in your database-schema. See table definition for [postgresql](db-scheduler/src/test/resources/postgresql_tables.sql), [oracle](db-scheduler/src/test/resources/oracle_tables.sql), [mssql](db-scheduler/src/test/resources/mssql_tables.sql) or [mysql](db-scheduler/src/test/resources/mysql_tables.sql).
+2. Create the `scheduled_tasks` table in your database-schema. See table definition for [postgresql](db-scheduler/src/test/resources/postgresql_tables.sql), [oracle](db-scheduler/src/test/resources/oracle_tables.sql), [mssql](db-scheduler/src/test/resources/mssql_tables.sql), [sqlite](db-scheduler/src/test/resources/sqlite_tables.sql) or [mysql](db-scheduler/src/test/resources/mysql_tables.sql).
 
 3. Instantiate and start the scheduler, which then will start any defined recurring tasks.
 

--- a/db-scheduler/pom.xml
+++ b/db-scheduler/pom.xml
@@ -228,6 +228,12 @@
       <version>${postgresql.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.xerial</groupId>
+      <artifactId>sqlite-jdbc</artifactId>
+      <version>3.25.2</version>
+      <scope>test</scope>
+    </dependency>
     <!-- https://mvnrepository.com/artifact/com.microsoft.sqlserver/mssql-jdbc -->
     <dependency>
       <groupId>io.zonky.test</groupId>

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/AutodetectJdbcCustomization.java
@@ -34,6 +34,7 @@ public class AutodetectJdbcCustomization implements JdbcCustomization {
   private static final Logger LOG = LoggerFactory.getLogger(AutodetectJdbcCustomization.class);
   private static final Logger SILENCABLE_LOG =
       LoggerFactory.getLogger(LOG.getName() + ".utc_warning");
+  public static final String SQLITE = "SQLite";
   private final JdbcCustomization jdbcCustomization;
 
   public AutodetectJdbcCustomization(DataSource dataSource) {
@@ -77,6 +78,9 @@ public class AutodetectJdbcCustomization implements JdbcCustomization {
           detectedCustomization = new MySQLJdbcCustomization(persistTimestampInUTC);
         }
 
+      } else if (databaseProductName.contains(SQLITE)) {
+        LOG.info("Using SQLite jdbc-overrides.");
+        detectedCustomization = new SqliteJdbcCustomization();
       } else {
         SILENCABLE_LOG.warn(
             "No database-specific jdbc-overrides applied. Se 'DefaultJdbcCustomization' for "

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/SqliteJdbcCustomization.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/SqliteJdbcCustomization.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) Gustav Karlsson
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.kagkarlsson.scheduler.jdbc;
+
+import static com.github.kagkarlsson.scheduler.jdbc.AutodetectJdbcCustomization.SQLITE;
+
+public class SqliteJdbcCustomization extends DefaultJdbcCustomization {
+
+  public SqliteJdbcCustomization() {
+    super(true);
+  }
+
+  @Override
+  public String getName() {
+    return SQLITE;
+  }
+
+  @Override
+  public String getQueryLimitPart(int limit) {
+    return Queries.postgresSqlLimitPart(limit);
+  }
+}

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/SqliteCompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/SqliteCompatibilityTest.java
@@ -1,0 +1,51 @@
+package com.github.kagkarlsson.scheduler.compatibility;
+
+import com.github.kagkarlsson.scheduler.DbUtils;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import java.time.Duration;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.sqlite.SQLiteDataSource;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Tag("compatibility")
+@Testcontainers
+public class SqliteCompatibilityTest extends CompatibilityTest {
+  private static HikariDataSource pooledDatasource;
+
+  public SqliteCompatibilityTest() {
+    super(false, true);
+  }
+
+  @BeforeAll
+  static void initSchema() {
+    final SQLiteDataSource datasource = new SQLiteDataSource();
+    datasource.setUrl("jdbc:sqlite:memory:myDb");
+
+    final HikariConfig hikariConfig = new HikariConfig();
+    hikariConfig.setDataSource(datasource);
+    hikariConfig.setMaximumPoolSize(1);
+    pooledDatasource = new HikariDataSource(hikariConfig);
+
+    DbUtils.dropTables(pooledDatasource);
+    DbUtils.runSqlResource("/sqlite_tables.sql").accept(pooledDatasource);
+  }
+
+  @BeforeEach
+  void overrideSchedulerShutdown() {
+    stopScheduler.setWaitBeforeInterrupt(Duration.ofMillis(100));
+  }
+
+  @Override
+  public DataSource getDataSource() {
+    return pooledDatasource;
+  }
+
+  @Override
+  public boolean commitWhenAutocommitDisabled() {
+    return false;
+  }
+}

--- a/db-scheduler/src/test/resources/sqlite_tables.sql
+++ b/db-scheduler/src/test/resources/sqlite_tables.sql
@@ -1,0 +1,19 @@
+create table scheduled_tasks (
+    task_name varchar(100),
+    task_instance varchar(100),
+    task_data blob,
+    execution_time TIMESTAMP,
+    picked BIT,
+    picked_by varchar(50),
+    last_success TIMESTAMP,
+    last_failure TIMESTAMP,
+    consecutive_failures INT,
+    last_heartbeat TIMESTAMP,
+    version BIGINT,
+    priority SMALLINT,
+    PRIMARY KEY (task_name, task_instance)
+);
+
+CREATE INDEX execution_time_idx ON scheduled_tasks (execution_time);
+CREATE INDEX last_heartbeat_idx ON scheduled_tasks (last_heartbeat);
+CREATE INDEX priority_execution_time_idx on scheduled_tasks (priority desc, execution_time asc);


### PR DESCRIPTION
SQLite is supported with the following limitations:
- `SKIP LOCKED` is not supported in SQLite — use `FETCH` polling strategy only
- `always-persist-timestamp-in-utc=true` is enabled explicitly in customization
- The HSQL schema (with `TIMESTAMP WITH TIME ZONE`) is tested

Tested in one small project. I used [hsql schema](https://github.com/strelchm/db-scheduler/blob/master/db-scheduler/src/test/resources/hsql_tables.sql) for it.
- If `always-persist-timestamp-in-utc=false`, then timestamp serialization worked well, but during task fetching there are errors connected with JDBC (cannot deseralize to OffsetDateTime):
```
com.github.kagkarlsson.jdbc.SQLRuntimeException: java.sql.SQLFeatureNotSupportedException
	at com.github.kagkarlsson.jdbc.JdbcRunner.withResultSet(JdbcRunner.java:280)
	at com.github.kagkarlsson.jdbc.JdbcRunner.mapResultSet(JdbcRunner.java:264)
	at com.github.kagkarlsson.jdbc.JdbcRunner.lambda$query$1(JdbcRunner.java:98)
	at com.github.kagkarlsson.jdbc.JdbcRunner.lambda$execute$0(JdbcRunner.java:156)
	at com.github.kagkarlsson.jdbc.JdbcRunner.withConnection(JdbcRunner.java:236)
	at com.github.kagkarlsson.jdbc.JdbcRunner.execute(JdbcRunner.java:131)
	at com.github.kagkarlsson.jdbc.JdbcRunner.query(JdbcRunner.java:94)
	at com.github.kagkarlsson.scheduler.jdbc.JdbcTaskRepository.getExecutions(JdbcTaskRepository.java:421)
	at com.github.kagkarlsson.scheduler.jdbc.JdbcTaskRepository.getDue(JdbcTaskRepository.java:343)
	at com.github.kagkarlsson.scheduler.FetchCandidates.run(FetchCandidates.java:87)
	at com.github.kagkarlsson.scheduler.RunUntilShutdown.run(RunUntilShutdown.java:44)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619)
	at java.base/java.lang.Thread.run(Thread.java:1447)
Caused by: java.sql.SQLFeatureNotSupportedException
	at org.sqlite.jdbc4.JDBC4ResultSet.getObject(JDBC4ResultSet.java:343)
	at com.zaxxer.hikari.pool.HikariProxyResultSet.getObject(HikariProxyResultSet.java)
	at com.github.kagkarlsson.scheduler.jdbc.DefaultJdbcCustomization.getInstant(DefaultJdbcCustomization.java:66)
	at com.github.kagkarlsson.scheduler.jdbc.AutodetectJdbcCustomization.getInstant(AutodetectJdbcCustomization.java:105)
	at com.github.kagkarlsson.scheduler.jdbc.JdbcTaskRepository$ExecutionResultSetConsumer.map(JdbcTaskRepository.java:787)
	at com.github.kagkarlsson.scheduler.jdbc.JdbcTaskRepository$ExecutionResultSetMapper.map(JdbcTaskRepository.java:757)
	at com.github.kagkarlsson.scheduler.jdbc.JdbcTaskRepository$ExecutionResultSetMapper.map(JdbcTaskRepository.java:741)
	at com.github.kagkarlsson.jdbc.JdbcRunner.lambda$mapResultSet$1(JdbcRunner.java:264)
	at com.github.kagkarlsson.jdbc.JdbcRunner.withResultSet(JdbcRunner.java:278)
	... 15 common frames omitted
```
- If `always-persist-timestamp-in-utc=true`, then everything works fine — task fetching succeeds and there are no problems

Fixes
https://github.com/kagkarlsson/db-scheduler/issues/868

#### Reminders

- [x] Added/ran automated tests
- [x] Update README and/or examples
- [x] Ran `mvn spotless:apply`
- [ ] If AI tools were used, disclosed per the [AI Contribution Policy](../AI_POLICY.md)

---

cc @kagkarlsson
