### PR TITLE
feat: add per-task summary to SchedulerClient

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ mvn test -Dtest=ClassName[#method]
 - AssertJ over Hamcrest in tests.
 - Compact tests are fine — multiple assertions/steps per test to reduce boilerplate.
 - Comments only when WHY is non-obvious.
+- Prefer `var` for local variable declaration
 
 ## Finalizing changes
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -341,6 +341,11 @@ public class Scheduler implements SchedulerClient {
     return this.delegate.getScheduledExecution(taskInstanceId);
   }
 
+  @Override
+  public List<TaskSummary> getScheduledExecutionsSummaryByTask() {
+    return this.delegate.getScheduledExecutionsSummaryByTask();
+  }
+
   public List<Execution> getFailingExecutions(Duration failingAtLeastFor) {
     return schedulerTaskRepository.getExecutionsFailingLongerThan(failingAtLeastFor);
   }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
@@ -306,6 +306,16 @@ public interface SchedulerClient {
    */
   Optional<ScheduledExecution<Object>> getScheduledExecution(TaskInstanceId taskInstanceId);
 
+  /**
+   * Summarizes all executions by task-name in the database (a {@code GROUP BY task_name}) and
+   * returns one {@link TaskSummary} per task-name. All executions are included, both picked
+   * (running) and not.
+   *
+   * @return one summary per task-name, empty if no executions exist
+   * @see com.github.kagkarlsson.scheduler.TaskSummary
+   */
+  List<TaskSummary> getScheduledExecutionsSummaryByTask();
+
   class ScheduleOptions {
 
     public static final ScheduleOptions WHEN_EXISTS_DO_NOTHING =
@@ -628,6 +638,11 @@ public interface SchedulerClient {
       Optional<Execution> e =
           taskRepository.getExecution(taskInstanceId.getTaskName(), taskInstanceId.getId());
       return e.map(oe -> new ScheduledExecution<>(Object.class, oe));
+    }
+
+    @Override
+    public List<TaskSummary> getScheduledExecutionsSummaryByTask() {
+      return taskRepository.getScheduledExecutionsSummaryByTask();
     }
   }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
@@ -61,6 +61,8 @@ public interface TaskRepository {
     return results;
   }
 
+  List<TaskSummary> getScheduledExecutionsSummaryByTask();
+
   List<Execution> lockAndFetchGeneric(Instant now, int limit);
 
   List<Execution> lockAndGetDue(Instant now, int limit);

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskSummary.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskSummary.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) Gustav Karlsson
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.kagkarlsson.scheduler;
+
+import java.time.Instant;
+
+/**
+ * Summary statistics for all executions sharing a task-name, intended for rendering task-centric
+ * dashboards without pulling every execution into memory.
+ *
+ * <p>{@code runningCount}, {@code failingCount} and {@code scheduledCount} are a non-overlapping
+ * partition of {@code instanceCount} (they sum to it): currently-picked executions are {@code
+ * running}, the rest are {@code failing} when they have consecutive failures and {@code scheduled}
+ * otherwise.
+ *
+ * @param taskName the task-name the executions are grouped by
+ * @param instanceCount total number of executions for the task-name
+ * @param runningCount executions currently picked (being executed)
+ * @param failingCount executions not picked with at least one consecutive failure
+ * @param scheduledCount executions not picked with no consecutive failures
+ * @param earliestExecutionTime soonest next execution-time across the executions, null if none
+ * @param latestLastSuccess most-recent successful execution across the executions, null if none
+ * @param latestLastFailure most-recent failed execution across the executions, null if none
+ * @param maxConsecutiveFailures highest consecutive-failure count across the executions
+ */
+public record TaskSummary(
+    String taskName,
+    int instanceCount,
+    int runningCount,
+    int failingCount,
+    int scheduledCount,
+    Instant earliestExecutionTime,
+    Instant latestLastSuccess,
+    Instant latestLastFailure,
+    int maxConsecutiveFailures) {}

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskSummary.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskSummary.java
@@ -15,25 +15,6 @@ package com.github.kagkarlsson.scheduler;
 
 import java.time.Instant;
 
-/**
- * Summary statistics for all executions sharing a task-name, intended for rendering task-centric
- * dashboards without pulling every execution into memory.
- *
- * <p>{@code runningCount}, {@code failingCount} and {@code scheduledCount} are a non-overlapping
- * partition of {@code instanceCount} (they sum to it): currently-picked executions are {@code
- * running}, the rest are {@code failing} when they have consecutive failures and {@code scheduled}
- * otherwise.
- *
- * @param taskName the task-name the executions are grouped by
- * @param instanceCount total number of executions for the task-name
- * @param runningCount executions currently picked (being executed)
- * @param failingCount executions not picked with at least one consecutive failure
- * @param scheduledCount executions not picked with no consecutive failures
- * @param earliestExecutionTime soonest next execution-time across the executions, null if none
- * @param latestLastSuccess most-recent successful execution across the executions, null if none
- * @param latestLastFailure most-recent failed execution across the executions, null if none
- * @param maxConsecutiveFailures highest consecutive-failure count across the executions
- */
 public record TaskSummary(
     String taskName,
     int instanceCount,

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
@@ -30,6 +30,7 @@ import com.github.kagkarlsson.scheduler.SchedulerName;
 import com.github.kagkarlsson.scheduler.TaskRepository;
 import com.github.kagkarlsson.scheduler.TaskResolver;
 import com.github.kagkarlsson.scheduler.TaskResolver.UnresolvedTask;
+import com.github.kagkarlsson.scheduler.TaskSummary;
 import com.github.kagkarlsson.scheduler.exceptions.ExecutionException;
 import com.github.kagkarlsson.scheduler.exceptions.FailedToScheduleBatchException;
 import com.github.kagkarlsson.scheduler.exceptions.TaskInstanceException;
@@ -332,6 +333,32 @@ public class JdbcTaskRepository implements TaskRepository {
         q.getQuery(jdbcCustomization),
         q.getPreparedStatementSetter(jdbcCustomization),
         new ExecutionResultSetConsumer(consumer, filter.getIncludeUnresolved(), false));
+  }
+
+  @Override
+  public List<TaskSummary> getScheduledExecutionsSummaryByTask() {
+    var query =
+        "select task_name, "
+            + "count(*) as instance_count, "
+            + "sum(case when picked = ? then 1 else 0 end) as running_count, "
+            + "sum(case when picked = ? and coalesce(consecutive_failures, 0) > 0 then 1 else 0 end) as failing_count, "
+            + "sum(case when picked = ? and coalesce(consecutive_failures, 0) = 0 then 1 else 0 end) as scheduled_count, "
+            + "min(execution_time) as earliest_execution_time, "
+            + "max(last_success) as latest_last_success, "
+            + "max(last_failure) as latest_last_failure, "
+            + "max(consecutive_failures) as max_consecutive_failures "
+            + "from "
+            + tableName
+            + " group by task_name";
+
+    return jdbcRunner.query(
+        query,
+        (PreparedStatement p) -> {
+          p.setBoolean(1, true); // running: picked
+          p.setBoolean(2, false); // failing: not picked
+          p.setBoolean(3, false); // scheduled: not picked
+        },
+        new TaskSummaryResultSetMapper());
   }
 
   @Override
@@ -801,6 +828,28 @@ public class JdbcTaskRepository implements TaskRepository {
     filter.getLimit().ifPresent(q::limit);
 
     return q;
+  }
+
+  private class TaskSummaryResultSetMapper implements ResultSetMapper<List<TaskSummary>> {
+
+    @Override
+    public List<TaskSummary> map(ResultSet rs) throws SQLException {
+      var summaries = new ArrayList<TaskSummary>();
+      while (rs.next()) {
+        summaries.add(
+            new TaskSummary(
+                rs.getString("task_name"),
+                rs.getInt("instance_count"),
+                rs.getInt("running_count"),
+                rs.getInt("failing_count"),
+                rs.getInt("scheduled_count"),
+                jdbcCustomization.getInstant(rs, "earliest_execution_time"),
+                jdbcCustomization.getInstant(rs, "latest_last_success"),
+                jdbcCustomization.getInstant(rs, "latest_last_failure"),
+                rs.getInt("max_consecutive_failures")));
+      }
+      return summaries;
+    }
   }
 
   private class ExecutionResultSetMapper implements ResultSetMapper<List<Execution>> {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
@@ -454,6 +454,71 @@ public class JdbcTaskRepositoryTest {
   }
 
   @Test
+  public void summary_by_task_name() {
+    Instant now = TimeHelper.truncatedInstantNow();
+
+    // OneTime: scheduled (with a previous success), running, failing, and running-after-failures
+    var scheduled = schedule(oneTimeTask.instance("scheduled"), now.plus(ofMinutes(10)));
+    taskRepository.reschedule(scheduled, now.plus(ofMinutes(10)), now.minus(ofMinutes(2)), null, 0);
+
+    var running = schedule(oneTimeTask.instance("running"), now.plus(ofMinutes(5)));
+    taskRepository.pick(running, now);
+
+    var failing = schedule(oneTimeTask.instance("failing"), now.plus(ofMinutes(20)));
+    taskRepository.reschedule(failing, now.plus(ofMinutes(20)), null, now.minus(ofMinutes(1)), 3);
+
+    var runningFailing = schedule(oneTimeTask.instance("running-failing"), now.plus(ofMinutes(15)));
+    taskRepository.reschedule(
+        runningFailing, now.plus(ofMinutes(15)), null, now.minus(ofMinutes(3)), 2);
+    taskRepository.pick(taskRepository.getExecution(runningFailing.taskInstance).get(), now);
+
+    // OneTimeWithData: a single scheduled execution
+    schedule(oneTimeTaskWithData.instance("only"), now.plus(ofMinutes(30)));
+
+    // Unresolved tasks are still summarized (grouping is purely by task_name)
+    schedule(unknownOneTimeTask.instance("only"), now.plus(ofMinutes(1)));
+
+    List<TaskSummary> summaries = taskRepository.getScheduledExecutionsSummaryByTask();
+    assertThat(summaries, hasSize(3));
+
+    TaskSummary oneTime = findSummary(summaries, oneTimeTask.getName());
+    assertEquals(4, oneTime.instanceCount());
+    assertEquals(2, oneTime.runningCount());
+    assertEquals(1, oneTime.failingCount());
+    assertEquals(1, oneTime.scheduledCount());
+    assertEquals(now.plus(ofMinutes(5)), oneTime.earliestExecutionTime());
+    assertEquals(now.minus(ofMinutes(2)), oneTime.latestLastSuccess());
+    assertEquals(now.minus(ofMinutes(1)), oneTime.latestLastFailure());
+    assertEquals(3, oneTime.maxConsecutiveFailures());
+
+    TaskSummary withData = findSummary(summaries, oneTimeTaskWithData.getName());
+    assertEquals(1, withData.instanceCount());
+    assertEquals(0, withData.runningCount());
+    assertEquals(0, withData.failingCount());
+    assertEquals(1, withData.scheduledCount());
+    assertEquals(now.plus(ofMinutes(30)), withData.earliestExecutionTime());
+    assertThat(withData.latestLastSuccess(), is(nullValue()));
+    assertThat(withData.latestLastFailure(), is(nullValue()));
+    assertEquals(0, withData.maxConsecutiveFailures());
+
+    TaskSummary unresolved = findSummary(summaries, unknownOneTimeTask.getName());
+    assertEquals(1, unresolved.instanceCount());
+    assertEquals(1, unresolved.scheduledCount());
+  }
+
+  private static TaskSummary findSummary(List<TaskSummary> summaries, String taskName) {
+    return summaries.stream()
+        .filter(s -> s.taskName().equals(taskName))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("No summary for task-name: " + taskName));
+  }
+
+  private Execution schedule(TaskInstance<?> instance, Instant executionTime) {
+    taskRepository.createIfNotExists(new SchedulableTaskInstance<>(instance, executionTime));
+    return taskRepository.getExecution(instance).get();
+  }
+
+  @Test
   public void get_scheduled_by_task_name() {
     Instant now = TimeHelper.truncatedInstantNow();
     final SchedulableTaskInstance<Void> execution1 =

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/CompatibilityTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/compatibility/CompatibilityTest.java
@@ -26,6 +26,7 @@ import com.github.kagkarlsson.scheduler.SchedulerName;
 import com.github.kagkarlsson.scheduler.StopSchedulerExtension;
 import com.github.kagkarlsson.scheduler.SystemClock;
 import com.github.kagkarlsson.scheduler.TaskResolver;
+import com.github.kagkarlsson.scheduler.TaskSummary;
 import com.github.kagkarlsson.scheduler.TestTasks;
 import com.github.kagkarlsson.scheduler.TestTasks.DoNothingHandler;
 import com.github.kagkarlsson.scheduler.event.SchedulerListeners;
@@ -243,6 +244,46 @@ public abstract class CompatibilityTest {
                 .limit(10));
 
     assertThat(idsFrom(rangePage), contains("3"));
+  }
+
+  @Test
+  public void test_jdbc_repository_summary_by_task() {
+    var repo = createJdbcTaskRepository(false);
+    var now = truncatedInstantNow();
+
+    // scheduled (with a previous success), running, failing, and running-after-failures
+    var scheduled = createExecution(repo, "scheduled", now.plusSeconds(600));
+    repo.reschedule(scheduled, now.plusSeconds(600), now.minusSeconds(120), null, 0);
+
+    var running = createExecution(repo, "running", now.plusSeconds(300));
+    repo.pick(running, now);
+
+    var failing = createExecution(repo, "failing", now.plusSeconds(1200));
+    repo.reschedule(failing, now.plusSeconds(1200), null, now.minusSeconds(60), 3);
+
+    var runningFailing = createExecution(repo, "running-failing", now.plusSeconds(900));
+    repo.reschedule(runningFailing, now.plusSeconds(900), null, now.minusSeconds(180), 2);
+    repo.pick(repo.getExecution(runningFailing.taskInstance).orElseThrow(), now);
+
+    List<TaskSummary> summaries = repo.getScheduledExecutionsSummaryByTask();
+    assertThat(summaries, hasSize(1));
+
+    TaskSummary summary = summaries.get(0);
+    assertEquals(ONETIME.getTaskName(), summary.taskName());
+    assertEquals(4, summary.instanceCount());
+    assertEquals(2, summary.runningCount()); // picked, regardless of failures
+    assertEquals(1, summary.failingCount()); // not picked, with failures
+    assertEquals(1, summary.scheduledCount()); // not picked, no failures
+    assertEquals(now.plusSeconds(300), summary.earliestExecutionTime());
+    assertEquals(now.minusSeconds(120), summary.latestLastSuccess());
+    assertEquals(now.minusSeconds(60), summary.latestLastFailure());
+    assertEquals(3, summary.maxConsecutiveFailures());
+  }
+
+  private Execution createExecution(JdbcTaskRepository repo, String id, Instant executionTime) {
+    var instance = ONETIME.instance(id).scheduledTo(executionTime);
+    repo.createIfNotExists(instance);
+    return repo.getExecution(instance).orElseThrow();
   }
 
   @Test


### PR DESCRIPTION
Rendering a task-centric dashboard (one row per task name) currently means loading every ScheduledExecution into memory and grouping client-side. This adds a SchedulerClient method that does the group-by in the database and returns one aggregate per task name.

- New `SchedulerClient#getScheduledExecutionsSummaryByTask()` returning a `TaskSummary` per task name, backed by a single grouped query in `JdbcTaskRepository`
- `TaskSummary` exposes instance/running/failing/scheduled counts (a non-overlapping partition of the total), earliest execution-time, latest success/failure and max consecutive failures
- Portable SQL (bound boolean for `picked`, `coalesce` for nullable `consecutive_failures`) — no per-dialect SQL or schema change

Fixes #873

---
This PR was prepared with Claude Code.