### PR TITLE
build: resolve compiler deprecation and unchecked warnings

### DIFF
--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerConfigurationSupport.java
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerConfigurationSupport.java
@@ -23,6 +23,7 @@ import com.github.kagkarlsson.scheduler.event.SchedulerListener;
 import com.github.kagkarlsson.scheduler.exceptions.SerializationException;
 import com.github.kagkarlsson.scheduler.serializer.Serializer;
 import com.github.kagkarlsson.scheduler.stats.StatsRegistry;
+import com.github.kagkarlsson.scheduler.stats.StatsRegistryAdapter;
 import com.github.kagkarlsson.scheduler.task.OnStartup;
 import com.github.kagkarlsson.scheduler.task.Task;
 import java.io.ByteArrayInputStream;
@@ -121,7 +122,7 @@ public final class DbSchedulerConfigurationSupport {
 
     builder.deleteUnresolvedAfter(config.getDeleteUnresolvedAfter());
     builder.startTasks(startupTasks(configuredTasks));
-    builder.statsRegistry(registry);
+    builder.addSchedulerListener(new StatsRegistryAdapter(registry));
     builder.failureLogging(config.getFailureLoggerLevel(), config.isFailureLoggerLogStackTrace());
     builder.shutdownMaxWait(config.getShutdownMaxWait());
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ExecutePicked.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/ExecutePicked.java
@@ -129,7 +129,8 @@ class ExecutePicked implements Runnable {
         ExecutionComplete.success(execution, executionStarted, clock.now());
     try {
       completion.complete(
-          completeEvent, new ExecutionOperations(taskRepository, schedulerListeners, execution));
+          completeEvent,
+          new ExecutionOperations(taskRepository, schedulerListeners, execution, clock));
     } catch (Throwable e) {
       schedulerListeners.onSchedulerEvent(SchedulerEventType.COMPLETIONHANDLER_ERROR);
       schedulerListeners.onSchedulerEvent(SchedulerEventType.UNEXPECTED_ERROR);
@@ -159,7 +160,7 @@ class ExecutePicked implements Runnable {
       task.getFailureHandler()
           .onFailure(
               completeEvent,
-              new ExecutionOperations(taskRepository, schedulerListeners, execution));
+              new ExecutionOperations(taskRepository, schedulerListeners, execution, clock));
     } catch (Throwable e) {
       schedulerListeners.onSchedulerEvent(SchedulerEventType.FAILUREHANDLER_ERROR);
       schedulerListeners.onSchedulerEvent(SchedulerEventType.UNEXPECTED_ERROR);

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -248,6 +248,7 @@ public class Scheduler implements SchedulerClient {
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public <T> void schedule(SchedulableInstance<T> schedulableInstance) {
     this.delegate.schedule(schedulableInstance);
   }
@@ -273,6 +274,7 @@ public class Scheduler implements SchedulerClient {
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public <T> void schedule(TaskInstance<T> taskInstance, Instant executionTime) {
     this.delegate.schedule(taskInstance, executionTime);
   }
@@ -400,7 +402,7 @@ public class Scheduler implements SchedulerClient {
                     .deadExecution(
                         ExecutionComplete.failure(execution, now, now, null),
                         new ExecutionOperations(
-                            schedulerTaskRepository, schedulerListeners, execution));
+                            schedulerTaskRepository, schedulerListeners, execution, clock));
               } else {
                 LOG.error(
                     "Failed to find implementation for task with name '{}' for detected dead execution. Either delete the execution from the databaser, or add an implementation for it.",

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
@@ -444,7 +444,7 @@ public interface SchedulerClient {
     @Override
     public <T> boolean scheduleIfNotExists(TaskInstance<T> taskInstance, Instant executionTime) {
       boolean success =
-          taskRepository.createIfNotExists(SchedulableInstance.of(taskInstance, executionTime));
+          taskRepository.createIfNotExists(new ScheduledTaskInstance(taskInstance, executionTime));
       if (success) {
         schedulerListeners.onExecutionScheduled(taskInstance, executionTime);
       }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
@@ -160,7 +160,7 @@ public class JdbcTaskRepository implements TaskRepository {
   private final String insertQuery;
 
   @Override
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "deprecation"})
   public boolean createIfNotExists(SchedulableInstance instance) {
     return createIfNotExists(
         new ScheduledTaskInstance(
@@ -232,7 +232,7 @@ public class JdbcTaskRepository implements TaskRepository {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "deprecation"})
   public Instant replace(Execution toBeReplaced, SchedulableInstance newInstance) {
     return replace(
         toBeReplaced,

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/ExecutionOperations.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/ExecutionOperations.java
@@ -13,6 +13,7 @@
  */
 package com.github.kagkarlsson.scheduler.task;
 
+import com.github.kagkarlsson.scheduler.Clock;
 import com.github.kagkarlsson.scheduler.TaskRepository;
 import com.github.kagkarlsson.scheduler.event.SchedulerListeners;
 import java.time.Instant;
@@ -22,12 +23,17 @@ public class ExecutionOperations<T> {
   private final TaskRepository taskRepository;
   private final SchedulerListeners schedulerListeners;
   private final Execution execution;
+  private final Clock clock;
 
   public ExecutionOperations(
-      TaskRepository taskRepository, SchedulerListeners schedulerListeners, Execution execution) {
+      TaskRepository taskRepository,
+      SchedulerListeners schedulerListeners,
+      Execution execution,
+      Clock clock) {
     this.taskRepository = taskRepository;
     this.schedulerListeners = schedulerListeners;
     this.execution = execution;
+    this.clock = clock;
   }
 
   public void stop() {
@@ -39,7 +45,9 @@ public class ExecutionOperations<T> {
   }
 
   public void removeAndScheduleNew(SchedulableInstance<?> schedulableInstance) {
-    Instant executionTime = taskRepository.replace(execution, schedulableInstance);
+    Instant executionTime =
+        taskRepository.replace(
+            execution, ScheduledTaskInstance.fixExecutionTime(schedulableInstance, clock));
     hintExecutionScheduled(schedulableInstance.getTaskInstance(), executionTime);
   }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleOnceOnStartup.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleOnceOnStartup.java
@@ -40,7 +40,8 @@ class ScheduleOnceOnStartup<T> implements ScheduleOnStartup<T> {
   }
 
   public void apply(SchedulerClient scheduler, Clock clock, Task<T> task) {
-    scheduler.schedule(getSchedulableInstance(task), firstExecutionTime.apply(clock.now()));
+    scheduler.scheduleIfNotExists(
+        getSchedulableInstance(task), firstExecutionTime.apply(clock.now()));
   }
 
   private TaskInstance<T> getSchedulableInstance(Task<T> task) {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleRecurringOnStartup.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/ScheduleRecurringOnStartup.java
@@ -76,7 +76,7 @@ class ScheduleRecurringOnStartup<T> implements ScheduleOnStartup<T> {
           "Creating initial execution for task-instance '{}'. Next execution-time: {}",
           instanceWithoutData,
           initialExecutionTime);
-      scheduler.schedule(getSchedulableInstance(task), initialExecutionTime);
+      scheduler.scheduleIfNotExists(getSchedulableInstance(task), initialExecutionTime);
     }
   }
 

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/testhelper/TestHelper.java
@@ -67,6 +67,7 @@ public class TestHelper {
       return this;
     }
 
+    @SuppressWarnings("deprecation")
     public ManualSchedulerBuilder statsRegistry(StatsRegistry statsRegistry) {
       super.statsRegistry = statsRegistry;
       return this;

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientExceptionsTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientExceptionsTest.java
@@ -1,7 +1,6 @@
 package com.github.kagkarlsson.scheduler;
 
 import static com.github.kagkarlsson.scheduler.task.TaskInstanceId.StandardTaskInstanceId;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
@@ -12,6 +11,7 @@ import com.github.kagkarlsson.scheduler.task.Execution;
 import com.github.kagkarlsson.scheduler.task.TaskInstance;
 import java.time.Instant;
 import java.util.Optional;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -24,6 +24,10 @@ public class SchedulerClientExceptionsTest {
   @InjectMocks SchedulerClient.StandardSchedulerClient schedulerClient;
 
   @Mock TaskRepository taskRepository;
+
+  private static String randomAlphanumeric(int count) {
+    return RandomStringUtils.insecure().nextAlphanumeric(count);
+  }
 
   @Test
   public void failsToRescheduleWhenTaskIsNotFound() {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/helper/TestableListener.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/helper/TestableListener.java
@@ -27,7 +27,7 @@ public class TestableListener implements SchedulerListener {
   private final List<ExecutionComplete> completed;
   private final List<SchedulerEventType> stats;
   private List<Condition> waitConditions;
-  private Map<String, AtomicLong> counters = new ConcurrentHashMap();
+  private Map<String, AtomicLong> counters = new ConcurrentHashMap<>();
   private final boolean logEvents;
 
   public TestableListener(boolean logEvents, List<Condition> waitConditions) {

--- a/examples/features/src/main/java/com/github/kagkarlsson/examples/ExponentialBackoffWithMaxRetriesMain.java
+++ b/examples/features/src/main/java/com/github/kagkarlsson/examples/ExponentialBackoffWithMaxRetriesMain.java
@@ -37,9 +37,7 @@ public class ExponentialBackoffWithMaxRetriesMain extends Example {
   public void run(DataSource dataSource) {
     OneTimeTask<Void> failingTask =
         Tasks.oneTime(EXPONENTIAL_BACKOFF_TASK)
-            .onFailure(
-                new FailureHandler.MaxRetriesFailureHandler<>(
-                    6, new FailureHandler.ExponentialBackoffFailureHandler<>(ofSeconds(1), 2)))
+            .onFailure(FailureHandler.<Void>maxRetries(6).withBackoff(ofSeconds(1), 2).thenRemove())
             .execute(
                 (taskInstance, executionContext) -> {
                   throw new RuntimeException("simulated task exception");


### PR DESCRIPTION
Cleanup a handful of deprecation and unchecked-operation warnings from internal uses of APIs that have since been superseded.

---
This PR was prepared with Claude Code.