### PR TITLE
Validate that scheduled_tasks table exists on scheduler startup

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Scheduler.java
@@ -93,6 +93,7 @@ public class Scheduler implements SchedulerClient {
       ScheduledExecutorService housekeeperExecutor) {
     this.clock = clock;
     this.schedulerTaskRepository = schedulerTaskRepository;
+    schedulerTaskRepository.validateTableExists();
     this.taskResolver = taskResolver;
     this.threadpoolSize = threadpoolSize;
     this.executor = new Executor(executorService, clock);

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
@@ -107,4 +107,6 @@ public interface TaskRepository {
   int removeExecutions(String taskName);
 
   void verifySupportsLockAndFetch();
+
+  void validateTableExists();
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
@@ -20,6 +20,7 @@ import static java.util.stream.Collectors.partitioningBy;
 import static java.util.stream.Collectors.toList;
 
 import com.github.kagkarlsson.jdbc.JdbcRunner;
+import com.github.kagkarlsson.jdbc.PreparedStatementSetter;
 import com.github.kagkarlsson.jdbc.ResultSetMapper;
 import com.github.kagkarlsson.jdbc.SQLRuntimeException;
 import com.github.kagkarlsson.scheduler.Clock;
@@ -800,6 +801,27 @@ public class JdbcTaskRepository implements TaskRepository {
           "Database using jdbc-customization '"
               + jdbcCustomization.getName()
               + "' does not support lock-and-fetch polling (i.e. Select-for-update)");
+    }
+  }
+
+  @Override
+  public void validateTableExists() {
+    String columns =
+        "task_name, task_instance, task_data, execution_time, picked, version"
+            + (orderByPriority ? ", priority" : "");
+    try {
+      jdbcRunner.query(
+          "select " + columns + " from " + tableName + " where 1 = 0",
+          PreparedStatementSetter.NOOP,
+          (ResultSetMapper<Object>) rs -> null);
+    } catch (SQLRuntimeException e) {
+      throw new IllegalStateException(
+          "Could not find table '"
+              + tableName
+              + "', or it is missing expected columns. "
+              + "Make sure it has been created using the correct DDL for your database — "
+              + "see the 'Database compatibility' section of the README.",
+          e);
     }
   }
 

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.github.kagkarlsson.scheduler.SchedulerName.Fixed;
 import com.github.kagkarlsson.scheduler.task.ExecutionComplete;
@@ -192,6 +193,17 @@ public class SchedulerTest {
     assertThat(scheduler.getCurrentlyExecuting(), hasSize(1));
 
     pausingHandler.waitInExecuteUntil.countDown();
+  }
+
+  @Test
+  public void scheduler_should_fail_to_start_if_table_missing() {
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            Scheduler.create(postgres.getDataSource())
+                .tableName("nonexistent_table")
+                .schedulerName(new SchedulerName.Fixed("missing-table-test"))
+                .build());
   }
 
   @Test


### PR DESCRIPTION
Fixes #507

Adds a fail-fast check that validates the configured table (`scheduled_tasks` by
default) exists and has the expected columns when `Scheduler.start()` is called.
If the table is missing or missing a column, the scheduler now throws an
`IllegalStateException` immediately instead of failing later/silently during
polling.

**Implementation:**
- Added `validateTableExists()` to the `TaskRepository` interface, mirroring the
  existing `verifySupportsLockAndFetch()` pattern.
- Implemented in `JdbcTaskRepository` using a lightweight `select ... where 1 = 0`
  query against all expected columns (including `priority` when enabled). This
  avoids per-database `DatabaseMetaData`/table-name-casing special-casing, since
  the query fails identically across all supported databases if the table or a
  column is missing.
- Called at the very start of `Scheduler.start()`, before any threads are started.
- Added `scheduler_should_fail_to_start_if_table_missing` to `SchedulerTest`,
  which points a `SchedulerBuilder` at a nonexistent table name and asserts
  `start()` throws.

**Open question:** this currently runs unconditionally (matching how
`verifySupportsLockAndFetch()` runs unconditionally for the lock-and-fetch
strategy), rather than being opt-in. Happy to add a `.skipTableValidation()`
escape hatch on `SchedulerBuilder` if you'd prefer it not be on by default —
let me know and I'll adjust.

Fixes #507

#### Reminders
- [x] Added/ran automated tests
- [ ] Update README and/or examples
- [x] Ran `mvn spotless:apply`
- [x] If AI tools were used, disclosed per the [AI Contribution Policy](../AI_POLICY.md)

Used Claude to help me understand the codebase and think through the
implementation approach, as this is my first open-source contribution. I've
reviewed, tested, and understand all the changes and can explain/maintain them.

---
cc @kagkarlsson