### PR TITLE
Add SchedulerListener.onExecutionRemoved callback

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
@@ -596,6 +596,7 @@ public interface SchedulerClient {
         }
 
         taskRepository.remove(execution.get());
+        schedulerListeners.onExecutionRemoved(execution.get());
       } else {
         throw new TaskInstanceNotFoundException(taskName, instanceId);
       }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/event/AbstractSchedulerListener.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/event/AbstractSchedulerListener.java
@@ -37,6 +37,9 @@ public abstract class AbstractSchedulerListener implements SchedulerListener {
   public void onExecutionFailedHeartbeat(CurrentlyExecuting currentlyExecuting) {}
 
   @Override
+  public void onExecutionRemoved(Execution execution) {}
+
+  @Override
   public void onSchedulerEvent(SchedulerEventType type) {}
 
   @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/event/SchedulerListener.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/event/SchedulerListener.java
@@ -72,6 +72,16 @@ public interface SchedulerListener {
   void onExecutionFailedHeartbeat(CurrentlyExecuting currentlyExecuting);
 
   /**
+   * Execution has been removed from the <code>scheduled_tasks</code> table, either because it
+   * completed with a <code>CompletionHandler</code> that stops the task (e.g. <code>
+   * ExecutionOperations.stop()</code>), or because it was explicitly cancelled via <code>
+   * SchedulerClient.cancel(TaskInstanceId)</code>.
+   *
+   * @param execution
+   */
+  void onExecutionRemoved(Execution execution);
+
+  /**
    * Internal scheduler event. Primarily intended for testing.
    *
    * @param type

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/event/SchedulerListeners.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/event/SchedulerListeners.java
@@ -95,6 +95,15 @@ public class SchedulerListeners implements SchedulerListener {
   }
 
   @Override
+  public void onExecutionRemoved(Execution execution) {
+    schedulerListeners.forEach(
+        listener -> {
+          fireAndLogErrors(
+              listener, "onExecutionRemoved", () -> listener.onExecutionRemoved(execution));
+        });
+  }
+
+  @Override
   public void onSchedulerEvent(SchedulerEventType type) {
     schedulerListeners.forEach(
         listener -> {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/stats/StatsRegistryAdapter.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/stats/StatsRegistryAdapter.java
@@ -57,6 +57,9 @@ public class StatsRegistryAdapter implements SchedulerListener {
   public void onExecutionFailedHeartbeat(CurrentlyExecuting currentlyExecuting) {}
 
   @Override
+  public void onExecutionRemoved(Execution execution) {}
+
+  @Override
   public void onSchedulerEvent(SchedulerEventType type) {
     if (statsRegistry == null) {
       return;

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/ExecutionOperations.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/ExecutionOperations.java
@@ -42,6 +42,7 @@ public class ExecutionOperations<T> {
 
   public void remove() {
     taskRepository.remove(execution);
+    schedulerListeners.onExecutionRemoved(execution);
   }
 
   public void removeAndScheduleNew(SchedulableInstance<?> schedulableInstance) {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/helper/TestableListener.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/helper/TestableListener.java
@@ -22,6 +22,7 @@ public class TestableListener implements SchedulerListener {
           SchedulerEventType.FAILUREHANDLER_ERROR,
           SchedulerEventType.DEAD_EXECUTION);
 
+  private final List<Execution> removed = Collections.synchronizedList(new ArrayList<>());
   private static final Logger LISTENER_LOGGER = LoggerFactory.getLogger(TestableListener.class);
 
   private final List<ExecutionComplete> completed;
@@ -66,6 +67,16 @@ public class TestableListener implements SchedulerListener {
   @Override
   public void onExecutionFailedHeartbeat(CurrentlyExecuting currentlyExecuting) {
     logOnExecutionFailedHeartbeat(currentlyExecuting);
+  }
+
+  @Override
+  public void onExecutionRemoved(Execution execution) {
+    removed.add(execution);
+    log("Execution removed: " + execution);
+  }
+
+  public List<Execution> getRemoved() {
+    return removed;
   }
 
   @Override


### PR DESCRIPTION
## Summary

Adds a new `SchedulerListener.onExecutionRemoved(Execution)` callback.

The callback is invoked after a successful `TaskRepository.remove(...)` operation and is triggered from:

- `ExecutionOperations.remove()`
- `SchedulerClient.cancel(...)`

Implements the listener hook proposed in #902.

## Verification

- `mvn -pl db-scheduler test`
- `mvn -pl db-scheduler spotless:check`                                                                                                                                                                                                                                                                                                                                                                                             

 ##AI tool disclosure
AI tools were used to help explore the codebase and discuss implementation approaches.
I reviewed, implemented, tested, and take responsibility for the submitted changes.