### PR TITLE
fix: remove package-relocation for com.github.kagkarlsson.jdbc

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,11 @@
 Version-specific upgrade notes. For the full list of changes per release, see
 [releases](https://github.com/kagkarlsson/db-scheduler/releases).
 
+**Upgrading to 16.13.x**
+* The internal JDBC helpers (`JdbcRunner`, `SQLRuntimeException`, etc.) have moved from
+`com.github.kagkarlsson.shaded.jdbc` to `com.github.kagkarlsson.jdbc`. Unlikely to affect anyone, but if you
+reference these classes directly you will have to update your imports.
+
 **Upgrading to 16.x**
 * Java 17+ is required now, since we migrated our codebase to Java 17
 

--- a/pom.xml
+++ b/pom.xml
@@ -208,10 +208,6 @@
             </filters>
             <relocations>
               <relocation>
-                <pattern>com.github.kagkarlsson.jdbc</pattern>
-                <shadedPattern>com.github.kagkarlsson.shaded.jdbc</shadedPattern>
-              </relocation>
-              <relocation>
                 <pattern>com.cronutils</pattern>
                 <shadedPattern>com.github.kagkarlsson.shaded.cronutils</shadedPattern>
               </relocation>


### PR DESCRIPTION
The shade plugin still relocated `com.github.kagkarlsson.jdbc` to `com.github.kagkarlsson.shaded.jdbc`. That made sense while these classes came from the separate `micro-jdbc` artifact, but since the sources were inlined in #682 it has been relocating first-party code. They now ship under the package they are declared in.

- Drop the `com.github.kagkarlsson.jdbc` relocation from the shade plugin config
- Add a 16.13.x upgrade note

`JdbcRunner` and the other JDBC helpers have moved from `com.github.kagkarlsson.shaded.jdbc` to `com.github.kagkarlsson.jdbc`. Code referencing them directly has to update its imports.

Fixes #907

---
This PR was prepared with Claude Code.
