### PR TITLE
Fix typo in DEFAULT_FAILURE_LOG_LEVEL

### DIFF
--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerProperties.java
@@ -115,7 +115,7 @@ public class DbSchedulerProperties {
    */
   private boolean alwaysPersistTimestampInUtc = false;
 
-  /** Which log level to use when logging task failures. Defaults to {@link LogLevel#DEBUG}. */
+  /** Which log level to use when logging task failures. Defaults to {@link LogLevel#WARN}. */
   private LogLevel failureLoggerLevel = SchedulerBuilder.DEFAULT_FAILURE_LOG_LEVEL;
 
   /** Whether or not to log the {@link Throwable} that caused a task to fail. */


### PR DESCRIPTION
Annotation states that default log level is DEBUG, but it was reverted back to WARN with commit 58dc285. Changing annotation to match

Original PR for custom logger: https://github.com/kagkarlsson/db-scheduler/pull/171

I did not run tests as this was a nit edit to a comment (non functional change), but let me know if any testing is needed.

---

cc @kagkarlsson
