### PR TITLE
fix: validate that pollingInterval is greater than zero

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
@@ -99,6 +99,12 @@ public class SchedulerBuilder {
   }
 
   public SchedulerBuilder pollingInterval(Duration pollingInterval) {
+    if (pollingInterval == null) {
+      throw new IllegalArgumentException("Polling interval must not be null");
+    }
+    if (pollingInterval.isZero() || pollingInterval.isNegative()) {
+      throw new IllegalArgumentException("Polling interval must be greater than 0");
+    }
     this.poolingInterval = pollingInterval;
     return this;
   }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
@@ -99,10 +99,7 @@ public class SchedulerBuilder {
   }
 
   public SchedulerBuilder pollingInterval(Duration pollingInterval) {
-    if (pollingInterval == null) {
-      throw new IllegalArgumentException("Polling interval must not be null");
-    }
-    if (pollingInterval.isZero() || pollingInterval.isNegative()) {
+    if (pollingInterval == null || pollingInterval.toMillis() <= 0) {
       throw new IllegalArgumentException("Polling interval must be greater than 0");
     }
     this.poolingInterval = pollingInterval;

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerBuilderTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerBuilderTest.java
@@ -26,7 +26,7 @@ public class SchedulerBuilderTest {
 
     assertThatThrownBy(() -> builder().pollingInterval(null))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Polling interval must not be null");
+        .hasMessage("Polling interval must be greater than 0");
   }
 
   @Test

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerBuilderTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerBuilderTest.java
@@ -1,0 +1,40 @@
+package com.github.kagkarlsson.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.kagkarlsson.scheduler.task.Task;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class SchedulerBuilderTest {
+
+  private static SchedulerBuilder builder() {
+    return new SchedulerBuilder(null, List.<Task<?>>of());
+  }
+
+  @Test
+  public void polling_interval_must_be_greater_than_zero() {
+    assertThatThrownBy(() -> builder().pollingInterval(Duration.ZERO))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Polling interval must be greater than 0");
+
+    assertThatThrownBy(() -> builder().pollingInterval(Duration.ofSeconds(-1)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Polling interval must be greater than 0");
+
+    assertThatThrownBy(() -> builder().pollingInterval(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Polling interval must not be null");
+  }
+
+  @Test
+  public void polling_interval_accepts_positive_duration() {
+    SchedulerBuilder builder = builder();
+
+    assertThat(builder.pollingInterval(Duration.ofMillis(1))).isSameAs(builder);
+    assertThat(builder.poolingInterval).isEqualTo(Duration.ofMillis(1));
+    assertThat(builder().poolingInterval).isEqualTo(SchedulerBuilder.DEFAULT_POLLING_INTERVAL);
+  }
+}


### PR DESCRIPTION
`pollingInterval()` accepted zero and negative durations, 
which makes the polling loop spin without pausing. It is now validated in the builder, like
`missedHeartbeatsLimit()` already is.

Fixes #339

#### Reminders

- [X] Added/ran automated tests
- [ ] Update README and/or examples
- [X] Ran `mvn spotless:apply`
- [ ] If AI tools were used, disclosed per the [AI Contribution Policy](../AI_POLICY.md)

---

cc @kagkarlsson
