### PR TITLE
feat: replace DbSchedulerCustomizer with DbSchedulerOverrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ For Spring Boot applications, there is a starter `db-scheduler-spring-boot-start
 
 ### Configuration options
 
-Configuration is mainly done via `application.properties`. Settings that cannot be expressed as properties — scheduler-name, serializer, executor-services, `JdbcCustomization` and `DataSource` — are configured by adding a bean of type `DbSchedulerOverrides` to your Spring context.
+Configuration is mainly done via `application.properties`. Settings that cannot be expressed as properties are configured by adding a bean of type `DbSchedulerOverrides` to your Spring context.
 
 ```java
 @Bean
@@ -464,13 +464,7 @@ DbSchedulerOverrides dbSchedulerOverrides() {
 }
 ```
 
-Anything left unset falls back to the corresponding property, and then to the library default. To set something programmatically that does have a property, or to reach a `SchedulerBuilder` option the starter does not surface, use the `customizeBuilder` escape hatch — it is applied last, so it wins over the properties:
-
-```java
-DbSchedulerOverrides.builder()
-    .customizeBuilder(builder -> builder.registerShutdownHook())
-    .build();
-```
+Anything left unset falls back to the corresponding property, and then to the library default. To set something programmatically that does have a property, or to reach a `SchedulerBuilder` option the starter does not surface, use the `customizeBuilder` escape hatch.
 
 **NB:** `DbSchedulerOverrides` replaces `DbSchedulerCustomizer` as of 17.0.0. An existing `DbSchedulerCustomizer` bean is still honoured, but it is deprecated and support for it will be removed in a future version.
 

--- a/README.md
+++ b/README.md
@@ -452,7 +452,27 @@ For Spring Boot applications, there is a starter `db-scheduler-spring-boot-start
 
 ### Configuration options
 
-Configuration is mainly done via `application.properties`. Configuration of scheduler-name, serializer and executor-service is done by adding a bean of type `DbSchedulerCustomizer` to your Spring context.
+Configuration is mainly done via `application.properties`. Settings that cannot be expressed as properties — scheduler-name, serializer, executor-services, `JdbcCustomization` and `DataSource` — are configured by adding a bean of type `DbSchedulerOverrides` to your Spring context.
+
+```java
+@Bean
+DbSchedulerOverrides dbSchedulerOverrides() {
+  return DbSchedulerOverrides.builder()
+      .schedulerName(new SchedulerName.Fixed("scheduler-1"))
+      .serializer(new JacksonSerializer())
+      .build();
+}
+```
+
+Anything left unset falls back to the corresponding property, and then to the library default. To set something programmatically that does have a property, or to reach a `SchedulerBuilder` option the starter does not surface, use the `customizeBuilder` escape hatch — it is applied last, so it wins over the properties:
+
+```java
+DbSchedulerOverrides.builder()
+    .customizeBuilder(builder -> builder.registerShutdownHook())
+    .build();
+```
+
+**NB:** `DbSchedulerOverrides` replaces `DbSchedulerCustomizer` as of 17.0.0. An existing `DbSchedulerCustomizer` bean is still honoured, but it is deprecated and support for it will be removed in a future version.
 
 ```
 # application.properties example showing default values

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot3-starter/pom.xml
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot3-starter/pom.xml
@@ -46,6 +46,10 @@
     <!-- Spring dependencies -->
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>
@@ -106,11 +110,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-beans</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-test</artifactId>

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot3-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot3-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
@@ -18,6 +18,7 @@ import com.github.kagkarlsson.scheduler.Scheduler;
 import com.github.kagkarlsson.scheduler.SystemClock;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerConfigurationSupport;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerCustomizer;
+import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerOverrides;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerProperties;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerStarter;
 import com.github.kagkarlsson.scheduler.boot.config.startup.ContextReadyStart;
@@ -31,6 +32,7 @@ import java.util.Objects;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.LazyInitializationExcludeFilter;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -76,13 +78,6 @@ public class DbSchedulerAutoConfiguration {
     this.executionInterceptors = executionInterceptors;
   }
 
-  /** Provide an empty customizer if not present in the context. */
-  @ConditionalOnMissingBean
-  @Bean
-  public DbSchedulerCustomizer noopCustomizer() {
-    return new DbSchedulerCustomizer() {};
-  }
-
   /** Will typically be created if Spring Boot Actuator is not on the classpath. */
   @ConditionalOnMissingBean(StatsRegistry.class)
   @Bean
@@ -101,12 +96,17 @@ public class DbSchedulerAutoConfiguration {
   @ConditionalOnMissingBean
   @DependsOnDatabaseInitialization
   @Bean(destroyMethod = "stop")
+  @SuppressWarnings("removal")
   public Scheduler scheduler(
-      DbSchedulerCustomizer customizer, StatsRegistry registry, Clock clock) {
+      ObjectProvider<DbSchedulerOverrides> overrides,
+      ObjectProvider<DbSchedulerCustomizer> legacyCustomizer,
+      StatsRegistry registry,
+      Clock clock) {
     log.info("Creating db-scheduler using tasks from Spring context: {}", configuredTasks);
     return DbSchedulerConfigurationSupport.buildScheduler(
         config,
-        customizer,
+        DbSchedulerConfigurationSupport.resolveOverrides(
+            overrides.getIfAvailable(), legacyCustomizer.getIfAvailable()),
         registry,
         clock,
         existingDataSource,

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot3-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot3-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
@@ -365,7 +365,6 @@ public class DbSchedulerAutoConfigurationTest {
     static final AtomicBoolean SCHEDULER_NAME_USED = new AtomicBoolean();
 
     @Bean
-    @SuppressWarnings("removal")
     DbSchedulerCustomizer customizer() {
       return new DbSchedulerCustomizer() {
         @Override

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot3-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot3-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
@@ -147,6 +147,7 @@ public class DbSchedulerAutoConfigurationTest {
   }
 
   @Test
+  @SuppressWarnings("removal")
   public void it_should_skip_autoconfiguration_if_explicitly_disabled() {
     ctxRunner
         .withPropertyValues("db-scheduler.enabled=false")
@@ -365,6 +366,7 @@ public class DbSchedulerAutoConfigurationTest {
     static final AtomicBoolean SCHEDULER_NAME_USED = new AtomicBoolean();
 
     @Bean
+    @SuppressWarnings("removal")
     DbSchedulerCustomizer customizer() {
       return new DbSchedulerCustomizer() {
         @Override

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot3-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot3-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
@@ -8,8 +8,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import com.github.kagkarlsson.scheduler.Scheduler;
+import com.github.kagkarlsson.scheduler.SchedulerName;
 import com.github.kagkarlsson.scheduler.boot.actuator.DbSchedulerHealthIndicator;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerCustomizer;
+import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerOverrides;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerProperties;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerStarter;
 import com.github.kagkarlsson.scheduler.boot.config.startup.AbstractSchedulerStarter;
@@ -25,6 +27,8 @@ import com.google.common.collect.ImmutableList;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
@@ -150,6 +154,7 @@ public class DbSchedulerAutoConfigurationTest {
             (AssertableApplicationContext ctx) -> {
               assertThat(ctx).doesNotHaveBean(Scheduler.class);
               assertThat(ctx).doesNotHaveBean(DbSchedulerStarter.class);
+              assertThat(ctx).doesNotHaveBean(DbSchedulerOverrides.class);
               assertThat(ctx).doesNotHaveBean(DbSchedulerCustomizer.class);
               assertThat(ctx).doesNotHaveBean(DbSchedulerHealthIndicator.class);
               assertThat(ctx).doesNotHaveBean(StatsRegistry.class);
@@ -195,6 +200,47 @@ public class DbSchedulerAutoConfigurationTest {
 
               DbSchedulerProperties props = ctx.getBean(DbSchedulerProperties.class);
               assertThat(props.isPriorityEnabled()).isTrue();
+            });
+  }
+
+  @Test
+  public void it_should_apply_a_db_scheduler_overrides_bean() {
+    OverridesConfiguration.SCHEDULER_NAME_USED.set(false);
+
+    ctxRunner
+        .withUserConfiguration(OverridesConfiguration.class)
+        .run(
+            (AssertableApplicationContext ctx) -> {
+              assertThat(ctx).hasSingleBean(Scheduler.class);
+              assertThat(OverridesConfiguration.SCHEDULER_NAME_USED).isTrue();
+            });
+  }
+
+  @Test
+  public void it_should_still_apply_a_deprecated_customizer_bean() {
+    LegacyCustomizerConfiguration.SCHEDULER_NAME_USED.set(false);
+
+    ctxRunner
+        .withUserConfiguration(LegacyCustomizerConfiguration.class)
+        .run(
+            (AssertableApplicationContext ctx) -> {
+              assertThat(ctx).hasSingleBean(Scheduler.class);
+              assertThat(LegacyCustomizerConfiguration.SCHEDULER_NAME_USED).isTrue();
+            });
+  }
+
+  /** customizeBuilder is applied last, so it wins over anything derived from the properties. */
+  @Test
+  public void it_should_let_customize_builder_win_over_properties() {
+    CustomizeBuilderConfiguration.SCHEDULER_NAME_USED.set(false);
+
+    ctxRunner
+        .withPropertyValues("db-scheduler.scheduler-name=name-from-property")
+        .withUserConfiguration(CustomizeBuilderConfiguration.class)
+        .run(
+            (AssertableApplicationContext ctx) -> {
+              assertThat(ctx).hasSingleBean(Scheduler.class);
+              assertThat(CustomizeBuilderConfiguration.SCHEDULER_NAME_USED).isTrue();
             });
   }
 
@@ -300,6 +346,55 @@ public class DbSchedulerAutoConfigurationTest {
     Task<String> thirdTask() {
       return namedStringTask("third-task");
     }
+  }
+
+  @Configuration
+  static class OverridesConfiguration extends SingleTaskConfiguration {
+    static final AtomicBoolean SCHEDULER_NAME_USED = new AtomicBoolean();
+
+    @Bean
+    DbSchedulerOverrides dbSchedulerOverrides() {
+      return DbSchedulerOverrides.builder()
+          .schedulerName(recordingSchedulerName(SCHEDULER_NAME_USED))
+          .build();
+    }
+  }
+
+  @Configuration
+  static class LegacyCustomizerConfiguration extends SingleTaskConfiguration {
+    static final AtomicBoolean SCHEDULER_NAME_USED = new AtomicBoolean();
+
+    @Bean
+    @SuppressWarnings("removal")
+    DbSchedulerCustomizer customizer() {
+      return new DbSchedulerCustomizer() {
+        @Override
+        public Optional<SchedulerName> schedulerName() {
+          return Optional.of(recordingSchedulerName(SCHEDULER_NAME_USED));
+        }
+      };
+    }
+  }
+
+  @Configuration
+  static class CustomizeBuilderConfiguration extends SingleTaskConfiguration {
+    static final AtomicBoolean SCHEDULER_NAME_USED = new AtomicBoolean();
+
+    @Bean
+    DbSchedulerOverrides dbSchedulerOverrides() {
+      return DbSchedulerOverrides.builder()
+          .customizeBuilder(
+              builder -> builder.schedulerName(recordingSchedulerName(SCHEDULER_NAME_USED)))
+          .build();
+    }
+  }
+
+  /** A {@link SchedulerName} that records having been asked for its name when the builder runs. */
+  private static SchedulerName recordingSchedulerName(AtomicBoolean used) {
+    return () -> {
+      used.set(true);
+      return "recorded-scheduler-name";
+    };
   }
 
   @Configuration

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot4-starter/pom.xml
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot4-starter/pom.xml
@@ -88,6 +88,10 @@
     <!-- Spring framework -->
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
 
@@ -121,11 +125,6 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-beans</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot4-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot4-starter/src/main/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfiguration.java
@@ -18,6 +18,7 @@ import com.github.kagkarlsson.scheduler.Scheduler;
 import com.github.kagkarlsson.scheduler.SystemClock;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerConfigurationSupport;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerCustomizer;
+import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerOverrides;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerProperties;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerStarter;
 import com.github.kagkarlsson.scheduler.boot.config.startup.ContextReadyStart;
@@ -31,6 +32,7 @@ import java.util.Objects;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.LazyInitializationExcludeFilter;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -76,13 +78,6 @@ public class DbSchedulerAutoConfiguration {
     this.executionInterceptors = executionInterceptors;
   }
 
-  /** Provide an empty customizer if not present in the context. */
-  @ConditionalOnMissingBean
-  @Bean
-  public DbSchedulerCustomizer noopCustomizer() {
-    return new DbSchedulerCustomizer() {};
-  }
-
   /** Will typically be created if Spring Boot Actuator is not on the classpath. */
   @ConditionalOnMissingBean(StatsRegistry.class)
   @Bean
@@ -101,12 +96,17 @@ public class DbSchedulerAutoConfiguration {
   @ConditionalOnMissingBean
   @DependsOnDatabaseInitialization
   @Bean(destroyMethod = "stop")
+  @SuppressWarnings("removal")
   public Scheduler scheduler(
-      DbSchedulerCustomizer customizer, StatsRegistry registry, Clock clock) {
+      ObjectProvider<DbSchedulerOverrides> overrides,
+      ObjectProvider<DbSchedulerCustomizer> legacyCustomizer,
+      StatsRegistry registry,
+      Clock clock) {
     log.info("Creating db-scheduler using tasks from Spring context: {}", configuredTasks);
     return DbSchedulerConfigurationSupport.buildScheduler(
         config,
-        customizer,
+        DbSchedulerConfigurationSupport.resolveOverrides(
+            overrides.getIfAvailable(), legacyCustomizer.getIfAvailable()),
         registry,
         clock,
         existingDataSource,

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot4-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot4-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
@@ -147,6 +147,7 @@ class DbSchedulerAutoConfigurationTest {
     @Autowired ApplicationContext ctx;
 
     @Test
+    @SuppressWarnings("removal")
     void it_should_skip_autoconfiguration_if_explicitly_disabled() {
       assertThat(ctx.getBeansOfType(Scheduler.class)).isEmpty();
       assertThat(ctx.getBeansOfType(DbSchedulerStarter.class)).isEmpty();

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot4-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot4-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/autoconfigure/DbSchedulerAutoConfigurationTest.java
@@ -10,12 +10,14 @@ import static org.assertj.core.api.Assertions.fail;
 import com.github.kagkarlsson.scheduler.Scheduler;
 import com.github.kagkarlsson.scheduler.boot.actuator.DbSchedulerHealthIndicator;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerCustomizer;
+import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerOverrides;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerProperties;
 import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerStarter;
 import com.github.kagkarlsson.scheduler.boot.config.startup.ContextReadyStart;
 import com.github.kagkarlsson.scheduler.boot.config.startup.ImmediateStart;
 import com.github.kagkarlsson.scheduler.boot.testconfig.CustomStarterConfiguration;
 import com.github.kagkarlsson.scheduler.boot.testconfig.CustomStatsRegistryConfiguration;
+import com.github.kagkarlsson.scheduler.boot.testconfig.DbSchedulerOverridesConfiguration;
 import com.github.kagkarlsson.scheduler.boot.testconfig.MultipleTasksConfiguration;
 import com.github.kagkarlsson.scheduler.boot.testconfig.SingleTaskConfiguration;
 import com.github.kagkarlsson.scheduler.stats.MicrometerStatsRegistry;
@@ -148,6 +150,7 @@ class DbSchedulerAutoConfigurationTest {
     void it_should_skip_autoconfiguration_if_explicitly_disabled() {
       assertThat(ctx.getBeansOfType(Scheduler.class)).isEmpty();
       assertThat(ctx.getBeansOfType(DbSchedulerStarter.class)).isEmpty();
+      assertThat(ctx.getBeansOfType(DbSchedulerOverrides.class)).isEmpty();
       assertThat(ctx.getBeansOfType(DbSchedulerCustomizer.class)).isEmpty();
       assertThat(ctx.getBeansOfType(DbSchedulerHealthIndicator.class)).isEmpty();
       assertThat(ctx.getBeansOfType(StatsRegistry.class)).isEmpty();
@@ -218,6 +221,27 @@ class DbSchedulerAutoConfigurationTest {
       assertThat(ctx.getBean("firstTask")).isInstanceOf(Task.class);
       assertThat(ctx.getBean("secondTask")).isInstanceOf(Task.class);
       assertThat(ctx.getBean("thirdTask")).isInstanceOf(Task.class);
+    }
+  }
+
+  /* -------------------------------------------------------------------------
+   *  DbSchedulerOverrides bean is picked up
+   * ------------------------------------------------------------------------- */
+  @Nested
+  @SpringBootTest(
+      classes = {
+        CommonAutoConfig.class,
+        SingleTaskConfiguration.class,
+        DbSchedulerOverridesConfiguration.class
+      })
+  class WithOverrides {
+
+    @Autowired ApplicationContext ctx;
+
+    @Test
+    void it_should_apply_a_db_scheduler_overrides_bean() {
+      assertThat(ctx.getBeansOfType(Scheduler.class)).hasSize(1);
+      assertThat(DbSchedulerOverridesConfiguration.SCHEDULER_NAME_USED).isTrue();
     }
   }
 

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot4-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/testconfig/DbSchedulerOverridesConfiguration.java
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot4-starter/src/test/java/com/github/kagkarlsson/scheduler/boot/testconfig/DbSchedulerOverridesConfiguration.java
@@ -1,0 +1,23 @@
+package com.github.kagkarlsson.scheduler.boot.testconfig;
+
+import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerOverrides;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class DbSchedulerOverridesConfiguration {
+
+  public static final AtomicBoolean SCHEDULER_NAME_USED = new AtomicBoolean();
+
+  @Bean
+  DbSchedulerOverrides dbSchedulerOverrides() {
+    return DbSchedulerOverrides.builder()
+        .schedulerName(
+            () -> {
+              SCHEDULER_NAME_USED.set(true);
+              return "recorded-scheduler-name";
+            })
+        .build();
+  }
+}

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/pom.xml
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/pom.xml
@@ -56,6 +56,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerConfigurationSupport.java
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerConfigurationSupport.java
@@ -50,8 +50,7 @@ public final class DbSchedulerConfigurationSupport {
   private DbSchedulerConfigurationSupport() {}
 
   /**
-   * @deprecated use the {@link DbSchedulerOverrides} overload. Will be removed in a future version
-   *     along with {@link DbSchedulerCustomizer}.
+   * @deprecated use the {@link DbSchedulerOverrides} overload
    */
   @Deprecated(since = "17.0.0", forRemoval = true)
   @SuppressWarnings("removal")
@@ -192,8 +191,7 @@ public final class DbSchedulerConfigurationSupport {
   }
 
   /**
-   * @deprecated bridge for {@link DbSchedulerCustomizer}, removed in a future version along with
-   *     it.
+   * @deprecated bridge for {@link DbSchedulerCustomizer}
    */
   @Deprecated(since = "17.0.0", forRemoval = true)
   @SuppressWarnings("removal")

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerConfigurationSupport.java
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerConfigurationSupport.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.sql.DataSource;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.ConfigurableObjectInputStream;
@@ -48,6 +49,11 @@ public final class DbSchedulerConfigurationSupport {
 
   private DbSchedulerConfigurationSupport() {}
 
+  /**
+   * @deprecated use the {@link DbSchedulerOverrides} overload. Will be removed in a future version
+   *     along with {@link DbSchedulerCustomizer}.
+   */
+  @Deprecated(since = "17.0.0", forRemoval = true)
   public static Scheduler buildScheduler(
       DbSchedulerProperties config,
       DbSchedulerCustomizer customizer,
@@ -58,8 +64,30 @@ public final class DbSchedulerConfigurationSupport {
       List<SchedulerListener> schedulerListeners,
       List<ExecutionInterceptor> executionInterceptors) {
 
-    Objects.requireNonNull(config, "Configuration must not be null");
     Objects.requireNonNull(customizer, "Customizer must not be null");
+    return buildScheduler(
+        config,
+        toOverrides(customizer),
+        registry,
+        clock,
+        existingDataSource,
+        configuredTasks,
+        schedulerListeners,
+        executionInterceptors);
+  }
+
+  public static Scheduler buildScheduler(
+      DbSchedulerProperties config,
+      DbSchedulerOverrides overrides,
+      StatsRegistry registry,
+      Clock clock,
+      DataSource existingDataSource,
+      List<Task<?>> configuredTasks,
+      List<SchedulerListener> schedulerListeners,
+      List<ExecutionInterceptor> executionInterceptors) {
+
+    Objects.requireNonNull(config, "Configuration must not be null");
+    Objects.requireNonNull(overrides, "Overrides must not be null");
     Objects.requireNonNull(registry, "StatsRegistry must not be null");
     Objects.requireNonNull(clock, "Clock must not be null");
     Objects.requireNonNull(existingDataSource, "DataSource must not be null");
@@ -68,7 +96,7 @@ public final class DbSchedulerConfigurationSupport {
     Objects.requireNonNull(executionInterceptors, "Execution interceptors must not be null");
 
     DataSource transactionalDataSource =
-        configureDataSource(customizer.dataSource().orElse(existingDataSource));
+        configureDataSource(overrides.dataSource().orElse(existingDataSource));
 
     SchedulerBuilder builder =
         Scheduler.create(transactionalDataSource, nonStartupTasks(configuredTasks));
@@ -94,15 +122,15 @@ public final class DbSchedulerConfigurationSupport {
     builder.heartbeatInterval(config.getHeartbeatInterval());
     builder.missedHeartbeatsLimit(config.getMissedHeartbeatsLimit());
 
-    if (customizer.schedulerName().isPresent()) {
-      builder.schedulerName(customizer.schedulerName().get());
+    if (overrides.schedulerName().isPresent()) {
+      builder.schedulerName(overrides.schedulerName().get());
     } else if (config.getSchedulerName() != null) {
       builder.schedulerName(new SchedulerName.Fixed(config.getSchedulerName()));
     }
 
     builder.tableName(config.getTableName());
-    builder.serializer(customizer.serializer().orElse(SPRING_JAVA_SERIALIZER));
-    customizer.jdbcCustomization().ifPresent(builder::jdbcCustomization);
+    builder.serializer(overrides.serializer().orElse(SPRING_JAVA_SERIALIZER));
+    overrides.jdbcCustomization().ifPresent(builder::jdbcCustomization);
 
     if (config.isAlwaysPersistTimestampInUtc()) {
       builder.alwaysPersistTimestampInUTC();
@@ -116,9 +144,9 @@ public final class DbSchedulerConfigurationSupport {
       builder.enablePriority();
     }
 
-    customizer.executorService().ifPresent(builder::executorService);
-    customizer.dueExecutor().ifPresent(builder::dueExecutor);
-    customizer.housekeeperExecutor().ifPresent(builder::housekeeperExecutor);
+    overrides.executorService().ifPresent(builder::executorService);
+    overrides.dueExecutor().ifPresent(builder::dueExecutor);
+    overrides.housekeeperExecutor().ifPresent(builder::housekeeperExecutor);
 
     builder.deleteUnresolvedAfter(config.getDeleteUnresolvedAfter());
     builder.startTasks(startupTasks(configuredTasks));
@@ -128,6 +156,55 @@ public final class DbSchedulerConfigurationSupport {
 
     schedulerListeners.forEach(builder::addSchedulerListener);
     executionInterceptors.forEach(builder::addExecutionInterceptor);
+
+    // Applied last so it can override anything derived from the properties above.
+    overrides.builderCustomizer().ifPresent(customize -> customize.accept(builder));
+
+    return builder.build();
+  }
+
+  /**
+   * Resolves which overrides to build the scheduler from, bridging a legacy {@link
+   * DbSchedulerCustomizer} bean if that is all the context provides.
+   */
+  @SuppressWarnings("removal")
+  public static DbSchedulerOverrides resolveOverrides(
+      @Nullable DbSchedulerOverrides overrides, @Nullable DbSchedulerCustomizer legacyCustomizer) {
+
+    if (overrides != null) {
+      if (legacyCustomizer != null) {
+        log.warn(
+            "Found both a DbSchedulerOverrides and a deprecated DbSchedulerCustomizer bean. "
+                + "The DbSchedulerCustomizer is ignored and should be removed.");
+      }
+      return overrides;
+    }
+
+    if (legacyCustomizer != null) {
+      log.warn(
+          "DbSchedulerCustomizer is deprecated and support for it will be removed in a future "
+              + "version. Expose a DbSchedulerOverrides bean instead.");
+      return toOverrides(legacyCustomizer);
+    }
+
+    return DbSchedulerOverrides.none();
+  }
+
+  /**
+   * @deprecated bridge for {@link DbSchedulerCustomizer}, removed in a future version along with
+   *     it.
+   */
+  @Deprecated(since = "17.0.0", forRemoval = true)
+  public static DbSchedulerOverrides toOverrides(DbSchedulerCustomizer customizer) {
+    DbSchedulerOverrides.Builder builder = DbSchedulerOverrides.builder();
+
+    customizer.schedulerName().ifPresent(builder::schedulerName);
+    customizer.serializer().ifPresent(builder::serializer);
+    customizer.dataSource().ifPresent(builder::dataSource);
+    customizer.executorService().ifPresent(builder::executorService);
+    customizer.dueExecutor().ifPresent(builder::dueExecutor);
+    customizer.housekeeperExecutor().ifPresent(builder::housekeeperExecutor);
+    customizer.jdbcCustomization().ifPresent(builder::jdbcCustomization);
 
     return builder.build();
   }

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerConfigurationSupport.java
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerConfigurationSupport.java
@@ -195,7 +195,7 @@ public final class DbSchedulerConfigurationSupport {
    *     it.
    */
   @Deprecated(since = "17.0.0", forRemoval = true)
-  public static DbSchedulerOverrides toOverrides(DbSchedulerCustomizer customizer) {
+  private static DbSchedulerOverrides toOverrides(DbSchedulerCustomizer customizer) {
     DbSchedulerOverrides.Builder builder = DbSchedulerOverrides.builder();
 
     customizer.schedulerName().ifPresent(builder::schedulerName);

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerConfigurationSupport.java
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerConfigurationSupport.java
@@ -54,6 +54,7 @@ public final class DbSchedulerConfigurationSupport {
    *     along with {@link DbSchedulerCustomizer}.
    */
   @Deprecated(since = "17.0.0", forRemoval = true)
+  @SuppressWarnings("removal")
   public static Scheduler buildScheduler(
       DbSchedulerProperties config,
       DbSchedulerCustomizer customizer,
@@ -195,6 +196,7 @@ public final class DbSchedulerConfigurationSupport {
    *     it.
    */
   @Deprecated(since = "17.0.0", forRemoval = true)
+  @SuppressWarnings("removal")
   private static DbSchedulerOverrides toOverrides(DbSchedulerCustomizer customizer) {
     DbSchedulerOverrides.Builder builder = DbSchedulerOverrides.builder();
 

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerCustomizer.java
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerCustomizer.java
@@ -24,7 +24,13 @@ import javax.sql.DataSource;
 /**
  * Provides functionality for customizing various aspects of the db-scheduler configuration that is
  * not easily done with properties.
+ *
+ * @deprecated in favour of {@link DbSchedulerOverrides}, which covers the same settings as an
+ *     immutable value object rather than an interface to implement. Expose a {@code
+ *     DbSchedulerOverrides} bean instead; a bean of this type is still honoured, but support will
+ *     be removed in a future version.
  */
+@Deprecated(since = "17.0.0", forRemoval = true)
 public interface DbSchedulerCustomizer {
   /** Provide a custom {@link SchedulerName} implementation. */
   default Optional<SchedulerName> schedulerName() {

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerCustomizer.java
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerCustomizer.java
@@ -25,10 +25,7 @@ import javax.sql.DataSource;
  * Provides functionality for customizing various aspects of the db-scheduler configuration that is
  * not easily done with properties.
  *
- * @deprecated in favour of {@link DbSchedulerOverrides}, which covers the same settings as an
- *     immutable value object rather than an interface to implement. Expose a {@code
- *     DbSchedulerOverrides} bean instead; a bean of this type is still honoured, but support will
- *     be removed in a future version.
+ * @deprecated in favour of {@link DbSchedulerOverrides}
  */
 @Deprecated(since = "17.0.0", forRemoval = true)
 public interface DbSchedulerCustomizer {

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerOverrides.java
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-common/src/main/java/com/github/kagkarlsson/scheduler/boot/config/DbSchedulerOverrides.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) Gustav Karlsson
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.kagkarlsson.scheduler.boot.config;
+
+import com.github.kagkarlsson.scheduler.SchedulerBuilder;
+import com.github.kagkarlsson.scheduler.SchedulerName;
+import com.github.kagkarlsson.scheduler.jdbc.JdbcCustomization;
+import com.github.kagkarlsson.scheduler.serializer.Serializer;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
+import javax.sql.DataSource;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Overrides for the parts of the db-scheduler configuration that cannot be expressed as properties.
+ *
+ * <p>Expose one as a bean to have it picked up by the auto-configuration:
+ *
+ * <pre>{@code
+ * @Bean
+ * DbSchedulerOverrides dbSchedulerOverrides() {
+ *   return DbSchedulerOverrides.builder()
+ *       .schedulerName(new SchedulerName.Fixed("scheduler-1"))
+ *       .serializer(new JacksonSerializer())
+ *       .build();
+ * }
+ * }</pre>
+ *
+ * <p>Anything left unset falls back to the corresponding {@code db-scheduler.*} property, and then
+ * to the library default. Settings that do have a property equivalent are deliberately absent here;
+ * to set one programmatically, or to reach a {@link SchedulerBuilder} option that the starter does
+ * not surface, use {@link Builder#customizeBuilder(Consumer)}.
+ */
+@NullMarked
+public final class DbSchedulerOverrides {
+  private static final DbSchedulerOverrides NONE = builder().build();
+
+  private final @Nullable SchedulerName schedulerName;
+  private final @Nullable Serializer serializer;
+  private final @Nullable DataSource dataSource;
+  private final @Nullable ExecutorService executorService;
+  private final @Nullable ExecutorService dueExecutor;
+  private final @Nullable ScheduledExecutorService housekeeperExecutor;
+  private final @Nullable JdbcCustomization jdbcCustomization;
+  private final @Nullable Consumer<SchedulerBuilder> builderCustomizer;
+
+  private DbSchedulerOverrides(Builder builder) {
+    this.schedulerName = builder.schedulerName;
+    this.serializer = builder.serializer;
+    this.dataSource = builder.dataSource;
+    this.executorService = builder.executorService;
+    this.dueExecutor = builder.dueExecutor;
+    this.housekeeperExecutor = builder.housekeeperExecutor;
+    this.jdbcCustomization = builder.jdbcCustomization;
+    this.builderCustomizer = builder.builderCustomizer;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Overrides where nothing is set, leaving the configuration entirely up to the properties. */
+  public static DbSchedulerOverrides none() {
+    return NONE;
+  }
+
+  /** A builder pre-populated with the values of this instance, for copy-and-adjust. */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  /** A custom {@link SchedulerName}. Takes precedence over {@code db-scheduler.scheduler-name}. */
+  public Optional<SchedulerName> schedulerName() {
+    return Optional.ofNullable(schedulerName);
+  }
+
+  /** A custom serializer for task data. */
+  public Optional<Serializer> serializer() {
+    return Optional.ofNullable(serializer);
+  }
+
+  /** A {@link DataSource} to use instead of the one found in the application context. */
+  public Optional<DataSource> dataSource() {
+    return Optional.ofNullable(dataSource);
+  }
+
+  /** An existing {@link ExecutorService} to use for processing tasks. */
+  public Optional<ExecutorService> executorService() {
+    return Optional.ofNullable(executorService);
+  }
+
+  /** An existing {@link ExecutorService} to use for handling due executions. */
+  public Optional<ExecutorService> dueExecutor() {
+    return Optional.ofNullable(dueExecutor);
+  }
+
+  /** An existing {@link ScheduledExecutorService} to use for housekeeping tasks. */
+  public Optional<ScheduledExecutorService> housekeeperExecutor() {
+    return Optional.ofNullable(housekeeperExecutor);
+  }
+
+  /** A custom {@link JdbcCustomization}. */
+  public Optional<JdbcCustomization> jdbcCustomization() {
+    return Optional.ofNullable(jdbcCustomization);
+  }
+
+  /** Direct access to the {@link SchedulerBuilder}, applied after everything else. */
+  public Optional<Consumer<SchedulerBuilder>> builderCustomizer() {
+    return Optional.ofNullable(builderCustomizer);
+  }
+
+  public static final class Builder {
+    private @Nullable SchedulerName schedulerName;
+    private @Nullable Serializer serializer;
+    private @Nullable DataSource dataSource;
+    private @Nullable ExecutorService executorService;
+    private @Nullable ExecutorService dueExecutor;
+    private @Nullable ScheduledExecutorService housekeeperExecutor;
+    private @Nullable JdbcCustomization jdbcCustomization;
+    private @Nullable Consumer<SchedulerBuilder> builderCustomizer;
+
+    private Builder() {}
+
+    private Builder(DbSchedulerOverrides overrides) {
+      this.schedulerName = overrides.schedulerName;
+      this.serializer = overrides.serializer;
+      this.dataSource = overrides.dataSource;
+      this.executorService = overrides.executorService;
+      this.dueExecutor = overrides.dueExecutor;
+      this.housekeeperExecutor = overrides.housekeeperExecutor;
+      this.jdbcCustomization = overrides.jdbcCustomization;
+      this.builderCustomizer = overrides.builderCustomizer;
+    }
+
+    public Builder schedulerName(SchedulerName schedulerName) {
+      this.schedulerName = Objects.requireNonNull(schedulerName, "schedulerName must not be null");
+      return this;
+    }
+
+    public Builder serializer(Serializer serializer) {
+      this.serializer = Objects.requireNonNull(serializer, "serializer must not be null");
+      return this;
+    }
+
+    public Builder dataSource(DataSource dataSource) {
+      this.dataSource = Objects.requireNonNull(dataSource, "dataSource must not be null");
+      return this;
+    }
+
+    public Builder executorService(ExecutorService executorService) {
+      this.executorService =
+          Objects.requireNonNull(executorService, "executorService must not be null");
+      return this;
+    }
+
+    public Builder dueExecutor(ExecutorService dueExecutor) {
+      this.dueExecutor = Objects.requireNonNull(dueExecutor, "dueExecutor must not be null");
+      return this;
+    }
+
+    public Builder housekeeperExecutor(ScheduledExecutorService housekeeperExecutor) {
+      this.housekeeperExecutor =
+          Objects.requireNonNull(housekeeperExecutor, "housekeeperExecutor must not be null");
+      return this;
+    }
+
+    public Builder jdbcCustomization(JdbcCustomization jdbcCustomization) {
+      this.jdbcCustomization =
+          Objects.requireNonNull(jdbcCustomization, "jdbcCustomization must not be null");
+      return this;
+    }
+
+    /**
+     * Escape hatch for anything not covered above, including settings that otherwise come from
+     * properties. Applied last, so it wins over both the properties and the other overrides.
+     *
+     * <p>Note that {@link #dataSource(DataSource)} is not reachable this way, as the DataSource is
+     * an input to the builder rather than a setting on it.
+     */
+    public Builder customizeBuilder(Consumer<SchedulerBuilder> builderCustomizer) {
+      this.builderCustomizer =
+          Objects.requireNonNull(builderCustomizer, "builderCustomizer must not be null");
+      return this;
+    }
+
+    public DbSchedulerOverrides build() {
+      return new DbSchedulerOverrides(this);
+    }
+  }
+}

--- a/examples/spring-boot-example/src/main/java/com/github/kagkarlsson/examples/boot/config/SchedulerConfiguration.java
+++ b/examples/spring-boot-example/src/main/java/com/github/kagkarlsson/examples/boot/config/SchedulerConfiguration.java
@@ -15,14 +15,12 @@ package com.github.kagkarlsson.examples.boot.config;
 
 import com.github.kagkarlsson.scheduler.CurrentlyExecuting;
 import com.github.kagkarlsson.scheduler.SchedulerName;
-import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerCustomizer;
+import com.github.kagkarlsson.scheduler.boot.config.DbSchedulerOverrides;
 import com.github.kagkarlsson.scheduler.event.AbstractSchedulerListener;
 import com.github.kagkarlsson.scheduler.event.SchedulerListener;
 import com.github.kagkarlsson.scheduler.serializer.Jackson3Serializer;
-import com.github.kagkarlsson.scheduler.serializer.Serializer;
 import com.github.kagkarlsson.scheduler.task.ExecutionComplete;
 import com.github.kagkarlsson.scheduler.task.TaskInstance;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -36,20 +34,13 @@ public class SchedulerConfiguration {
   private static final String MDC_TASK_INSTANCE_ID = "task-instance-id";
   private static final Logger LOG = LoggerFactory.getLogger(SchedulerConfiguration.class);
 
-  /** Bean defined when a configuration-property in DbSchedulerCustomizer needs to be overridden. */
+  /** Bean defined when something needs to be configured that properties cannot express. */
   @Bean
-  DbSchedulerCustomizer customizer() {
-    return new DbSchedulerCustomizer() {
-      @Override
-      public Optional<SchedulerName> schedulerName() {
-        return Optional.of(new SchedulerName.Fixed("spring-boot-scheduler-1"));
-      }
-
-      @Override
-      public Optional<Serializer> serializer() {
-        return Optional.of(new Jackson3Serializer());
-      }
-    };
+  DbSchedulerOverrides dbSchedulerOverrides() {
+    return DbSchedulerOverrides.builder()
+        .schedulerName(new SchedulerName.Fixed("spring-boot-scheduler-1"))
+        .serializer(new Jackson3Serializer())
+        .build();
   }
 
   @Bean


### PR DESCRIPTION
Replaces the `DbSchedulerCustomizer` interface with `DbSchedulerOverrides`, an immutable value object with a nested builder. Configuring the starter programmatically no longer means implementing an interface, and an overrides object can be built up conditionally or copied and adjusted via `toBuilder()`.

- New `DbSchedulerOverrides` in the Spring common module: nested builder, `toBuilder()`, `Optional` accessors, null-rejecting setters
- Adds a `customizeBuilder(Consumer<SchedulerBuilder>)` escape hatch, applied last, so it can override property-derived settings and reach `SchedulerBuilder` options the starter does not surface
- `DbSchedulerCustomizer` is deprecated rather than deleted. An existing bean is still bridged with a warning, and overrides win if both are present
- Both Boot 3 and Boot 4 auto-configurations resolve the two types via `ObjectProvider`
- README and the Spring Boot example migrated to the new shape

**Breaking**: the starter no longer registers a no-op `DbSchedulerCustomizer` bean, so injecting that type directly will fail to resolve.

---
This PR was prepared with Claude Code.