### PR TITLE
fix: swap module names between the Boot 3 and Boot 4 starters

### DIFF
--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot3-starter/pom.xml
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot3-starter/pom.xml
@@ -157,8 +157,6 @@
     </pluginManagement>
 
     <plugins>
-      <!-- Freezes the name this jar has derived from its filename since 6.0; the clean
-           com.github.kagkarlsson.scheduler.boot goes to the Boot 4 starter, which outlives this one -->
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot3-starter/pom.xml
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot3-starter/pom.xml
@@ -157,12 +157,14 @@
     </pluginManagement>
 
     <plugins>
+      <!-- Freezes the name this jar has derived from its filename since 6.0; the clean
+           com.github.kagkarlsson.scheduler.boot goes to the Boot 4 starter, which outlives this one -->
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
             <manifestEntries>
-              <Automatic-Module-Name>com.github.kagkarlsson.scheduler.boot</Automatic-Module-Name>
+              <Automatic-Module-Name>db.scheduler.spring.boot.starter</Automatic-Module-Name>
             </manifestEntries>
           </archive>
         </configuration>

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot4-starter/pom.xml
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot4-starter/pom.xml
@@ -175,7 +175,7 @@
         <configuration>
           <archive>
             <manifestEntries>
-              <Automatic-Module-Name>com.github.kagkarlsson.scheduler.boot4</Automatic-Module-Name>
+              <Automatic-Module-Name>com.github.kagkarlsson.scheduler.boot</Automatic-Module-Name>
             </manifestEntries>
           </archive>
         </configuration>

--- a/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot4-starter/pom.xml
+++ b/db-scheduler-spring-boot-starter-parent/db-scheduler-spring-boot4-starter/pom.xml
@@ -169,7 +169,6 @@
     </pluginManagement>
 
     <plugins>
-      <!-- Must differ from the Boot 3 starter's name; identical names silently shadow each other on a module path -->
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
Follow-up to #914.

- Revert the module-name change for the Boot 3 starter — back to `db.scheduler.spring.boot.starter`.
- Rename the Boot 4 starter module to `com.github.kagkarlsson.scheduler.boot`.

---
This PR was prepared with Claude Code.
