### PR TITLE
fix: make cancel remove the execution atomically

### DIFF
--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerClient.java
@@ -589,16 +589,13 @@ public interface SchedulerClient {
     public void cancel(TaskInstanceId taskInstanceId) {
       String taskName = taskInstanceId.getTaskName();
       String instanceId = taskInstanceId.getId();
-      Optional<Execution> execution = taskRepository.getExecution(taskName, instanceId);
-      if (execution.isPresent()) {
-        if (execution.get().isPicked()) {
-          throw new TaskInstanceCurrentlyExecutingException(taskName, instanceId);
-        }
-
-        taskRepository.remove(execution.get());
-      } else {
-        throw new TaskInstanceNotFoundException(taskName, instanceId);
+      if (taskRepository.removeIfNotPicked(taskInstanceId)) {
+        return;
       }
+      if (taskRepository.getExecution(taskName, instanceId).isPresent()) {
+        throw new TaskInstanceCurrentlyExecutingException(taskName, instanceId);
+      }
+      throw new TaskInstanceNotFoundException(taskName, instanceId);
     }
 
     @Override

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/TaskRepository.java
@@ -69,6 +69,21 @@ public interface TaskRepository {
 
   void remove(Execution execution);
 
+  /**
+   * Implementations should remove in a single atomic operation, so that an execution cannot be
+   * picked between deciding and removing.
+   *
+   * @return true if it was removed, false if it does not exist or is currently picked
+   */
+  default boolean removeIfNotPicked(TaskInstanceId taskInstanceId) {
+    Optional<Execution> execution = getExecution(taskInstanceId);
+    if (execution.isEmpty() || execution.get().isPicked()) {
+      return false;
+    }
+    remove(execution.get());
+    return true;
+  }
+
   boolean reschedule(Execution execution, RescheduleUpdate rescheduleUpdate);
 
   boolean reschedule(

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/jdbc/JdbcTaskRepository.java
@@ -41,6 +41,7 @@ import com.github.kagkarlsson.scheduler.task.SchedulableInstance;
 import com.github.kagkarlsson.scheduler.task.ScheduledTaskInstance;
 import com.github.kagkarlsson.scheduler.task.Task;
 import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import com.github.kagkarlsson.scheduler.task.TaskInstanceId;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -500,6 +501,21 @@ public class JdbcTaskRepository implements TaskRepository {
               + "indicates that it does not support SELECT FOR UPDATE .. SKIP LOCKED. If it indeed does, "
               + "please indicate so in the JdbcCustomization.");
     }
+  }
+
+  @Override
+  public boolean removeIfNotPicked(TaskInstanceId taskInstanceId) {
+    final int removed =
+        jdbcRunner.execute(
+            "delete from "
+                + tableName
+                + " where task_name = ? and task_instance = ? and picked = ?",
+            ps -> {
+              ps.setString(1, taskInstanceId.getTaskName());
+              ps.setString(2, taskInstanceId.getId());
+              ps.setBoolean(3, false);
+            });
+    return removed > 0;
   }
 
   @Override

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/JdbcTaskRepositoryTest.java
@@ -786,6 +786,29 @@ public class JdbcTaskRepositoryTest {
     seenData.forEach(data -> assertSame(seenData.get(0), data));
   }
 
+  @Test
+  public void remove_if_not_picked_should_remove_regardless_of_version() {
+    Instant now = TimeHelper.truncatedInstantNow();
+    TaskInstance<Void> instance = oneTimeTask.instance("id1");
+    taskRepository.createIfNotExists(new SchedulableTaskInstance<>(instance, now));
+    taskRepository.reschedule(
+        taskRepository.getExecution(instance).get(), now.plusSeconds(1), null, null, 0);
+
+    assertTrue(taskRepository.removeIfNotPicked(instance));
+    assertTrue(taskRepository.getExecution(instance).isEmpty());
+  }
+
+  @Test
+  public void remove_if_not_picked_should_keep_picked_execution() {
+    Instant now = TimeHelper.truncatedInstantNow();
+    TaskInstance<Void> instance = oneTimeTask.instance("id1");
+    taskRepository.createIfNotExists(new SchedulableTaskInstance<>(instance, now));
+    taskRepository.pick(taskRepository.getExecution(instance).get(), now);
+
+    assertFalse(taskRepository.removeIfNotPicked(instance));
+    assertTrue(taskRepository.getExecution(instance).isPresent());
+  }
+
   private List<Execution> getScheduledExecutions(
       ScheduledExecutionsFilter filter, String taskName) {
     List<Execution> alternativeTasks = new ArrayList<>();

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientExceptionsTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/SchedulerClientExceptionsTest.java
@@ -1,6 +1,7 @@
 package com.github.kagkarlsson.scheduler;
 
 import static com.github.kagkarlsson.scheduler.task.TaskInstanceId.StandardTaskInstanceId;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
@@ -119,6 +120,15 @@ public class SchedulerClientExceptionsTest {
             + taskInstance.getId()
             + ")",
         actualException.getMessage());
+  }
+
+  @Test
+  public void cancelSucceedsWhenTheExecutionWasRemoved() {
+    StandardTaskInstanceId taskInstance =
+        new StandardTaskInstanceId(randomAlphanumeric(10), randomAlphanumeric(10));
+    when(taskRepository.removeIfNotPicked(taskInstance)).thenReturn(true);
+
+    assertDoesNotThrow(() -> schedulerClient.cancel(taskInstance));
   }
 
   private Execution createExecutingExecution(StandardTaskInstanceId taskInstance) {

--- a/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/TaskRepositoryTest.java
+++ b/db-scheduler/src/test/java/com/github/kagkarlsson/scheduler/TaskRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.github.kagkarlsson.scheduler;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.kagkarlsson.scheduler.task.Execution;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import com.github.kagkarlsson.scheduler.task.TaskInstanceId;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class TaskRepositoryTest {
+
+  @Mock TaskRepository taskRepository;
+
+  @Test
+  public void default_remove_if_not_picked_only_removes_unpicked_executions() {
+    TaskInstanceId id = TaskInstanceId.of("task", "1");
+    Execution unpicked = new Execution(Instant.now(), new TaskInstance<>("task", "1"));
+    Execution picked =
+        new Execution(
+            Instant.now(),
+            new TaskInstance<>("task", "1"),
+            true,
+            "scheduler1",
+            null,
+            null,
+            0,
+            null,
+            1);
+    when(taskRepository.removeIfNotPicked(id)).thenCallRealMethod();
+    when(taskRepository.getExecution(id))
+        .thenReturn(Optional.empty())
+        .thenReturn(Optional.of(picked))
+        .thenReturn(Optional.of(unpicked));
+
+    assertFalse(taskRepository.removeIfNotPicked(id));
+    assertFalse(taskRepository.removeIfNotPicked(id));
+    assertTrue(taskRepository.removeIfNotPicked(id));
+
+    verify(taskRepository).remove(unpicked);
+    verify(taskRepository, never()).remove(picked);
+  }
+}


### PR DESCRIPTION
`cancel()` checked `isPicked()` and then deleted by `version`. 
If another scheduler picked the execution in between, the delete matched no rows 
and the caller got an `ExecutionException` saying "Indicates a bug" for an ordinary race. 
An unrelated concurrent update bumps the version too, so that failed the cancel as well.

The delete is now a single statement guarded by `picked = false`. 
`remove(Execution)`  keeps its version guard for callers that hold an execution they are processing
- `cancel(TaskInstanceId)` takes an id, so it never had snapshot semantics.

Fixes #786

#### Reminders

- [X] Added/ran automated tests
- [ ] Update README and/or examples
- [X] Ran `mvn spotless:apply`
- [ ] If AI tools were used, disclosed per the [AI Contribution Policy](../AI_POLICY.md)

---

cc @kagkarlsson
